### PR TITLE
Add design system tokens and apply reusable styling

### DIFF
--- a/Job Tracker/DesignSystem/DesignSystem.md
+++ b/Job Tracker/DesignSystem/DesignSystem.md
@@ -1,0 +1,51 @@
+# Job Tracker Design System
+
+The `DesignSystem/` module collects the tokens and reusable components that keep
+screens feeling consistent. Start here when building new UI rather than
+recreating colors or glass effects in individual views.
+
+## Tokens
+
+| Area | Type | Notes |
+| --- | --- | --- |
+| Colors | `JTColors` | Brand gradient stops (`backgroundTop`, `backgroundBottom`), semantic text colors, and glass strokes. Use `JTGradients.background` for full-screen backgrounds. |
+| Typography | `JTTypography` | Preconfigured fonts for screen titles, headlines, captions, and buttons. |
+| Spacing | `JTSpacing` | Baseline spacing units (`xs`–`xxl`). Multiply these rather than inventing ad-hoc constants. |
+| Shapes | `JTShapes` | Corner radii for cards, buttons, fields, and helper factories such as `roundedRectangle(cornerRadius:)`. |
+| Elevation | `JTElevations` | Shadow recipes. Apply via `.jtShadow(JTElevations.card)` etc. |
+
+## Surfaces and modifiers
+
+* `.jtGlassBackground(cornerRadius:strokeColor:strokeWidth:)` wraps the ultra-thin material background, stroke, and clipping in a single modifier. Use the overload that accepts a `Shape` when you need capsules or custom shapes.
+* `GlassCard` combines the glass background with the standard card shadow. Wrap content that should float above the gradient background.
+
+## Components
+
+* `JTPrimaryButton` renders the primary call to action. Provide the label text (and optionally a SF Symbol) and the tap action.
+* `JTTextField` renders a material-backed text input. Supply the placeholder and `Binding<String>`, plus `icon` or `isSecure` as needed.
+
+These components already consume the tokens above. Compose them together whenever you are building new flows so typography, spacing, and color stay aligned with the rest of the experience.
+
+### Example
+
+```swift
+VStack(spacing: JTSpacing.lg) {
+    Text("Invite a teammate")
+        .font(JTTypography.screenTitle)
+        .foregroundStyle(JTColors.textPrimary)
+
+    GlassCard {
+        VStack(alignment: .leading, spacing: JTSpacing.md) {
+            JTTextField("Email", text: $email, icon: "envelope")
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+
+            JTPrimaryButton("Send Invite", systemImage: "paperplane.fill") {
+                sendInvite()
+            }
+        }
+        .padding(JTSpacing.lg)
+    }
+}
+.background(JTGradients.background.ignoresSafeArea())
+```

