### PR TITLE
Delay share actions until jobs finish loading

### DIFF
--- a/Job Tracker/Views/DashboardView.swift
+++ b/Job Tracker/Views/DashboardView.swift
@@ -486,6 +486,19 @@ extension DashboardView {
             .frame(maxWidth: .infinity)
 
             Button {
+                guard jobsViewModel.hasLoadedInitialJobs else {
+                    importToastIsError = true
+                    importToastMessage = "Jobs are still loading…"
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+                        showImportToast = true
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            showImportToast = false
+                        }
+                    }
+                    return
+                }
                 prepareShareItems()
             } label: {
                 Image(systemName: "square.and.arrow.up")
@@ -533,6 +546,7 @@ extension DashboardView {
     }
     /// Build the items array for UIActivityViewController: summary text + any job images/links.
     private func prepareShareItems(limitImages: Int = 20) {
+        guard jobsViewModel.hasLoadedInitialJobs else { return }
         // Keep the same text summary you already had
         let text = shareText()
         var items: [Any] = [text]


### PR DESCRIPTION
## Summary
- add a `hasLoadedInitialJobs` flag to `JobsViewModel` that flips when the first listener callback completes
- gate the dashboard share button behind the loading flag and surface a toast when jobs are still loading
- ensure share sheet preparation exits early until jobs have finished loading

## Testing
- not run (requires Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc8077a99c832db8c6f399e5aadf58