### PR TITLE
Normalize and downsize job sheet images before upload

### DIFF
--- a/Job Tracker/Views/Creating and Editing Jobs/SupervisorJobImportView.swift
+++ b/Job Tracker/Views/Creating and Editing Jobs/SupervisorJobImportView.swift
@@ -350,7 +350,10 @@ final class JobSheetParser {
     }
 
     func parse(image: UIImage, users: [AppUser]) async throws -> [ParsedEntry] {
-        guard let jpegData = image.jpegData(compressionQuality: 0.8) else { return [] }
+        let preparedImage = image.aiFixingOrientationAndResizingIfNeeded(maxDimension: 2048) ?? image
+        // The 2048 px cap keeps these 0.8-quality JPEGs around 3–4 MB (≈5 MB once base64-encoded), well under OpenAI's 20 MB
+        // per-image upload limit while preserving legible job text.
+        guard let jpegData = preparedImage.jpegData(compressionQuality: 0.8) else { return [] }
         guard
             let apiKey = Bundle.main.infoDictionary?["OPENAI_API_KEY"] as? String,
             !apiKey.isEmpty

--- a/Job Tracker/Views/Creating and Editing Jobs/UIImage+AIResize.swift
+++ b/Job Tracker/Views/Creating and Editing Jobs/UIImage+AIResize.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+extension UIImage {
+    /// Returns an image whose orientation is normalized and whose longest side does not exceed the given pixel cap.
+    /// - Parameter maxDimension: The maximum length, in pixels, allowed for the longest side of the image.
+    func aiFixingOrientationAndResizingIfNeeded(maxDimension: CGFloat = 2048) -> UIImage? {
+        guard size.width > 0, size.height > 0, maxDimension > 0 else {
+            return nil
+        }
+
+        let pixelWidth = size.width * scale
+        let pixelHeight = size.height * scale
+        let longestSide = max(pixelWidth, pixelHeight)
+        let resizeRatio = longestSide > maxDimension ? maxDimension / longestSide : 1
+        let needsOrientationNormalization = imageOrientation != .up
+
+        if resizeRatio == 1 && !needsOrientationNormalization {
+            return self
+        }
+
+        let targetSize = CGSize(width: size.width * resizeRatio, height: size.height * resizeRatio)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = max(1, scale)
+        format.opaque = false
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
+        return renderer.image { _ in
+            draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a UIImage helper that fixes EXIF orientation and clamps the long edge to 2048 px
- invoke the helper from `JobSheetParser.parse` before JPEG encoding and document the OpenAI upload limit rationale

## Testing
- not run (Xcode tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdab86ac64832d80ebd4709fce098d