--- a/Job Tracker/DesignSystem/JTColors.swift
+++ b/Job Tracker/DesignSystem/JTColors.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Centralized color tokens for the Job Tracker design system.
+enum JTColors {
+    // MARK: App chroma
+    static let backgroundTop = Color(red: 0.1725, green: 0.2431, blue: 0.3137)
+    static let backgroundBottom = Color(red: 0.2980, green: 0.6314, blue: 0.6863)
+
+    static let accent = Color.accentColor
+    static let onAccent = Color.white
+
+    // MARK: Text
+    static let textPrimary = Color.white
+    static let textSecondary = Color.white.opacity(0.85)
+    static let textMuted = Color.white.opacity(0.6)
+
+    // MARK: Surfaces
+    static let glassStroke = Color.white.opacity(0.18)
+    static let glassSoftStroke = Color.white.opacity(0.06)
+    static let glassHighlight = Color.white.opacity(0.12)
+    static let fieldPlaceholder = Color.white.opacity(0.5)
+
+    // MARK: Semantic status
+    static let success = Color.green.opacity(0.9)
+    static let warning = Color.yellow.opacity(0.9)
+    static let info = Color.blue.opacity(0.9)
+}
+
+/// Gradients that compose reusable backgrounds.
+enum JTGradients {
+    static let background = LinearGradient(
+        colors: [JTColors.backgroundTop, JTColors.backgroundBottom],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}

--- a/Job Tracker/DesignSystem/JTElevations.swift
+++ b/Job Tracker/DesignSystem/JTElevations.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Shadow styles that express elevation and depth.
+struct JTShadow {
+    let color: Color
+    let radius: CGFloat
+    let x: CGFloat
+    let y: CGFloat
+
+    static let none = JTShadow(color: .clear, radius: 0, x: 0, y: 0)
+}
+
+enum JTElevations {
+    static let card = JTShadow(color: Color.black.opacity(0.20), radius: 10, x: 0, y: 6)
+    static let raised = JTShadow(color: Color.black.opacity(0.25), radius: 18, x: 0, y: 12)
+    static let button = JTShadow(color: Color.black.opacity(0.22), radius: 8, x: 0, y: 4)
+}
+
+extension View {
+    func jtShadow(_ shadow: JTShadow) -> some View {
+        self.shadow(color: shadow.color, radius: shadow.radius, x: shadow.x, y: shadow.y)
+    }
+}

--- a/Job Tracker/DesignSystem/JTShapes.swift
+++ b/Job Tracker/DesignSystem/JTShapes.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Component shapes used throughout the app.
+enum JTShapes {
+    static let cardCornerRadius: CGFloat = 16
+    static let smallCardCornerRadius: CGFloat = 14
+    static let largeCardCornerRadius: CGFloat = 20
+    static let buttonCornerRadius: CGFloat = 12
+    static let fieldCornerRadius: CGFloat = 12
+    static let chipCornerRadius: CGFloat = 10
+
+    static func roundedRectangle(cornerRadius: CGFloat) -> RoundedRectangle {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    }
+}

--- a/Job Tracker/DesignSystem/JTSpacing.swift
+++ b/Job Tracker/DesignSystem/JTSpacing.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// Layout spacing tokens used to compose consistent stacks and paddings.
+enum JTSpacing {
+    static let xs: CGFloat = 4
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 12
+    static let lg: CGFloat = 16
+    static let xl: CGFloat = 24
+    static let xxl: CGFloat = 32
+}

--- a/Job Tracker/DesignSystem/JTTypography.swift
+++ b/Job Tracker/DesignSystem/JTTypography.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Font styles that keep typography consistent across screens.
+enum JTTypography {
+    static let screenTitle = Font.system(size: 34, weight: .bold, design: .rounded)
+    static let title = Font.system(size: 28, weight: .semibold, design: .rounded)
+    static let title3 = Font.system(size: 22, weight: .semibold, design: .rounded)
+    static let headline = Font.system(size: 17, weight: .semibold, design: .default)
+    static let body = Font.system(size: 16, weight: .regular, design: .default)
+    static let subheadline = Font.system(size: 15, weight: .regular, design: .default)
+    static let caption = Font.system(size: 13, weight: .regular, design: .default)
+    static let captionEmphasized = Font.system(size: 13, weight: .semibold, design: .default)
+    static let button = Font.system(size: 17, weight: .semibold, design: .rounded)
+
+    static func monospacedCaption(weight: Font.Weight = .medium) -> Font {
+        Font.system(size: 12, weight: weight, design: .monospaced)
+    }
+}

--- a/Job Tracker/Views/JobSearchDetailView.swift
+++ b/Job Tracker/Views/JobSearchDetailView.swift
@@ -7,7 +7,6 @@
 
 
 import SwiftUI
-import MapKit
 
 struct JobSearchDetailView: View {
     let job: Job
@@ -17,143 +16,57 @@ struct JobSearchDetailView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                // Background gradient.
-                LinearGradient(
-                    gradient: Gradient(colors: [
-                        Color(red: 0.17254902, green: 0.24313726, blue: 0.3137255, opacity: 1),
-                        Color(red: 0.29803923, green: 0.6313726, blue: 0.6862745, opacity: 1)
-                    ]),
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-                .edgesIgnoringSafeArea(.all)
-                
+                JTGradients.background
+                    .ignoresSafeArea()
+
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: JTSpacing.lg) {
                         Text("Job Details")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
-                            .foregroundColor(.white)
-                            .padding(.top, 40)
-                        
-                        VStack(alignment: .leading, spacing: 12) {
-                            Group {
-                                Text("Address:")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                Text(job.address)
-                                    .font(.body)
-                                    .foregroundColor(.white)
-                            }
-                            
-                            Group {
-                                Text("Job Number:")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                Text(job.jobNumber ?? "N/A")
-                                    .font(.body)
-                                    .foregroundColor(.white)
-                            }
-                            
-                            Group {
-                                Text("Date:")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                Text(job.date, style: .date)
-                                    .font(.body)
-                                    .foregroundColor(.white)
-                            }
-                            
-                            Group {
-                                Text("Status:")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                Text(job.status)
-                                    .font(.body)
-                                    .foregroundColor(.white)
-                            }
-                            
-                            if let materials = job.materialsUsed, !materials.isEmpty {
-                                Group {
-                                    Text("Materials:")
-                                        .font(.headline)
-                                        .foregroundColor(.white)
-                                    Text(materials)
-                                        .font(.body)
-                                        .foregroundColor(.white)
+                            .font(JTTypography.screenTitle)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .padding(.top, JTSpacing.xl)
+                            .padding(.horizontal, JTSpacing.lg)
+
+                        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                                  strokeColor: JTColors.glassSoftStroke) {
+                            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                                detailSection(title: "Address:", value: job.address)
+                                detailSection(title: "Job Number:", value: job.jobNumber ?? "N/A")
+                                detailSection(title: "Date:", value: DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))
+                                detailSection(title: "Status:", value: job.status)
+
+                                if let materials = job.materialsUsed, !materials.isEmpty {
+                                    detailSection(title: "Materials:", value: materials)
                                 }
-                            }
-                            
-                            Group {
+
                                 if let can = job.canFootage, !can.isEmpty {
-                                    Text("CAN Footage:")
-                                        .font(.headline)
-                                        .foregroundColor(.white)
-                                    Text(can)
-                                        .font(.body)
-                                        .foregroundColor(.white)
+                                    detailSection(title: "CAN Footage:", value: can)
                                 }
                                 if let nid = job.nidFootage, !nid.isEmpty {
-                                    Text("NID Footage:")
-                                        .font(.headline)
-                                        .foregroundColor(.white)
-                                    Text(nid)
-                                        .font(.body)
-                                        .foregroundColor(.white)
+                                    detailSection(title: "NID Footage:", value: nid)
                                 }
-                            }
-                            
-                            if let notes = job.notes, !notes.isEmpty {
-                                Group {
-                                    Text("Notes:")
-                                        .font(.headline)
-                                        .foregroundColor(.white)
-                                    Text(notes)
-                                        .font(.body)
-                                        .foregroundColor(.white)
+
+                                if let notes = job.notes, !notes.isEmpty {
+                                    detailSection(title: "Notes:", value: notes)
                                 }
-                            }
-                            
-                            if !job.photos.isEmpty {
-                                Text("Photos:")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                ScrollView(.horizontal, showsIndicators: false) {
-                                    HStack(spacing: 10) {
-                                        ForEach(job.photos, id: \.self) { urlString in
-                                            if let url = URL(string: urlString) {
-                                                AsyncImage(url: url) { phase in
-                                                    switch phase {
-                                                    case .empty:
-                                                        ProgressView()
-                                                            .frame(width: 100, height: 100)
-                                                    case .success(let image):
-                                                        image
-                                                            .resizable()
-                                                            .scaledToFill()
-                                                            .frame(width: 100, height: 100)
-                                                            .clipped()
-                                                    case .failure:
-                                                        Color.red.frame(width: 100, height: 100)
-                                                    @unknown default:
-                                                        EmptyView()
-                                                    }
-                                                }
-                                            } else {
-                                                Color.gray.frame(width: 100, height: 100)
+
+                                if !job.photos.isEmpty {
+                                    Text("Photos:")
+                                        .font(JTTypography.headline)
+                                        .foregroundStyle(JTColors.textPrimary)
+                                    ScrollView(.horizontal, showsIndicators: false) {
+                                        HStack(spacing: JTSpacing.sm) {
+                                            ForEach(job.photos, id: \.self) { urlString in
+                                                PhotoThumbnail(urlString: urlString)
                                             }
                                         }
                                     }
                                 }
                             }
+                            .padding(JTSpacing.lg)
                         }
-                        .padding()
-                        .background(Color.black.opacity(0.8))
-                        .cornerRadius(12)
-                        .shadow(color: Color.black.opacity(0.2), radius: 5, x: 0, y: 3)
-                        .padding(.horizontal)
-                        
-                        Spacer()
+                        .padding(.horizontal, JTSpacing.lg)
+                        .padding(.bottom, JTSpacing.xl)
                     }
                 }
             }
@@ -164,5 +77,46 @@ struct JobSearchDetailView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func detailSection(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            Text(title)
+                .font(JTTypography.headline)
+                .foregroundStyle(JTColors.textPrimary)
+            Text(value)
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+    }
+}
+
+private struct PhotoThumbnail: View {
+    let urlString: String
+
+    var body: some View {
+        Group {
+            if let url = URL(string: urlString) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    case .failure:
+                        Color.red
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+            } else {
+                Color.gray
+            }
+        }
+        .frame(width: 100, height: 100)
+        .clipShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
     }
 }

--- a/Job Tracker/Views/JobSearchView.swift
+++ b/Job Tracker/Views/JobSearchView.swift
@@ -73,44 +73,23 @@ struct JobSearchView: View {
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
-                // Same gradient used app-wide
-                LinearGradient(
-                    gradient: Gradient(colors: [
-                        Color(red: 0.17254902, green: 0.24313726, blue: 0.3137255, opacity: 1),
-                        Color(red: 0.29803923, green: 0.6313726, blue: 0.6862745, opacity: 1)
-                    ]),
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-                .ignoresSafeArea()
+                JTGradients.background
+                    .ignoresSafeArea()
 
                 ScrollView {
-                    VStack(spacing: 20) {
-                        // Title row
+                    VStack(spacing: JTSpacing.lg) {
                         Text("Search Jobs")
-                            .font(.largeTitle.bold())
+                            .font(JTTypography.screenTitle)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .foregroundStyle(.white)
+                            .foregroundStyle(JTColors.textPrimary)
 
-                        // Inline search bar (so the hamburger button never overlaps it)
-                        HStack(spacing: 8) {
-                            Image(systemName: "magnifyingglass")
-                                .foregroundStyle(.white.opacity(0.9))
-                            TextField("Address, #, status, user…", text: $searchText)
-                                .textInputAutocapitalization(.never)
-                                .disableAutocorrection(true)
-                        }
-                        .padding(12)
-                        .background(
-                            .ultraThinMaterial,
-                            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        )
+                        JTTextField("Address, #, status, user…", text: $searchText, icon: "magnifyingglass")
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
 
-                        // Results/content
                         resultsContent
                     }
-                    .padding(16)
-                    
+                    .padding(JTSpacing.lg)
                 }
             }
         }
@@ -124,42 +103,44 @@ struct JobSearchView: View {
     @ViewBuilder
     private var resultsContent: some View {
         if searchText.isEmpty {
-            VStack(spacing: 16) {
+            VStack(spacing: JTSpacing.md) {
                 Spacer(minLength: 40)
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 42, weight: .semibold))
                     .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(.white.opacity(0.8))
+                    .foregroundStyle(JTColors.textSecondary)
                 Text("Search all jobs")
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(.white)
+                    .font(JTTypography.title3)
+                    .foregroundStyle(JTColors.textPrimary)
                 Text("Type part of an address, job #, status (e.g. \"Completed\"), or the name of the person who added it — results include jobs from all users.")
                     .multilineTextAlignment(.center)
-                    .foregroundStyle(.white.opacity(0.9))
-                    .padding(.horizontal, 24)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .padding(.horizontal, JTSpacing.xl)
                 Spacer(minLength: 20)
             }
         } else if aggregatedResults.isEmpty {
-            VStack(spacing: 12) {
+            VStack(spacing: JTSpacing.sm) {
                 Spacer(minLength: 40)
                 Text("No jobs found for “\(searchText)”")
-                    .font(.headline)
-                    .foregroundStyle(.white)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
                 Text("Try fewer keywords, or search by street, city, job #, status, or creator name.")
                     .multilineTextAlignment(.center)
-                    .foregroundStyle(.white.opacity(0.9))
-                    .padding(.horizontal, 24)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .padding(.horizontal, JTSpacing.xl)
                 Spacer(minLength: 20)
             }
         } else {
-            LazyVStack(spacing: 14) {
+            LazyVStack(spacing: JTSpacing.md) {
                 ForEach(aggregatedResults) { agg in
                     NavigationLink {
                         AggregatedDetailView(aggregate: agg)
                             .environmentObject(usersViewModel)
                     } label: {
                         AggregatedJobCard(aggregate: agg)
-                            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .contentShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
                     }
                     .buttonStyle(.plain)
                 }
@@ -210,33 +191,34 @@ private struct JobRow: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
                 Text(job.address)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.white)
+                    .font(JTTypography.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(JTColors.textPrimary)
                     .lineLimit(2)
                 Spacer(minLength: 8)
                 if let num = job.jobNumber, !num.isEmpty {
                     Text("#\(num)")
-                        .font(.caption2.monospaced())
+                        .font(JTTypography.caption)
                         .padding(.vertical, 3)
                         .padding(.horizontal, 6)
-                        .background(.ultraThinMaterial, in: Capsule())
-                        .foregroundStyle(.white)
+                        .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                        .foregroundStyle(JTColors.textPrimary)
                 }
             }
 
             HStack(spacing: 10) {
                 Label(job.status, systemImage: "checkmark.seal")
-                    .font(.caption)
-                    .foregroundStyle(.white.opacity(0.9))
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
                 Text(job.date, style: .date)
-                    .font(.caption)
-                    .foregroundStyle(.white.opacity(0.9))
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
                 if let creator {
                     Text("·")
-                        .foregroundStyle(.white.opacity(0.5))
+                        .foregroundStyle(JTColors.textMuted)
                     Text("\(creator.firstName) \(creator.lastName)")
-                        .font(.caption2)
-                        .foregroundStyle(.white.opacity(0.8))
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
                 }
             }
         }
@@ -250,88 +232,80 @@ private struct AggregatedJobCard: View {
 
     private func statusColor(_ status: String) -> Color {
         switch status.lowercased() {
-        case "done", "completed": return Color.green.opacity(0.9)
-        case "pending": return Color.yellow.opacity(0.9)
-        default: return Color.blue.opacity(0.9)
+        case "done", "completed": return JTColors.success
+        case "pending": return JTColors.warning
+        default: return JTColors.info
         }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            // Title
-            HStack(alignment: .firstTextBaseline) {
-                Text(aggregate.address)
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(.white)
-                    .lineLimit(2)
-                Spacer(minLength: 8)
-                if !aggregate.jobNumber.isEmpty {
-                    Text("#\(aggregate.jobNumber)")
-                        .font(.caption2.monospaced())
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .background(.ultraThinMaterial, in: Capsule())
-                        .foregroundStyle(.white)
+        GlassCard(cornerRadius: JTShapes.smallCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke,
+                  shadow: JTShadow.none) {
+            VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(aggregate.address)
+                        .font(JTTypography.headline)
+                        .foregroundStyle(JTColors.textPrimary)
+                        .lineLimit(2)
+                    Spacer(minLength: JTSpacing.sm)
+                    if !aggregate.jobNumber.isEmpty {
+                        Text("#\(aggregate.jobNumber)")
+                            .font(JTTypography.caption)
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 8)
+                            .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                            .foregroundStyle(JTColors.textPrimary)
+                    }
                 }
-            }
 
-            // Most recent line
-            if let recent = aggregate.jobs.first {
-                HStack(spacing: 10) {
-                    Label(recent.status, systemImage: "checkmark.seal")
-                        .font(.caption)
-                        .foregroundStyle(statusColor(recent.status))
-                    Text(recent.date, style: .date)
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.9))
+                if let recent = aggregate.jobs.first {
+                    HStack(spacing: JTSpacing.sm) {
+                        Label(recent.status, systemImage: "checkmark.seal")
+                            .font(JTTypography.caption)
+                            .foregroundStyle(statusColor(recent.status))
+                        Text(recent.date, style: .date)
+                            .font(JTTypography.caption)
+                            .foregroundStyle(JTColors.textSecondary)
+                    }
                 }
-            }
 
-            // Creators (unique)
-            if !aggregate.creators.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 6) {
-                        ForEach(aggregate.creators, id: \.id) { u in
-                            Text("\(u.firstName) \(u.lastName)")
-                                .font(.caption2)
-                                .padding(.vertical, 4)
-                                .padding(.horizontal, 8)
-                                .background(Color.white.opacity(0.12), in: Capsule())
-                                .foregroundStyle(.white)
+                if !aggregate.creators.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: JTSpacing.xs) {
+                            ForEach(aggregate.creators, id: \.id) { u in
+                                Text("\(u.firstName) \(u.lastName)")
+                                    .font(JTTypography.caption)
+                                    .padding(.vertical, 4)
+                                    .padding(.horizontal, 8)
+                                    .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                                    .foregroundStyle(JTColors.textPrimary)
+                            }
                         }
                     }
                 }
-            }
 
-            // If duplicates exist, show a tiny summary row
-            if aggregate.jobs.count > 1 {
-                HStack(spacing: 6) {
-                    Image(systemName: "square.stack.3d.down.right")
-                        .imageScale(.small)
-                        .foregroundStyle(.white.opacity(0.8))
-                    Text("\(aggregate.jobs.count) entries – latest shown")
-                        .font(.caption2)
-                        .foregroundStyle(.white.opacity(0.8))
+                if aggregate.jobs.count > 1 {
+                    HStack(spacing: JTSpacing.xs) {
+                        Image(systemName: "square.stack.3d.down.right")
+                            .imageScale(.small)
+                            .foregroundStyle(JTColors.textSecondary)
+                        Text("\(aggregate.jobs.count) entries – latest shown")
+                            .font(JTTypography.caption)
+                            .foregroundStyle(JTColors.textSecondary)
+                    }
                 }
             }
+            .padding(JTSpacing.md)
         }
         .overlay(
             HStack {
                 Spacer()
                 Image(systemName: "chevron.right")
-                    .foregroundStyle(.white.opacity(0.6))
-                    .padding(.trailing, 10)
+                    .foregroundStyle(JTColors.textMuted)
+                    .padding(.trailing, JTSpacing.md)
             }
         )
-        .background(
-            .ultraThinMaterial,
-            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.06))
-        )
-        .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
 
@@ -347,81 +321,69 @@ private struct AggregatedDetailView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            LinearGradient(
-                gradient: Gradient(colors: [
-                    Color(red: 0.17254902, green: 0.24313726, blue: 0.3137255, opacity: 1),
-                    Color(red: 0.29803923, green: 0.6313726, blue: 0.6862745, opacity: 1)
-                ]),
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .ignoresSafeArea()
+            JTGradients.background
+                .ignoresSafeArea()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: JTSpacing.lg) {
                     // Header
                     VStack(alignment: .leading, spacing: 8) {
                         Text(aggregate.address)
-                            .font(.largeTitle.bold())
-                            .foregroundStyle(.white)
+                            .font(JTTypography.screenTitle)
+                            .foregroundStyle(JTColors.textPrimary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         if !aggregate.jobNumber.isEmpty {
                             Text("#\(aggregate.jobNumber)")
-                                .font(.caption.monospaced())
+                                .font(JTTypography.caption)
                                 .padding(.vertical, 4)
                                 .padding(.horizontal, 8)
-                                .background(.ultraThinMaterial, in: Capsule())
-                                .foregroundStyle(.white)
+                                .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                                .foregroundStyle(JTColors.textPrimary)
                         }
 
                         if !aggregate.creators.isEmpty {
-                            HStack(spacing: 6) {
+                            HStack(spacing: JTSpacing.xs) {
                                 Image(systemName: "person.2")
-                                    .foregroundStyle(.white.opacity(0.9))
+                                    .foregroundStyle(JTColors.textSecondary)
                                 Text("\(aggregate.creators.count) contributor\(aggregate.creators.count == 1 ? "" : "s")")
-                                    .foregroundStyle(.white.opacity(0.9))
-                                    .font(.subheadline)
+                                    .foregroundStyle(JTColors.textSecondary)
+                                    .font(JTTypography.subheadline)
                             }
                         }
                     }
 
                     // Timeline of all entries (newest first)
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: JTSpacing.md) {
                         ForEach(aggregate.jobs, id: \.id) { job in
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack(alignment: .firstTextBaseline) {
-                                    Text(job.status)
-                                        .font(.headline)
-                                        .foregroundStyle(.white)
-                                    Spacer()
-                                    Text(job.date, style: .date)
-                                        .font(.caption)
-                                        .foregroundStyle(.white.opacity(0.8))
-                                }
-
-                                if let u = creator(for: job) {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "person.crop.circle")
-                                        Text("\(u.firstName) \(u.lastName)")
+                            GlassCard(cornerRadius: JTShapes.smallCardCornerRadius,
+                                      strokeColor: JTColors.glassSoftStroke,
+                                      shadow: JTShadow.none) {
+                                VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                                    HStack(alignment: .firstTextBaseline) {
+                                        Text(job.status)
+                                            .font(JTTypography.headline)
+                                            .foregroundStyle(JTColors.textPrimary)
+                                        Spacer()
+                                        Text(job.date, style: .date)
+                                            .font(JTTypography.caption)
+                                            .foregroundStyle(JTColors.textSecondary)
                                     }
-                                    .font(.caption)
-                                    .foregroundStyle(.white.opacity(0.9))
-                                }
 
-                                // You can add more fields here if your Job model has them (e.g., notes, photos)
-                                // Example (safe-guarded):
-                                // if let notes = job.notes, !notes.isEmpty { Text(notes) ... }
+                                    if let u = creator(for: job) {
+                                        HStack(spacing: JTSpacing.xs) {
+                                            Image(systemName: "person.crop.circle")
+                                            Text("\(u.firstName) \(u.lastName)")
+                                        }
+                                        .font(JTTypography.caption)
+                                        .foregroundStyle(JTColors.textSecondary)
+                                    }
+                                }
+                                .padding(JTSpacing.md)
                             }
-                            .padding(12)
-                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                    .stroke(Color.white.opacity(0.06))
-                            )
                         }
                     }
                 }
-                .padding(16)
+                .padding(JTSpacing.lg)
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/Job Tracker/Views/SignUpView.swift
+++ b/Job Tracker/Views/SignUpView.swift
@@ -10,63 +10,67 @@ struct SignUpView: View {
     @State private var errorMessage = ""
     
     let positions = ["Aerial", "Underground", "Nid", "Can"]
-    
+
     var body: some View {
         ZStack {
-            // Background gradient
-            LinearGradient(
-                gradient: Gradient(colors: [
-                    Color(red: 0.17254902, green: 0.24313726, blue: 0.3137255),
-                    Color(red: 0.29803923, green: 0.6313726, blue: 0.6862745)
-                ]),
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .edgesIgnoringSafeArea(.all)
-            
-            VStack(spacing: 20) {
+            JTGradients.background
+                .ignoresSafeArea()
+
+            VStack(spacing: JTSpacing.xl) {
                 Text("Sign Up")
-                    .font(.largeTitle)
-                    .foregroundColor(.white)
-                
-                TextField("First Name", text: $firstName)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                TextField("Last Name", text: $lastName)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                TextField("Email", text: $email)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .autocapitalization(.none)
-                SecureField("Password", text: $password)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                
-                Picker("Position", selection: $position) {
-                    ForEach(positions, id: \.self) { pos in
-                        Text(pos)
-                    }
-                }
-                .pickerStyle(SegmentedPickerStyle())
-                
-                Button("Create Account") {
-                    authViewModel.signUp(firstName: firstName, lastName: lastName, position: position, email: email, password: password) { error in
-                        if let error = error {
-                            errorMessage = error.localizedDescription
+                    .font(JTTypography.screenTitle)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+                    VStack(spacing: JTSpacing.md) {
+                        JTTextField("First Name", text: $firstName, icon: "person")
+                            .textInputAutocapitalization(.words)
+
+                        JTTextField("Last Name", text: $lastName, icon: "person")
+                            .textInputAutocapitalization(.words)
+
+                        JTTextField("Email", text: $email, icon: "envelope")
+                            .textInputAutocapitalization(.never)
+                            .keyboardType(.emailAddress)
+                            .disableAutocorrection(true)
+
+                        JTTextField("Password", text: $password, icon: "lock", isSecure: true)
+
+                        Picker("Position", selection: $position) {
+                            ForEach(positions, id: \.self) { pos in
+                                Text(pos)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+
+                        JTPrimaryButton("Create Account", systemImage: "checkmark.circle.fill") {
+                            authViewModel.signUp(firstName: firstName,
+                                                 lastName: lastName,
+                                                 position: position,
+                                                 email: email,
+                                                 password: password) { error in
+                                if let error = error {
+                                    errorMessage = error.localizedDescription
+                                }
+                            }
+                        }
+
+                        if !errorMessage.isEmpty {
+                            Text(errorMessage)
+                                .font(JTTypography.caption)
+                                .foregroundColor(.red)
+                                .multilineTextAlignment(.center)
+                                .padding(.top, JTSpacing.sm)
                         }
                     }
+                    .padding(JTSpacing.lg)
                 }
-                .padding()
-                .background(Color.blue)
-                .foregroundColor(.white)
-                .cornerRadius(8)
-                
-                if !errorMessage.isEmpty {
-                    Text(errorMessage)
-                        .foregroundColor(.red)
-                        .multilineTextAlignment(.center)
-                }
-                
+                .padding(.horizontal, JTSpacing.lg)
+
                 Spacer()
             }
-            .padding()
+            .padding(.top, JTSpacing.xl)
+            .padding(.bottom, JTSpacing.lg)
         }
     }
 }

--- a/Job Tracker/Views/Yellow Sheet STuff/HelpCenterView.swift
+++ b/Job Tracker/Views/Yellow Sheet STuff/HelpCenterView.swift
@@ -8,27 +8,6 @@ import CoreLocation   // for distance / CLLocation
 import SwiftUI
 import UIKit // for UIImage in share attachments
 
-// Local glass card style to avoid relying on fileprivate symbols from other files
-private struct HelpGlassCard: ViewModifier {
-    var cornerRadius: CGFloat = 14
-    func body(content: Content) -> some View {
-        content
-            .background(
-                .ultraThinMaterial,
-                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .stroke(Color.white.opacity(0.18), lineWidth: 1)
-            )
-    }
-}
-private extension View {
-    func helpGlassCard(cornerRadius: CGFloat = 14) -> some View {
-        modifier(HelpGlassCard(cornerRadius: cornerRadius))
-    }
-}
-
 // MARK: – Help Center
 struct HelpCenterView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
@@ -175,84 +154,61 @@ struct HelpCenterView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            // Match your app’s gradient
-            LinearGradient(
-                colors: [Color(red: 0.10, green: 0.14, blue: 0.18),
-                         Color(red: 0.20, green: 0.45, blue: 0.55)],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .ignoresSafeArea()
+            JTGradients.background
+                .ignoresSafeArea()
 
             ScrollView {
-                VStack(spacing: 16) {
-                    // Header + search
-                    VStack(spacing: 10) {
+                VStack(spacing: JTSpacing.lg) {
+                    VStack(alignment: .leading, spacing: JTSpacing.sm) {
                         Text("Help Center")
-                            .font(.largeTitle.bold())
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .foregroundStyle(.white)
+                            .font(JTTypography.screenTitle)
+                            .foregroundStyle(JTColors.textPrimary)
 
-                        HStack(spacing: 8) {
-                            Image(systemName: "magnifyingglass")
-                            TextField("Search help…", text: $query)
-                                .textInputAutocapitalization(.never)
-                                .disableAutocorrection(true)
-                        }
-                        .padding(12)
-                        .background(.ultraThinMaterial,
-                                    in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        JTTextField("Search help…", text: $query, icon: "magnifyingglass")
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
                     }
 
-                   
-
-                    // Adaptive grid (great on iPad)
-                    let columns = [GridItem(.adaptive(minimum: 280), spacing: 12)]
-                    LazyVGrid(columns: columns, spacing: 12) {
+                    let columns = [GridItem(.adaptive(minimum: 280), spacing: JTSpacing.md)]
+                    LazyVGrid(columns: columns, spacing: JTSpacing.md) {
                         ForEach(filteredTopics) { topic in
                             Button { selectedTopic = topic } label: {
-                                VStack(alignment: .leading, spacing: 8) {
-                                    Label(topic.title, systemImage: topic.icon)
-                                        .font(.headline)
-                                        .foregroundStyle(.white)
-                                    Text(topic.summary)
-                                        .font(.subheadline)
-                                        .foregroundStyle(.white.opacity(0.85))
-                                        .fixedSize(horizontal: false, vertical: true)
+                                GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+                                    VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                                        Label(topic.title, systemImage: topic.icon)
+                                            .font(JTTypography.headline)
+                                            .foregroundStyle(JTColors.textPrimary)
+                                        Text(topic.summary)
+                                            .font(JTTypography.subheadline)
+                                            .foregroundStyle(JTColors.textSecondary)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(JTSpacing.md)
                                 }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(14)
                             }
                             .buttonStyle(.plain)
-                            .helpGlassCard(cornerRadius: 16)
                         }
                     }
 
-                    // Support block
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Need more help?")
-                            .font(.title3.bold())
-                            .foregroundStyle(.white)
-                        Text("Tap a topic for step‑by‑step instructions. Remember: jobs marked **In Progress** or **Done** are auto‑included in **Timesheets** and **Yellow Sheet** for the appropriate week.")
-                            .foregroundStyle(.white.opacity(0.8))
+                    GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+                        VStack(alignment: .leading, spacing: JTSpacing.md) {
+                            Text("Need more help?")
+                                .font(JTTypography.title3)
+                                .foregroundStyle(JTColors.textPrimary)
+                            Text("Tap a topic for step‑by‑step instructions. Remember: jobs marked **In Progress** or **Done** are auto‑included in **Timesheets** and **Yellow Sheet** for the appropriate week.")
+                                .foregroundStyle(JTColors.textSecondary)
 
-                        HStack(spacing: 12) {
-                            Button {
+                            JTPrimaryButton("Email Support", systemImage: "envelope.fill") {
                                 if let url = URL(string: "mailto:support@example.com") {
                                     UIApplication.shared.open(url)
                                 }
-                            } label: {
-                                Label("Email Support", systemImage: "envelope.fill")
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 12)
                             }
-                            .helpGlassCard(cornerRadius: 14)
-
-                            
                         }
+                        .padding(JTSpacing.lg)
                     }
                 }
-                .padding(16)
+                .padding(JTSpacing.lg)
             }
         }
         .sheet(isPresented: $showingCreateJob) {
@@ -277,11 +233,11 @@ struct HelpCenterView: View {
         var body: some View {
             NavigationView {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: JTSpacing.md) {
                         Label(topic.title, systemImage: topic.icon)
                             .font(.title2.bold())
                         ForEach(topic.bullets, id: \.self) { line in
-                            HStack(alignment: .top, spacing: 8) {
+                            HStack(alignment: .top, spacing: JTSpacing.sm) {
                                 Image(systemName: "checkmark.circle")
                                     .imageScale(.small)
                                     .foregroundStyle(.green)
@@ -290,19 +246,14 @@ struct HelpCenterView: View {
                             }
                         }
                         if let action = topic.action {
-                            Button {
+                            JTPrimaryButton("Try it now", systemImage: "arrow.right.circle.fill") {
                                 action()
                                 dismiss()
-                            } label: {
-                                Label("Try it now", systemImage: "arrow.right.circle.fill")
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 12)
                             }
-                            .helpGlassCard(cornerRadius: 14)
-                            .padding(.top, 8)
+                            .padding(.top, JTSpacing.md)
                         }
                     }
-                    .padding()
+                    .padding(JTSpacing.lg)
                 }
                 .navigationTitle("Guide")
                 .toolbar {


### PR DESCRIPTION
## Summary
- add a DesignSystem module with color, typography, spacing, shape, and elevation tokens plus reusable components like GlassCard, JTPrimaryButton, and JTTextField
- refactor Dashboard, Help Center, Job Search, Sign Up, and job detail views to consume the new gradient, glass modifiers, and shared components
- document usage expectations for the new tokens and components in DesignSystem.md to keep future features consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdb5c88598832d8bcb013712c29498