### PR TITLE
Adjust RouteLegendEntry hashing

### DIFF
--- a/Job Tracker/Services/MapShape.swift
+++ b/Job Tracker/Services/MapShape.swift
@@ -34,7 +34,7 @@ private extension CLLocationCoordinate2D {
 }
 
 // MARK: - ShapeStyle
-public struct ShapeStyle: Equatable, Codable {
+public struct ShapeStyle: Equatable, Hashable, Codable {
     public var color: UIColor
     public var width: CGFloat
     public var dashed: Bool
@@ -62,6 +62,30 @@ public struct ShapeStyle: Equatable, Codable {
 
     public static var `default`: ShapeStyle { ShapeStyle() }
 
+    // MARK: Equatable
+    public static func == (lhs: ShapeStyle, rhs: ShapeStyle) -> Bool {
+        lhs.rgbaComponents == rhs.rgbaComponents &&
+        lhs.width == rhs.width &&
+        lhs.dashed == rhs.dashed &&
+        lhs.arrow == rhs.arrow &&
+        lhs.arrowSize == rhs.arrowSize &&
+        lhs.arrowLength == rhs.arrowLength
+    }
+
+    // MARK: Hashable
+    public func hash(into hasher: inout Hasher) {
+        let rgba = rgbaComponents
+        hasher.combine(rgba.r)
+        hasher.combine(rgba.g)
+        hasher.combine(rgba.b)
+        hasher.combine(rgba.a)
+        hasher.combine(width)
+        hasher.combine(dashed)
+        hasher.combine(arrow)
+        hasher.combine(arrowSize)
+        hasher.combine(arrowLength)
+    }
+
     // MARK: Codable
     private enum CodingKeys: String, CodingKey { case color, width, dashed, arrow, arrowSize, arrowLength }
     public init(from decoder: Decoder) throws {
@@ -83,6 +107,10 @@ public struct ShapeStyle: Equatable, Codable {
         try c.encode(arrowSize, forKey: .arrowSize)
         try c.encode(arrowLength, forKey: .arrowLength)
     }
+}
+
+private extension ShapeStyle {
+    var rgbaComponents: RGBAColor { RGBAColor(color) }
 }
 
 // MARK: - MapShape

--- a/Job Tracker/Services/MapsView.swift
+++ b/Job Tracker/Services/MapsView.swift
@@ -158,6 +158,35 @@ struct MarkupShape: Identifiable, Hashable {
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 }
 
+// MARK: - Route Legend
+struct RouteLegendEntry: Identifiable, Hashable {
+    let id: UUID
+    var label: String
+    var detail: String?
+    var style: ShapeStyle
+
+    init(id: UUID = UUID(), label: String, detail: String? = nil, style: ShapeStyle) {
+        self.id = id
+        self.label = label
+        self.detail = detail
+        self.style = style
+    }
+
+    static func == (lhs: RouteLegendEntry, rhs: RouteLegendEntry) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.label == rhs.label &&
+        lhs.detail == rhs.detail &&
+        lhs.style == rhs.style
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(label)
+        hasher.combine(detail)
+        hasher.combine(style)
+    }
+}
+
 // MARK: - MapCanvas (UIKit MapKit wrapper)
 struct MapCanvas: UIViewRepresentable {
     @Binding var poles: [Pole]


### PR DESCRIPTION
## Summary
- add a dedicated RouteLegendEntry model in MapsView with manual Hashable conformance that hashes the rendered ShapeStyle scalars
- make ShapeStyle explicitly Hashable by hashing its RGBA components and scalar drawing attributes for reuse in legend hashing

## Testing
- not run (xcodebuild is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc6310598c832d971e970b3ea99ee9