### PR TITLE
Make supervisor date pickers visible

### DIFF
--- a/Job Tracker/Views/PDF stuff/admin and sup/SupervisorRole.swift
+++ b/Job Tracker/Views/PDF stuff/admin and sup/SupervisorRole.swift
@@ -296,19 +296,35 @@ struct SupervisorDashboardView: View {
             }
 
             HStack(spacing: 12) {
-                DatePicker(
-                    "From",
-                    selection: Binding(get: { dateRange.start }, set: { dateRange = DateInterval(start: $0, end: dateRange.end) }),
-                    displayedComponents: .date
-                )
-                .labelsHidden()
-                DatePicker(
-                    "To",
-                    selection: Binding(get: { dateRange.end }, set: { dateRange = DateInterval(start: dateRange.start, end: $0) }),
-                    displayedComponents: .date
-                )
-                .labelsHidden()
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("From")
+                        .font(.footnote)
+                        .foregroundColor(.white.opacity(0.8))
+                    DatePicker(
+                        "From",
+                        selection: Binding(get: { dateRange.start }, set: { dateRange = DateInterval(start: $0, end: dateRange.end) }),
+                        displayedComponents: .date
+                    )
+                    .labelsHidden()
+                    .accessibilityLabel("From")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("To")
+                        .font(.footnote)
+                        .foregroundColor(.white.opacity(0.8))
+                    DatePicker(
+                        "To",
+                        selection: Binding(get: { dateRange.end }, set: { dateRange = DateInterval(start: dateRange.start, end: $0) }),
+                        displayedComponents: .date
+                    )
+                    .labelsHidden()
+                    .accessibilityLabel("To")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .padding(.top, 4)
         }
         .padding(12)
         .background(Color.black.opacity(0.25))


### PR DESCRIPTION
## Summary
- wrap the supervisor dashboard date pickers with visible labels for clearer voiceover announcements
- balance vertical spacing and layout constraints so the labeled pickers still fit within the filter card

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc55d06428832da487d1b943497b79