### PR TITLE
Include partner jobs in weekly timesheet PDF

### DIFF
--- a/Job Tracker/Views/Time SHeet stuff/WeeklyTimesheetView.swift
+++ b/Job Tracker/Views/Time SHeet stuff/WeeklyTimesheetView.swift
@@ -445,6 +445,7 @@ extension WeeklyTimesheetView {
             endOfWeek: endOfWeek,
             jobs: timesheetJobsVM.jobs,
             currentUserID: authViewModel.currentUser?.id ?? "",
+            partnerUserID: partnerUid,
             supervisor: supervisor,
             name1: name1Val,
             name2: name2Val,


### PR DESCRIPTION
## Summary
- allow `WeeklyTimesheetPDFGenerator` to accept an optional partner ID and include partner-owned jobs when filtering rows
- pass the partner UID from `WeeklyTimesheetView` so generated PDFs mirror the on-device list while still skipping pending work

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb476c809c832d904c9e289d06ebbd