### PR TITLE
Refactor dashboard into modular components

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardHeaderToolbar.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardHeaderToolbar.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct DashboardHeaderToolbar: View {
+    let title: String
+    let subtitle: String
+    let isPreparingShare: Bool
+    let shareAccessibilityLabel: String
+    let onCalendarTap: () -> Void
+    let onShareTap: () -> Void
+
+    var body: some View {
+        HStack(spacing: JTSpacing.md) {
+            Button(action: onCalendarTap) {
+                Image(systemName: "calendar")
+                    .font(.headline)
+                    .frame(width: 28, height: 28)
+                    .padding(JTSpacing.xs)
+                    .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassStroke.opacity(0.6))
+            }
+            .buttonStyle(.plain)
+
+            VStack(spacing: JTSpacing.xs / 2) {
+                Text(title)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                Text(subtitle)
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+            .frame(maxWidth: .infinity)
+
+            Button(action: onShareTap) {
+                ZStack {
+                    if isPreparingShare {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                    } else {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.headline)
+                    }
+                }
+                .frame(width: 28, height: 28)
+                .padding(JTSpacing.xs)
+                .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassStroke.opacity(0.6))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(shareAccessibilityLabel)
+            .accessibilityHint("Creates a summary for the selected day")
+            .disabled(isPreparingShare)
+        }
+        .padding(.horizontal, JTSpacing.lg)
+        .padding(.vertical, JTSpacing.md)
+        .jtGlassBackground(cornerRadius: JTShapes.largeCardCornerRadius)
+    }
+}
+
+private struct DashboardHeaderToolbarPreviewContainer: View {
+    let isPreparingShare: Bool
+
+    var body: some View {
+        DashboardHeaderToolbar(
+            title: "Jobs",
+            subtitle: "April 29, 2025",
+            isPreparingShare: isPreparingShare,
+            shareAccessibilityLabel: "Share Jobs for April 29, 2025",
+            onCalendarTap: {},
+            onShareTap: {}
+        )
+        .padding()
+        .background(JTGradients.background.ignoresSafeArea())
+    }
+}
+
+#Preview("Header – iPhone 15 Pro") {
+    DashboardHeaderToolbarPreviewContainer(isPreparingShare: false)
+        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}
+
+#Preview("Header – iPad Pro 11") {
+    DashboardHeaderToolbarPreviewContainer(isPreparingShare: true)
+        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
+        .frame(maxWidth: 600)
+}

--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+
+struct DashboardJobSectionsView: View {
+    let sections: DashboardViewModel.JobSections
+    let statusOptions: [String]
+    let nearestJobID: String?
+    let distanceStrings: [String: String]
+    let onJobTap: (Job) -> Void
+    let onMapTap: (Job) -> Void
+    let onStatusChange: (Job, String) -> Void
+    let onDelete: (Job) -> Void
+    let onShare: (Job) -> Void
+
+    var body: some View {
+        if sections.isEmpty {
+            VStack { // keep centered width for layout parity
+                Text("No jobs for this date")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.white)
+                    .padding(.horizontal, JTSpacing.lg)
+                    .padding(.vertical, JTSpacing.sm)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .overlay(Capsule().stroke(Color.white.opacity(0.18), lineWidth: 1))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, JTSpacing.xl)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: JTSpacing.lg) {
+                    if !sections.notCompleted.isEmpty {
+                        DashboardJobSectionHeader(title: "Not Completed")
+                        ForEach(sections.notCompleted, id: \.id) { job in
+                            JobCard(
+                                job: job,
+                                isHere: job.id == nearestJobID,
+                                statusOptions: statusOptions,
+                                onMapTap: { onMapTap(job) },
+                                onStatusChange: { newStatus in onStatusChange(job, newStatus) },
+                                onDelete: { onDelete(job) },
+                                onShare: { onShare(job) },
+                                distanceString: distanceStrings[job.id]
+                            )
+                            .id("\(job.id)_\(job.status)")
+                            .onTapGesture { onJobTap(job) }
+                        }
+                    }
+
+                    if !sections.completed.isEmpty {
+                        DashboardJobSectionHeader(title: "Completed")
+                            .padding(.top, JTSpacing.sm)
+                        ForEach(sections.completed, id: \.id) { job in
+                            JobCard(
+                                job: job,
+                                isHere: job.id == nearestJobID,
+                                statusOptions: statusOptions,
+                                onMapTap: { onMapTap(job) },
+                                onStatusChange: { newStatus in onStatusChange(job, newStatus) },
+                                onDelete: { onDelete(job) },
+                                onShare: { onShare(job) },
+                                distanceString: distanceStrings[job.id]
+                            )
+                            .id("\(job.id)_\(job.status)")
+                            .onTapGesture { onJobTap(job) }
+                        }
+                    }
+                }
+                .padding(JTSpacing.lg)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+private struct DashboardJobSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(JTTypography.headline)
+            .foregroundStyle(Color.white.opacity(0.9))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, JTSpacing.sm)
+    }
+}
+
+struct JobCard: View {
+    let job: Job
+    let isHere: Bool
+    let statusOptions: [String]
+    let onMapTap: () -> Void
+    let onStatusChange: (String) -> Void
+    let onDelete: () -> Void
+    let onShare: () -> Void
+    let distanceString: String?
+
+    @State private var showDeleteConfirm = false
+    @State private var showStatusDialog = false
+    @State private var showCustomStatusEntry = false
+    @State private var customStatusText = ""
+
+    init(
+        job: Job,
+        isHere: Bool,
+        statusOptions: [String],
+        onMapTap: @escaping () -> Void,
+        onStatusChange: @escaping (String) -> Void,
+        onDelete: @escaping () -> Void,
+        onShare: @escaping () -> Void,
+        distanceString: String?
+    ) {
+        self.job = job
+        self.isHere = isHere
+        self.statusOptions = statusOptions
+        self.onMapTap = onMapTap
+        self.onStatusChange = onStatusChange
+        self.onDelete = onDelete
+        self.onShare = onShare
+        self.distanceString = distanceString
+    }
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.cardCornerRadius) {
+            VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                header
+                details
+                actions
+            }
+            .padding(JTSpacing.md)
+        }
+        .padding(.horizontal, JTSpacing.xs)
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+            Button(action: onShare) {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+            .tint(.blue)
+        }
+        .contextMenu {
+            Button("Directions", systemImage: "map.fill", action: onMapTap)
+            Button("Share", systemImage: "square.and.arrow.up", action: onShare)
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+        .alert("Delete this job?", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive, action: onDelete)
+            Button("Cancel", role: .cancel) { }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(houseNumber(job.address)), \(DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))")
+        .accessibilityHint("Double tap for details. Swipe actions for share and delete.")
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: JTSpacing.sm) {
+            Image(systemName: "mappin.and.ellipse")
+                .font(.callout)
+                .foregroundStyle(JTColors.textSecondary)
+            Text(job.address)
+                .font(JTTypography.headline)
+                .fontWeight(.semibold)
+                .foregroundStyle(JTColors.textPrimary)
+                .lineLimit(2)
+                .truncationMode(.tail)
+            Spacer(minLength: JTSpacing.sm)
+        }
+    }
+
+    private var details: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            HStack(spacing: JTSpacing.xs) {
+                Text(job.date, style: .date)
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+
+                if let distanceString, !distanceString.isEmpty {
+                    Text("• \(distanceString)")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .accessibilityLabel("Distance \(distanceString)")
+                }
+
+                if isHere {
+                    Text("Here")
+                        .font(JTTypography.caption)
+                        .fontWeight(.bold)
+                        .padding(.horizontal, JTSpacing.sm)
+                        .padding(.vertical, JTSpacing.xs)
+                        .background(JTColors.success)
+                        .foregroundStyle(JTColors.textPrimary)
+                        .clipShape(Capsule())
+                        .accessibilityLabel("You are here")
+                }
+
+                Spacer()
+            }
+
+            if let assignments = job.assignments?.trimmedNonEmpty {
+                KeyValueRow(key: "Assignment:", value: assignments)
+            }
+            if let materials = job.materialsUsed?.trimmedNonEmpty {
+                KeyValueRow(key: "Materials:", value: materials, lineLimit: 2)
+            }
+            if let notes = job.notes?.trimmedNonEmpty {
+                KeyValueRow(key: "Notes:", value: notes, lineLimit: 2)
+            }
+        }
+    }
+
+    private var actions: some View {
+        HStack(spacing: JTSpacing.sm) {
+            Text("Status:")
+                .foregroundStyle(JTColors.textPrimary)
+
+            Button {
+                showStatusDialog = true
+            } label: {
+                Text(job.status)
+                    .font(JTTypography.subheadline)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, JTSpacing.md)
+                    .padding(.vertical, JTSpacing.xs)
+                    .background(statusBackground(for: job.status))
+                    .foregroundStyle(JTColors.textPrimary)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .confirmationDialog("Change Status", isPresented: $showStatusDialog, titleVisibility: .visible) {
+                ForEach(statusOptions, id: \.self) { option in
+                    if option == "Custom" {
+                        Button("Custom…") { showCustomStatusEntry = true }
+                    } else {
+                        Button(option) { onStatusChange(option) }
+                    }
+                }
+            }
+            .sheet(isPresented: $showCustomStatusEntry) {
+                NavigationStack {
+                    Form {
+                        TextField("Status", text: $customStatusText)
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") {
+                                let trimmed = customStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    onStatusChange(trimmed)
+                                }
+                                customStatusText = ""
+                                showCustomStatusEntry = false
+                            }
+                        }
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") {
+                                customStatusText = ""
+                                showCustomStatusEntry = false
+                            }
+                        }
+                    }
+                }
+                .presentationDetents([.medium])
+            }
+
+            Spacer()
+
+            Button(action: onMapTap) {
+                Image(systemName: "map")
+                    .imageScale(.medium)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .padding(JTSpacing.xs)
+                    .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
+            }
+            .accessibilityLabel("Directions")
+
+            Button(action: onShare) {
+                Image(systemName: "square.and.arrow.up")
+                    .imageScale(.medium)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .padding(JTSpacing.xs)
+                    .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
+            }
+
+            Button {
+                showDeleteConfirm = true
+                #if canImport(UIKit)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                #endif
+            } label: {
+                Image(systemName: "trash")
+                    .imageScale(.medium)
+                    .foregroundColor(.red)
+                    .padding(JTSpacing.xs)
+                    .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
+            }
+        }
+    }
+
+    private func statusBackground(for status: String) -> Color {
+        let s = status.lowercased()
+        if s == "done" { return JTColors.success.opacity(0.7) }
+        if s == "pending" { return JTColors.warning.opacity(0.6) }
+        if s.contains("needs") { return JTColors.info.opacity(0.6) }
+        return JTColors.glassHighlight
+    }
+
+    private func houseNumber(_ full: String) -> String {
+        if let comma = full.firstIndex(of: ",") {
+            return String(full[..<comma])
+        }
+        return full
+    }
+}
+
+private struct KeyValueRow: View {
+    let key: String
+    let value: String
+    var lineLimit: Int = 1
+
+    var body: some View {
+        HStack(alignment: .top, spacing: JTSpacing.xs) {
+            Text(key)
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+            Text(value)
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textPrimary)
+                .lineLimit(lineLimit)
+                .truncationMode(.tail)
+        }
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}
+
+private struct DashboardJobSectionsPreviewContainer: View {
+    let sections: DashboardViewModel.JobSections
+
+    init() {
+        let today = Date()
+        let pending = Job(
+            id: "1",
+            address: "123 Main Street, Springfield, IL",
+            date: today,
+            status: "Pending",
+            assignments: "12.3.2",
+            materialsUsed: "Coax, Splitter",
+            notes: "Call ahead"
+        )
+        let done = Job(
+            id: "2",
+            address: "456 Elm Road, Springfield, IL",
+            date: today,
+            status: "Done",
+            notes: "Customer not home",
+            hours: 2
+        )
+        sections = DashboardViewModel.JobSections(
+            notCompleted: [pending],
+            completed: [done],
+            distanceStrings: ["1": "0.4 mi", "2": "1.2 mi"]
+        )
+    }
+
+    var body: some View {
+        DashboardJobSectionsView(
+            sections: sections,
+            statusOptions: DashboardViewModel().statusOptions,
+            nearestJobID: sections.notCompleted.first?.id,
+            distanceStrings: sections.distanceStrings,
+            onJobTap: { _ in },
+            onMapTap: { _ in },
+            onStatusChange: { _, _ in },
+            onDelete: { _ in },
+            onShare: { _ in }
+        )
+        .background(JTGradients.background.ignoresSafeArea())
+    }
+}
+
+#Preview("Job Sections – iPhone") {
+    DashboardJobSectionsPreviewContainer()
+        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}
+
+#Preview("Job Sections – iPad") {
+    DashboardJobSectionsPreviewContainer()
+        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
+        .frame(maxWidth: 820)
+}

--- a/Job Tracker/Features/Dashboard/Components/DashboardShareSheets.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardShareSheets.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct DashboardDatePickerSheet: View {
+    @Binding var selectedDate: Date
+    let onSelection: (Date) -> Void
+
+    var body: some View {
+        VStack {
+            DatePicker(
+                "Select a date",
+                selection: $selectedDate,
+                displayedComponents: [.date]
+            )
+            .datePickerStyle(.graphical)
+            .labelsHidden()
+        }
+        .padding()
+        .onChange(of: selectedDate) { newValue in
+            onSelection(newValue)
+        }
+    }
+}
+
+struct DashboardDailyShareSheet: View {
+    let items: [Any]
+    let subject: String
+
+    var body: some View {
+        ActivityView(activityItems: items, subject: subject)
+    }
+}
+
+struct DashboardJobShareSheet: View {
+    let url: URL
+    let subject: String
+
+    var body: some View {
+        ActivityView(activityItems: [url], subject: subject)
+    }
+}
+
+private struct DashboardDatePickerSheetPreviewContainer: View {
+    @State private var date = Date()
+
+    var body: some View {
+        DashboardDatePickerSheet(selectedDate: $date) { _ in }
+            .presentationDetents([.medium])
+    }
+}
+
+#Preview("Date Picker Sheet") {
+    DashboardDatePickerSheetPreviewContainer()
+        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}
+
+#Preview("Daily Share Sheet") {
+    DashboardDailyShareSheet(items: [NSString(string: "Jobs for May 1, 2025" )], subject: "Jobs for May 1, 2025")
+        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
+}
+
+#Preview("Job Share Sheet") {
+    DashboardJobShareSheet(url: URL(string: "https://example.com/job")!, subject: "Job link for May 1, 2025")
+        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}

--- a/Job Tracker/Features/Dashboard/Components/DashboardSummaryCard.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSummaryCard.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct DashboardSummaryCard: View {
+    let date: Date
+    let total: Int
+    let pending: Int
+    let completed: Int
+
+    private var metrics: [(title: String, value: Int)] {
+        [
+            ("Total", total),
+            ("Pending", pending),
+            ("Done", completed)
+        ]
+    }
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+            HStack(alignment: .center, spacing: JTSpacing.lg) {
+                VStack(alignment: .leading, spacing: JTSpacing.xs) {
+                    Text("Today")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                    Text(formatted(date))
+                        .font(JTTypography.title3)
+                        .foregroundStyle(JTColors.textPrimary)
+                }
+
+                Spacer(minLength: JTSpacing.md)
+
+                ForEach(metrics, id: \.title) { metric in
+                    DashboardMetricPill(title: metric.title, value: metric.value)
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private func formatted(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+private struct DashboardMetricPill: View {
+    let title: String
+    let value: Int
+
+    var body: some View {
+        VStack(spacing: JTSpacing.xs) {
+            Text(title)
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+            Text("\(value)")
+                .font(JTTypography.headline)
+                .foregroundStyle(JTColors.textPrimary)
+        }
+        .padding(.vertical, JTSpacing.sm)
+        .padding(.horizontal, JTSpacing.md)
+        .background(
+            Capsule(style: .continuous)
+                .fill(JTColors.glassHighlight)
+        )
+    }
+}
+
+private struct DashboardSummaryCardPreviewContainer: View {
+    var body: some View {
+        DashboardSummaryCard(
+            date: Date(timeIntervalSince1970: 1_715_000_000),
+            total: 12,
+            pending: 5,
+            completed: 7
+        )
+        .padding()
+        .background(JTGradients.background.ignoresSafeArea())
+    }
+}
+
+#Preview("Summary – iPhone 15 Pro") {
+    DashboardSummaryCardPreviewContainer()
+        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}
+
+#Preview("Summary – iPad Pro 11") {
+    DashboardSummaryCardPreviewContainer()
+        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
+        .frame(maxWidth: 700)
+}

--- a/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct DashboardSyncBanner: View {
+    let done: Int
+    let total: Int
+    let inFlight: Int
+    let phase: CGFloat
+
+    private var progress: CGFloat {
+        guard total > 0 else { return 0 }
+        return CGFloat(done) / CGFloat(total)
+    }
+
+    private var title: String {
+        if total == 0 { return "All changes are up to date" }
+        if done >= total { return "All changes uploaded" }
+        if inFlight > 0 { return "Uploading… (\(inFlight) in progress)" }
+        return "Syncing changes…"
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.black.opacity(0.76))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                )
+
+            GeometryReader { _ in
+                ZStack {
+                    WaterWave(progress: progress, phase: phase, amplitude: 6)
+                        .fill(Color.accentColor.opacity(0.55))
+                        .blur(radius: 0.4)
+                    WaterWave(progress: progress, phase: phase * 1.6 + 0.2, amplitude: 4)
+                        .fill(Color.accentColor.opacity(0.75))
+                }
+                .mask(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                )
+            }
+
+            HStack(spacing: JTSpacing.sm) {
+                Image(systemName: "arrow.up.arrow.down.circle.fill")
+                    .imageScale(.medium)
+                    .foregroundStyle(Color.white.opacity(0.95))
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.white)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                Text("\(max(done, 0))/\(max(total, 0))")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.white.opacity(0.9))
+                    .padding(.horizontal, JTSpacing.sm)
+                    .padding(.vertical, JTSpacing.xs)
+                    .background(Color.white.opacity(0.12))
+                    .clipShape(Capsule())
+            }
+            .padding(.horizontal, JTSpacing.md)
+        }
+        .frame(height: 44)
+        .padding(.horizontal, JTSpacing.lg)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(title)
+    }
+}
+
+struct WaterWave: Shape {
+    var progress: CGFloat
+    var phase: CGFloat
+    var amplitude: CGFloat
+
+    var animatableData: CGFloat {
+        get { phase }
+        set { phase = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let twoPi = CGFloat.pi * 2
+        let level = rect.height * (1 - max(0, min(progress, 1)))
+        let wavelength = max(rect.width / 1.2, 1)
+        let radians = phase * twoPi
+
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: level))
+
+        var x: CGFloat = 0
+        while x <= rect.width {
+            let relative = x / wavelength
+            let y = level + sin(relative * twoPi + radians) * amplitude
+            path.addLine(to: CGPoint(x: rect.minX + x, y: y))
+            x += 1
+        }
+
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+#Preview("Sync Banner – Uploading") {
+    DashboardSyncBanner(done: 2, total: 5, inFlight: 1, phase: 0.3)
+        .padding(.vertical)
+        .background(JTGradients.background.ignoresSafeArea())
+        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}
+
+#Preview("Sync Banner – Complete") {
+    DashboardSyncBanner(done: 5, total: 5, inFlight: 0, phase: 0.9)
+        .padding(.vertical)
+        .background(JTGradients.background.ignoresSafeArea())
+        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
+        .frame(maxWidth: 600)
+}

--- a/Job Tracker/Features/Dashboard/Components/DashboardWeekdayPicker.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardWeekdayPicker.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct DashboardWeekdayPicker: View {
+    let weekdays: [DashboardViewModel.Weekday]
+    let selectedOffset: Int?
+    let onSelect: (DashboardViewModel.Weekday) -> Void
+
+    var body: some View {
+        HStack(spacing: JTSpacing.sm) {
+            ForEach(weekdays) { day in
+                let isSelected = day.offset == selectedOffset
+                Button {
+                    onSelect(day)
+                } label: {
+                    Text(day.label)
+                        .font(JTTypography.subheadline)
+                        .fontWeight(isSelected ? .semibold : .regular)
+                        .padding(.vertical, JTSpacing.sm)
+                        .padding(.horizontal, JTSpacing.md)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(isSelected ? JTColors.accent.opacity(0.9) : JTColors.glassHighlight)
+                        )
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .stroke(isSelected ? JTColors.accent : Color.clear, lineWidth: 1.5)
+                        )
+                        .foregroundStyle(JTColors.textPrimary)
+                        .scaleEffect(isSelected ? 1.05 : 1.0)
+                        .animation(.easeInOut(duration: 0.15), value: isSelected)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Select \(day.label)")
+            }
+        }
+        .padding(.horizontal, JTSpacing.md)
+    }
+}
+
+#Preview("Weekday Picker – iPhone") {
+    DashboardWeekdayPicker(
+        weekdays: DashboardViewModel().weekdays,
+        selectedOffset: 2,
+        onSelect: { _ in }
+    )
+    .padding()
+    .background(JTGradients.background.ignoresSafeArea())
+    .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
+}
+
+#Preview("Weekday Picker – iPad") {
+    DashboardWeekdayPicker(
+        weekdays: DashboardViewModel().weekdays,
+        selectedOffset: nil,
+        onSelect: { _ in }
+    )
+    .padding()
+    .frame(maxWidth: 600)
+    .background(JTGradients.background.ignoresSafeArea())
+    .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
+}

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -1,242 +1,49 @@
-
-
-import CoreLocation   // for distance / CLLocation
 import SwiftUI
-import UIKit // for UIImage in share attachments
 
 struct DashboardView: View {
-    @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var jobsViewModel: JobsViewModel
-
-    // Smart‑routing settings
-    @AppStorage("smartRoutingEnabled") private var smartRoutingEnabled = false
-    @AppStorage("routingOptimizeBy")  private var routingOptimizeBy   = "closest" // or "farthest"
-    @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple" // "apple" or "google"
-    
-    // Live location
     @EnvironmentObject var locationService: LocationService
+
+    @AppStorage("smartRoutingEnabled") private var smartRoutingEnabled = false
+    @AppStorage("routingOptimizeBy") private var routingOptimizeBy = "closest"
+    @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
+
+    @StateObject private var viewModel = DashboardViewModel()
 
     private var sortClosest: Bool { routingOptimizeBy == "closest" }
 
-    @State private var selectedJob: Job?
-    @State private var nearestJobID: String?
-
-    // Per‑job share state (simplified)
-    @State private var jobShareURL: URL? = nil
-    @State private var showSystemShareForJob = false
-    @State private var isGeneratingShareLink = false
-
-    // Import result toast
-    @State private var showImportToast = false
-    @State private var importToastMessage = ""
-    @State private var importToastIsError = false
-    
-    // This tracks the user’s chosen date from the DatePicker:
-    @State private var selectedDate = Date()
-    
-    /// Weekday labels and their 0‑based offset from Monday.
-    private let weekdays: [(label: String, offset: Int)] = [
-        ("Mon", 0),
-        ("Tue", 1),
-        ("Wed", 2),
-        ("Thu", 3),
-        ("Fri", 4)
-    ]
-    @State private var selectedOffset: Int? = nil
-    
-    // Status options for updating job status
-    private let statusOptions = [
-        "Pending",
-        "Needs Aerial",
-        "Needs Underground",
-        "Needs Nid",
-        "Needs Can",
-        "Done",
-        "Talk to Rick",   // new fixed option
-        "Custom"          // opens manual entry
-    ]
-
-    // For animated transitions
-    @Namespace private var animation
-    
-    // Unified sheet controller
-    private enum ActiveSheet: Identifiable {
-        case datePicker
-        case share
-        case createJob
-        
-        var id: Int { hashValue }
-    }
-    @State private var activeSheet: ActiveSheet?
-    @State private var shareItems: [Any] = []
-    @State private var isPreparingDailyShare = false
-
-    // Sync banner state (offline/online uploads)
-    @State private var syncTotal: Int = 0
-    @State private var syncDone: Int = 0
-    @State private var syncInFlight: Int = 0
-    @State private var showSyncBanner: Bool = false
-
-    // Water animation phase
-    @State private var wavePhase: CGFloat = 0
-
-    // Scroll and summary state
-    @State private var scrollY: CGFloat = 0
-
-    private var jobsForSelectedDay: [Job] {
-        filteredJobs()
-    }
-    private var pendingCountForDay: Int {
-        jobsForSelectedDay.filter { $0.status.lowercased() == "pending" }.count
-    }
-    private var completedCountForDay: Int {
-        max(0, jobsForSelectedDay.count - pendingCountForDay)
+    private var sections: DashboardViewModel.JobSections {
+        viewModel.sections(
+            for: jobsViewModel.jobs,
+            smartRoutingEnabled: smartRoutingEnabled,
+            sortClosest: sortClosest,
+            currentLocation: locationService.current
+        )
     }
 
+    private var summaryCounts: (total: Int, pending: Int, completed: Int) {
+        viewModel.summaryCounts(from: jobsViewModel.jobs)
+    }
 
-    // MARK: – Main Content (broken out to reduce compiler load)
-    @ViewBuilder
-    private var mainContent: some View {
-        VStack(spacing: 12) {
-            // Floating toolbar header
-            headerView
+    private var selectedJobBinding: Binding<Job?> {
+        Binding(
+            get: { viewModel.selectedJob },
+            set: { viewModel.selectedJob = $0 }
+        )
+    }
 
-            // Summary (Liquid Glass)
-            SummaryCard(date: selectedDate,
-                        total: jobsForSelectedDay.count,
-                        pending: pendingCountForDay,
-                        completed: completedCountForDay)
-                .padding(.horizontal)
+    private var activeSheetBinding: Binding<DashboardViewModel.ActiveSheet?> {
+        Binding(
+            get: { viewModel.activeSheet },
+            set: { viewModel.activeSheet = $0 }
+        )
+    }
 
-            // Monday–Friday picker.
-            weekdayPickerView
-                .padding(.top, 4)
-
-            // Full-width Create Job button
-            JTPrimaryButton("Create Job", systemImage: "plus") {
-                activeSheet = .createJob
-            }
-            .padding(.horizontal)
-            .padding(.top, JTSpacing.sm)
-
-            // Job list grouped into Not Completed and Completed sections.
-            let allJobs = filteredJobs()
-            let rawNotCompleted = allJobs.filter { $0.status.lowercased() == "pending" }
-            let completed       = allJobs.filter { $0.status.lowercased() != "pending" }
-
-            // Distance strings keyed by job id (used by JobCard)
-            let (notCompleted, distanceStrings): ([Job], [String: String]) = {
-                guard smartRoutingEnabled, let here = locationService.current else {
-                    return (rawNotCompleted, [:])
-                }
-                // Pre‑compute distances to lighten the sort closure
-                let pairs: [(Job, CLLocationDistance)] = rawNotCompleted.map { job in
-                    let d = job.clLocation?.distance(from: here) ?? .greatestFiniteMagnitude
-                    return (job, d)
-                }
-                let sortedPairs = pairs.sorted { a, b in
-                    sortClosest ? a.1 < b.1 : a.1 > b.1
-                }
-                var map: [String: String] = [:]
-                for (job, d) in sortedPairs {
-                    if d.isFinite, d < .greatestFiniteMagnitude {
-                        map[job.id] = formatDistance(d)
-                    }
-                }
-                return (sortedPairs.map { $0.0 }, map)
-            }()
-
-            if allJobs.isEmpty {
-                HStack { // keep it centered and give it width for layout
-                    Text("No jobs for this date")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(.ultraThinMaterial, in: Capsule())
-                        .overlay(Capsule().stroke(Color.white.opacity(0.18), lineWidth: 1))
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.top, 28)
-                .padding(.horizontal)
-            } else {
-                ScrollView {
-                    LazyVStack(spacing: 16) {
-                        // Not Completed section
-                        if !notCompleted.isEmpty {
-                            Text("Not Completed")
-                                .font(.headline)
-                                .foregroundColor(.white.opacity(0.9))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.vertical, 4)
-                                .padding(.horizontal, 8)
-
-                            ForEach(notCompleted, id: \.id) { job in
-                                JobCard(
-                                    job: job,
-                                    isHere: job.id == nearestJobID,
-                                    statusOptions: statusOptions,
-                                    onMapTap: { openJobInMaps(job) },
-                                    onStatusChange: { newStatus in
-                                        DispatchQueue.main.async {
-                                            jobsViewModel.updateJobStatus(job: job, newStatus: newStatus)
-                                        }
-                                    },
-                                    onDelete: { jobsViewModel.deleteJob(documentID: job.id) },
-                                    onShare: {
-                                        Task { await shareJob(job) }
-                                    },
-                                    distanceString: distanceStrings[job.id]
-                                )
-                                .id("\(job.id)_\(job.status)")
-                                .listRowInsets(EdgeInsets())
-                                .listRowSeparator(.hidden)
-                                .listRowBackground(Color.clear)
-                                .transaction { $0.disablesAnimations = true }
-                                .onTapGesture { selectedJob = job }
-                            }
-                        }
-
-                        // Completed section
-                        if !completed.isEmpty {
-                            Text("Completed")
-                                .font(.headline)
-                                .foregroundColor(.white.opacity(0.9))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.top, 4)
-                                .padding(.horizontal, 8)
-
-                            ForEach(completed, id: \.id) { job in
-                                JobCard(
-                                    job: job,
-                                    isHere: job.id == nearestJobID,
-                                    statusOptions: statusOptions,
-                                    onMapTap: { openJobInMaps(job) },
-                                    onStatusChange: { newStatus in
-                                        DispatchQueue.main.async {
-                                            jobsViewModel.updateJobStatus(job: job, newStatus: newStatus)
-                                        }
-                                    },
-                                    onDelete: { jobsViewModel.deleteJob(documentID: job.id) },
-                                    onShare: {
-                                        Task { await shareJob(job) }
-                                    },
-                                    distanceString: distanceStrings[job.id]
-                                )
-                                .id("\(job.id)_\(job.status)")
-                                .listRowInsets(EdgeInsets())
-                                .listRowSeparator(.hidden)
-                                .listRowBackground(Color.clear)
-                                .transaction { $0.disablesAnimations = true }
-                                .onTapGesture { selectedJob = job }
-                            }
-                        }
-                    }
-                    .padding()
-                }
-                .coordinateSpace(name: "dashScroll")
-            }
-        }
+    private var showSystemShareBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.showSystemShareForJob },
+            set: { viewModel.showSystemShareForJob = $0 }
+        )
     }
 
     var body: some View {
@@ -245,43 +52,94 @@ struct DashboardView: View {
                 JTGradients.background
                     .ignoresSafeArea()
 
-                mainContent
+                VStack(spacing: JTSpacing.md) {
+                    DashboardHeaderToolbar(
+                        title: "Jobs",
+                        subtitle: viewModel.formattedDate(viewModel.selectedDate),
+                        isPreparingShare: viewModel.isPreparingDailyShare,
+                        shareAccessibilityLabel: viewModel.shareSubject,
+                        onCalendarTap: { viewModel.presentDatePicker() },
+                        onShareTap: { Task { await viewModel.handleDailyShareTap() } }
+                    )
+                    .padding(.horizontal)
+                    .padding(.top, JTSpacing.xl)
+
+                    DashboardSummaryCard(
+                        date: viewModel.selectedDate,
+                        total: summaryCounts.total,
+                        pending: summaryCounts.pending,
+                        completed: summaryCounts.completed
+                    )
+                    .padding(.horizontal)
+
+                    DashboardWeekdayPicker(
+                        weekdays: viewModel.weekdays,
+                        selectedOffset: viewModel.selectedOffset,
+                        onSelect: { day in viewModel.selectWeekday(offset: day.offset) }
+                    )
+                    .padding(.top, JTSpacing.sm)
+
+                    JTPrimaryButton("Create Job", systemImage: "plus") {
+                        viewModel.presentCreateJob()
+                    }
+                    .padding(.horizontal)
+                    .padding(.top, JTSpacing.sm)
+
+                    DashboardJobSectionsView(
+                        sections: sections,
+                        statusOptions: viewModel.statusOptions,
+                        nearestJobID: viewModel.nearestJobID,
+                        distanceStrings: sections.distanceStrings,
+                        onJobTap: { job in viewModel.selectedJob = job },
+                        onMapTap: { job in viewModel.openJobInMaps(job, suggestionProviderRaw: suggestionProviderRaw) },
+                        onStatusChange: { job, status in
+                            DispatchQueue.main.async {
+                                jobsViewModel.updateJobStatus(job: job, newStatus: status)
+                            }
+                        },
+                        onDelete: { job in jobsViewModel.deleteJob(documentID: job.id) },
+                        onShare: { job in
+                            Task { await viewModel.share(job: job) }
+                        }
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                }
             }
             .overlay(alignment: .top) {
-                VStack(spacing: 8) {
-                    // Syncing banner (appears only when there are pending uploads)
-                    if showSyncBanner, syncTotal > 0, syncDone <= syncTotal {
-                        SyncBanner(done: syncDone, total: syncTotal, inFlight: syncInFlight, phase: wavePhase)
-                            .transition(.move(edge: .top).combined(with: .opacity))
+                VStack(spacing: JTSpacing.sm) {
+                    if viewModel.showSyncBanner, viewModel.syncTotal > 0, viewModel.syncDone <= viewModel.syncTotal {
+                        DashboardSyncBanner(
+                            done: viewModel.syncDone,
+                            total: viewModel.syncTotal,
+                            inFlight: viewModel.syncInFlight,
+                            phase: viewModel.wavePhase
+                        )
+                        .transition(.move(edge: .top).combined(with: .opacity))
                     }
 
-                    // Existing toast(s)
-                    if showImportToast {
-                        HStack(spacing: 10) {
-                            Image(systemName: importToastIsError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    if viewModel.showImportToast {
+                        HStack(spacing: JTSpacing.sm) {
+                            Image(systemName: viewModel.importToastIsError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
                                 .imageScale(.medium)
-                                .foregroundColor(importToastIsError ? .yellow : .green)
-                            Text(importToastMessage)
+                                .foregroundStyle(viewModel.importToastIsError ? Color.yellow : Color.green)
+                            Text(viewModel.importToastMessage)
                                 .font(.subheadline)
-                                .foregroundColor(.white)
+                                .foregroundStyle(Color.white)
                         }
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 10)
+                        .padding(.horizontal, JTSpacing.md)
+                        .padding(.vertical, JTSpacing.sm)
                         .background(Color.black.opacity(0.85))
                         .clipShape(Capsule())
-                        .padding(.top, 6)
                         .transition(.move(edge: .top).combined(with: .opacity))
                     }
                 }
-                .padding(.top, 18)
+                .padding(.top, JTSpacing.md)
             }
-            // .overlay(alignment: .bottomTrailing) { ... } // AI Helper button removed
             .toolbar(.hidden, for: .navigationBar)
             .safeAreaInset(edge: .top) {
-                // Extra breathing room so the hamburger/menu button doesn't overlap the header card
-                Color.clear.frame(height: 66) // extra headroom so the floating hamburger button never overlaps the header
+                Color.clear.frame(height: 66)
             }
-            .sheet(item: $selectedJob) { job in
+            .sheet(item: selectedJobBinding) { job in
                 if let index = jobsViewModel.jobs.firstIndex(where: { $0.id == job.id }) {
                     JobDetailView(job: $jobsViewModel.jobs[index])
                 } else {
@@ -289,920 +147,66 @@ struct DashboardView: View {
                         .padding()
                 }
             }
-            .sheet(item: $activeSheet) { sheet in
+            .sheet(item: activeSheetBinding) { sheet in
                 switch sheet {
                 case .datePicker:
-                    VStack {
-                        DatePicker(
-                            "Select a date",
-                            selection: $selectedDate,
-                            displayedComponents: [.date]
+                    DashboardDatePickerSheet(
+                        selectedDate: Binding(
+                            get: { viewModel.selectedDate },
+                            set: { viewModel.selectedDate = $0 }
                         )
-                        .datePickerStyle(GraphicalDatePickerStyle())
-                        .labelsHidden()
-                        .onChange(of: selectedDate) { _ in
-                            activeSheet = nil
-                        }
+                    ) { _ in
+                        viewModel.dismissSheets()
                     }
-                    .padding()
                 case .share:
-                    ActivityView(
-                        activityItems: shareItems,
-                        subject: shareSubject()
-                    )
+                    DashboardDailyShareSheet(items: viewModel.shareItems, subject: viewModel.shareSubject)
                 case .createJob:
                     CreateJobView()
                 }
             }
-            // (Per‑job share sheet with privacy toggles removed)
-            // System share sheet for the generated deep link
-            .sheet(isPresented: $showSystemShareForJob) {
-                if let url = jobShareURL {
-                    ActivityView(
-                        activityItems: [url],
-                        subject: "Job link for \(formattedDate(selectedDate))"
-                    )
+            .sheet(isPresented: showSystemShareBinding) {
+                if let url = viewModel.jobShareURL {
+                    DashboardJobShareSheet(url: url, subject: viewModel.shareSubject)
                 }
             }
-            // When the view appears or selectedDate changes, fetch jobs for the week.
             .onAppear {
-                jobsViewModel.fetchJobsForWeek(selectedDate)
-                updateNearest(with: jobsViewModel.jobs)
+                viewModel.configureIfNeeded(jobsViewModel: jobsViewModel)
+                viewModel.updateNearestJob(with: jobsViewModel.jobs, currentLocation: locationService.current)
             }
-            .onChange(of: selectedDate) { _ in
-                
-                selectedOffset = weekdayOffset(for: selectedDate)
-                jobsViewModel.fetchJobsForWeek(selectedDate)
+            .onReceive(locationService.$current) { location in
+                viewModel.updateNearestJob(with: jobsViewModel.jobs, currentLocation: location)
             }
-            .onReceive(locationService.$current) { _ in
-                updateNearest(with: jobsViewModel.jobs)
-            }
-            .onReceive(jobsViewModel.$jobs) { newList in
-                if activeSheet != nil { activeSheet = nil }
-                updateNearest(with: newList)
-            }
-            .onReceive(authViewModel.$currentUser) { _ in
-                // No-op: job visibility is handled by Firestore queries scoped via `participants`.
+            .onReceive(jobsViewModel.$jobs) { newJobs in
+                viewModel.handleJobsListChange(newJobs, currentLocation: locationService.current)
             }
             .onReceive(NotificationCenter.default.publisher(for: .jobImportSucceeded)) { _ in
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
-                    importToastIsError = false
-                    importToastMessage = "Job imported to your dashboard"
-                    showImportToast = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                    withAnimation(.easeInOut(duration: 0.25)) { showImportToast = false }
-                }
+                viewModel.presentImportSuccessToast()
             }
             .onReceive(NotificationCenter.default.publisher(for: .jobImportFailed)) { note in
-                let msg: String
-                if let err = note.object as? NSError, !err.localizedDescription.isEmpty {
-                    msg = err.localizedDescription
+                let message: String
+                if let error = note.object as? NSError, !error.localizedDescription.isEmpty {
+                    message = error.localizedDescription
+                } else if let error = note.object as? Error, !error.localizedDescription.isEmpty {
+                    message = error.localizedDescription
                 } else {
-                    msg = "Import failed"
+                    message = "Import failed"
                 }
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
-                    importToastIsError = true
-                    importToastMessage = msg
-                    showImportToast = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                    withAnimation(.easeInOut(duration: 0.25)) { showImportToast = false }
-                }
+                viewModel.presentImportFailureToast(message: message)
             }
             .onReceive(NotificationCenter.default.publisher(for: .jobsSyncStateDidChange)) { note in
-                // Expecting userInfo keys: "total", "uploaded" (or "done"), "inFlight"
                 let info = note.userInfo ?? [:]
                 let total = (info["total"] as? Int) ?? 0
-                let done  = (info["uploaded"] as? Int) ?? (info["done"] as? Int) ?? 0
+                let done = (info["uploaded"] as? Int) ?? (info["done"] as? Int) ?? 0
                 let inFlight = (info["inFlight"] as? Int) ?? 0
-
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
-                    syncTotal = max(total, 0)
-                    syncDone = max(min(done, total), 0)
-                    syncInFlight = max(inFlight, 0)
-                    showSyncBanner = (syncTotal > 0) && (syncDone < syncTotal)
-                }
-
-                // If finished, fade out banner shortly after
-                if syncTotal > 0 && syncDone >= syncTotal {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        withAnimation(.easeInOut(duration: 0.25)) { showSyncBanner = false }
-                    }
+                viewModel.handleSyncStateChange(total: total, done: done, inFlight: inFlight)
+            }
+            .onChange(of: viewModel.showSyncBanner) { visible in
+                if visible {
+                    viewModel.startWaveAnimation()
+                } else {
+                    viewModel.resetWave()
                 }
             }
-            .onChange(of: showSyncBanner) { visible in
-                // Drive the water "sloshing" while visible
-                guard visible else { return }
-                // Reset phase
-                wavePhase = 0
-                withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
-                    wavePhase = 1.0
-                }
-            }
-        }
-    }
-}
-
-// MARK: - Header
-extension DashboardView {
-    /// Format a distance in meters into a short, human‑readable string (e.g., "650 m" or "0.4 mi").
-    private func formatDistance(_ meters: CLLocationDistance) -> String {
-        guard meters.isFinite else { return "" }
-        // Simple heuristic: prefer miles in the US, meters/km otherwise.
-        let usesUSUnits: Bool = Locale.current.usesMetricSystem == false
-        if usesUSUnits {
-            let miles = meters / 1609.344
-            if miles < 0.1 { return "<0.1 mi" }
-            return String(format: "%.1f mi", miles)
-        } else {
-            if meters < 1000 { return "\(Int(meters.rounded())) m" }
-            let km = meters / 1000
-            return String(format: "%.1f km", km)
-        }
-    }
-    private var headerView: some View {
-        HStack(spacing: 12) {
-            Button {
-                activeSheet = .datePicker
-            } label: {
-                Image(systemName: "calendar")
-                    .font(.headline)
-                    .padding(10)
-                    .background(.ultraThinMaterial, in: Circle())
-            }
-
-            VStack(spacing: 0) {
-                Text("Jobs")
-                    .font(.title3.weight(.semibold))
-                Text(formattedDate(selectedDate))
-                    .font(.footnote)
-                    .foregroundColor(.white.opacity(0.85))
-            }
-            .frame(maxWidth: .infinity)
-
-            Button {
-                Task { await handleDailyShareTap() }
-            } label: {
-                ZStack {
-                    if isPreparingDailyShare {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                    } else {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(.headline)
-                    }
-                }
-                .frame(width: 24, height: 24)
-                .padding(10)
-                .background(.ultraThinMaterial, in: Circle())
-            }
-            .disabled(isPreparingDailyShare)
-            .accessibilityLabel("Share \(shareSubject())")
-            .accessibilityHint("Creates a summary for the selected day")
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous).stroke(Color.white.opacity(0.18), lineWidth: 1))
-        )
-        .padding(.horizontal)
-        .padding(.top, 24)
-    }
-}
-
-// MARK: - Sharing Helpers
-
-fileprivate final class DailyJobsSummaryItemSource: NSObject, UIActivityItemSource {
-    private let textProvider: () -> String
-    private let fallbackProvider: () -> String
-    private let subjectProvider: () -> String
-
-    init(textProvider: @escaping () -> String,
-         fallbackProvider: @escaping () -> String,
-         subjectProvider: @escaping () -> String) {
-        self.textProvider = textProvider
-        self.fallbackProvider = fallbackProvider
-        self.subjectProvider = subjectProvider
-        super.init()
-    }
-
-    private func resolvedText() -> NSString {
-        let trimmed = textProvider().trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            return NSString(string: trimmed)
-        }
-        let fallback = fallbackProvider().trimmingCharacters(in: .whitespacesAndNewlines)
-        if fallback.isEmpty {
-            return NSString(string: " ")
-        }
-        return NSString(string: fallback)
-    }
-
-    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        resolvedText()
-    }
-
-    func activityViewController(_ activityViewController: UIActivityViewController,
-                                itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        resolvedText()
-    }
-
-    func activityViewController(_ activityViewController: UIActivityViewController,
-                                subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
-        let subject = subjectProvider().trimmingCharacters(in: .whitespacesAndNewlines)
-        return subject
-    }
-}
-
-extension DashboardView {
-    /// Create a minimal deep link for a single job and present the system share sheet.
-    private func shareJob(_ job: Job) async {
-        guard !isGeneratingShareLink else { return }
-        await MainActor.run { isGeneratingShareLink = true }
-        defer { Task { await MainActor.run { isGeneratingShareLink = false } } }
-        do {
-            let url = try await SharedJobService.shared.publishShareLink(job: job)
-            await MainActor.run {
-                jobShareURL = url
-                showSystemShareForJob = true
-            }
-        } catch {
-            print("Share publish failed: \(error.localizedDescription)")
-            await MainActor.run {
-                importToastIsError = true
-                importToastMessage = "Couldn't create link: \(error.localizedDescription)"
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) { showImportToast = true }
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                withAnimation(.easeInOut(duration: 0.25)) { showImportToast = false }
-            }
-        }
-    }
-    private func handleDailyShareTap() async {
-        let hasLoaded = await MainActor.run { jobsViewModel.hasLoadedInitialJobs }
-        guard hasLoaded else {
-            await MainActor.run { showJobsStillLoadingToast() }
-            return
-        }
-
-        let alreadyPreparing = await MainActor.run { isPreparingDailyShare }
-        guard !alreadyPreparing else { return }
-
-        await MainActor.run { isPreparingDailyShare = true }
-        defer { Task { await MainActor.run { isPreparingDailyShare = false } } }
-
-        await waitForLatestJobsData()
-
-        await MainActor.run {
-            presentDailyShareSheet()
-        }
-    }
-
-    private func waitForLatestJobsData(maxWait: TimeInterval = 1.0) async {
-        guard maxWait > 0 else { return }
-        let deadline = Date().addingTimeInterval(maxWait)
-        while Date() < deadline {
-            if Task.isCancelled { return }
-            let ready = await MainActor.run {
-                !filteredJobs().isEmpty || jobsViewModel.lastServerSync != nil
-            }
-            if ready { return }
-            try? await Task.sleep(nanoseconds: 80_000_000)
-        }
-    }
-
-    @MainActor
-    private func presentDailyShareSheet(limitImages: Int = 20) {
-        let items = buildDailyShareItems(limitImages: limitImages)
-        shareItems = items
-        activeSheet = nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            activeSheet = .share
-        }
-    }
-
-    @MainActor
-    private func buildDailyShareItems(limitImages: Int = 20) -> [Any] {
-        let summarySource = DailyJobsSummaryItemSource(
-            textProvider: { shareText() },
-            fallbackProvider: { shareEmptyFallbackText() },
-            subjectProvider: { shareSubject() }
-        )
-
-        var items: [Any] = [summarySource]
-
-        let jobsForDay = filteredJobs().filter { $0.status.lowercased() != "pending" }
-        var attachments: [Any] = []
-        for job in jobsForDay {
-            attachments.append(contentsOf: shareableAttachments(for: job))
-            if attachments.count >= limitImages { break }
-        }
-        if !attachments.isEmpty {
-            items.append(contentsOf: attachments.prefix(limitImages))
-        }
-        return items
-    }
-
-    @MainActor
-    private func showJobsStillLoadingToast() {
-        importToastIsError = true
-        importToastMessage = "Jobs are still loading…"
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
-            showImportToast = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            withAnimation(.easeInOut(duration: 0.25)) {
-                showImportToast = false
-            }
-        }
-    }
-
-    /// Try to find photo/image content on the Job using reflection so we don't rely on a specific model field name.
-    /// Supports: [UIImage], UIImage, [Data] (converted to UIImage), [URL], [String] (converted to URL if possible)
-    private func shareableAttachments(for job: Job) -> [Any] {
-        var out: [Any] = []
-        let mirror = Mirror(reflecting: job)
-        for child in mirror.children {
-            guard let label = child.label?.lowercased() else { continue }
-            // Heuristics: look for common photo/image keys
-            if label.contains("photo") || label.contains("image") || label.contains("picture") {
-                switch child.value {
-                case let arr as [UIImage]:
-                    out.append(contentsOf: arr)
-                case let img as UIImage:
-                    out.append(img)
-                case let arr as [Data]:
-                    out.append(contentsOf: arr.compactMap { UIImage(data: $0) })
-                case let data as Data:
-                    if let img = UIImage(data: data) { out.append(img) }
-                case let arr as [URL]:
-                    out.append(contentsOf: arr)
-                case let arr as [String]:
-                    out.append(contentsOf: arr.compactMap { URL(string: $0) })
-                case let str as String:
-                    if let url = URL(string: str) { out.append(url) }
-                default:
-                    break
-                }
-            }
-        }
-        return out
-    }
-}
-
-// MARK: - Monday–Friday Picker
-extension DashboardView {
-    private var weekdayPickerView: some View {
-        HStack(spacing: 10) {
-            ForEach(weekdays, id: \.label) { day in
-                Button {
-                    selectedOffset = day.offset
-                    selectedDate = dateForOffset(day.offset)
-                    jobsViewModel.fetchJobsForWeek(selectedDate)
-                } label: {
-                    Text(day.label)
-                        .fontWeight(selectedOffset == day.offset ? .bold : .regular)
-                        .padding(.vertical, 10)
-                        .padding(.horizontal, 16)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(selectedOffset == day.offset
-                                      ? Color.accentColor.opacity(0.9)
-                                      : Color.white.opacity(0.15))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color.white, lineWidth: selectedOffset == day.offset ? 2 : 0)
-                        )
-                        .foregroundColor(.white)
-                        .scaleEffect(selectedOffset == day.offset ? 1.1 : 1.0)
-                        .animation(.easeInOut(duration: 0.15), value: selectedOffset == day.offset)
-                }
-            }
-        }
-    }
-    
-    /// Return the `Date` for the weekday *offset* (0 = Mon … 4 = Fri) in the same week as `selectedDate`.
-    private func dateForOffset(_ offset: Int) -> Date {
-        var calendar = Calendar.current
-        calendar.firstWeekday = 2 // Monday
-        // Start (Monday) of the week containing selectedDate
-        let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: selectedDate))!
-        return calendar.date(byAdding: .day, value: offset, to: startOfWeek)!
-    }
-}
-
-// MARK: - Helpers
-extension DashboardView {
-    private func shareSubject() -> String {
-        "Jobs for \(formattedDate(selectedDate))"
-    }
-
-    private func shareEmptyFallbackText() -> String {
-        "No jobs to share for \(formattedDate(selectedDate))."
-    }
-
-    /// Compose share text for the selected date: "Jobs for Apr 29 2025:\n123 Main St – Done"
-    private func shareText() -> String {
-        let jobsForDay = filteredJobs().filter { $0.status.lowercased() != "pending" }
-        guard !jobsForDay.isEmpty else {
-            return shareEmptyFallbackText()
-        }
-
-        let header = "\(shareSubject()):"
-        let lines = jobsForDay.map { job in
-            let address = houseNumberAndStreet(from: job.address)
-            var entry = "\(address) – \(job.status)"
-            // Include notes if present
-            let noteText = (job.notes ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            if !noteText.isEmpty {
-                entry += " (Notes: \(noteText))"
-            }
-            return entry
-        }
-        return ([header] + lines).joined(separator: "\n")
-    }
-    
-    /// Trim address to house number and street.
-    private func houseNumberAndStreet(from fullAddress: String) -> String {
-        if let comma = fullAddress.firstIndex(of: ",") {
-            return String(fullAddress[..<comma]).trimmingCharacters(in: .whitespaces)
-        }
-        // Fallback: stop after common street suffix.
-        let suffixes: Set<String> = ["st","street","rd","road","ave","avenue","blvd","circle","cir","ln","lane","dr","drive","ct","court","pkwy","pl","place","ter","terrace"]
-        var tokens: [Substring] = []
-        for token in fullAddress.split(separator: " ") {
-            tokens.append(token)
-            let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: ",.")).lowercased()
-            if suffixes.contains(cleaned) { break }
-        }
-        return tokens.joined(separator: " ")
-    }
-    
-    /// Return 0 = Mon … 4 = Fri if the date is a weekday; otherwise nil.
-    private func weekdayOffset(for date: Date) -> Int? {
-        let weekday = Calendar.current.component(.weekday, from: date) // Sun = 1
-        let monBased = (weekday + 5) % 7   // Sun→6, Mon→0, Tue→1, … Sat→5
-        return monBased < 5 ? monBased : nil
-    }
-    /// Format selectedDate as "Apr 29 2025".
-    private func formattedDate(_ date: Date) -> String {
-        let fmt = DateFormatter()
-        fmt.dateStyle = .medium
-        return fmt.string(from: date)
-    }
-    
-    /// Return the jobs for the selected date. JobsViewModel now provides only jobs the current user can see (via `participants`).
-    private func filteredJobs() -> [Job] {
-        // JobsViewModel now provides only jobs the current user can see (via `participants`).
-        // Here we only filter by the selected calendar day and dedupe by id.
-        let dayFiltered = jobsViewModel.jobs.filter { job in
-            Calendar.current.isDate(job.date, inSameDayAs: selectedDate)
-        }
-        var seen = Set<String>()
-        var uniqueReversed: [Job] = []
-        for job in dayFiltered.reversed() {
-            if !seen.contains(job.id) {
-                seen.insert(job.id)
-                uniqueReversed.append(job)
-            }
-        }
-        return uniqueReversed.reversed()
-    }
-
-    /// Compute the single nearest job within 90 m (if any).
-    private func updateNearest(with jobs: [Job]) {
-        guard let here = locationService.current else {
-            nearestJobID = nil
-            return
-        }
-        let nearest = jobs
-            .compactMap { job -> (String, CLLocationDistance)? in
-                guard let d = job.clLocation?.distance(from: here) else { return nil }
-                return (job.id, d)
-            }
-            .min { $0.1 < $1.1 }
-        
-        let newID: String? = (nearest?.1 ?? .greatestFiniteMagnitude) < 90 ? nearest?.0 : nil
-        if newID != nearestJobID { nearestJobID = newID }
-    }
-    
-    private func openJobInMaps(_ job: Job) {
-        guard let encoded = job.address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            return
-        }
-        // Honor the user's preference from Settings → Maps & Addresses
-        if suggestionProviderRaw == "google" {
-            // Try Google Maps app first; if unavailable, fall back to Apple Maps
-            if let gURL = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") {
-                UIApplication.shared.open(gURL, options: [:]) { success in
-                    if !success {
-                        // Fallback to Apple Maps
-                        if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
-                            UIApplication.shared.open(appleURL)
-                        }
-                    }
-                }
-                return
-            }
-        }
-        // Default (or fallback): Apple Maps
-        if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
-            UIApplication.shared.open(appleURL)
-        }
-    }
-}
-
-
-
-// MARK: - JobCard
-struct JobCard: View {
-    let isHere: Bool       // NEW flag
-    let job: Job
-    let onDelete: () -> Void   // NEW
-    let statusOptions: [String]
-    let onMapTap: () -> Void
-    let onStatusChange: (String) -> Void
-    let onShare: () -> Void
-    @State private var showDeleteConfirm = false   // NEW
-    @State private var showStatusDialog = false
-    @State private var showCustomStatusEntry = false
-    @State private var customStatusText = ""
-
-    // NEW: Optional distance string displayed next to date
-    var distanceString: String? = nil
-
-    init(
-        job: Job,
-        isHere: Bool,
-        statusOptions: [String],
-        onMapTap: @escaping () -> Void,
-        onStatusChange: @escaping (String) -> Void,
-        onDelete: @escaping () -> Void,
-        onShare: @escaping () -> Void,
-        distanceString: String? = nil
-    ) {
-        self.job = job
-        self.isHere = isHere
-        self.statusOptions = statusOptions
-        self.onMapTap = onMapTap
-        self.onStatusChange = onStatusChange
-        self.onDelete = onDelete
-        self.onShare = onShare
-        self.distanceString = distanceString
-    }
-
-    var body: some View {
-        GlassCard(cornerRadius: JTShapes.cardCornerRadius) {
-            VStack(alignment: .leading, spacing: 10) {
-                // TITLE ROW
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Image(systemName: "mappin.and.ellipse")
-                        .font(.callout)
-                        .foregroundStyle(JTColors.textSecondary)
-                    Text(job.address)
-                        .font(JTTypography.headline)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(JTColors.textPrimary)
-                        .lineLimit(2)
-                        .truncationMode(.tail)
-                    Spacer(minLength: 6)
-                }
-
-                // SUBTITLE ROW: date + distance + HERE
-                HStack(spacing: 8) {
-                    Text(job.date, style: .date)
-                        .font(JTTypography.caption)
-                        .foregroundStyle(JTColors.textSecondary)
-
-                    if let d = distanceString, !d.isEmpty {
-                        Text("• \(d)")
-                            .font(JTTypography.caption)
-                            .foregroundStyle(JTColors.textSecondary)
-                            .accessibilityLabel("Distance \(d)")
-                    }
-
-                    if isHere {
-                        Text("Here")
-                            .font(JTTypography.caption)
-                            .fontWeight(.bold)
-                            .padding(.horizontal, 6).padding(.vertical, 4)
-                            .background(JTColors.success)
-                            .foregroundStyle(JTColors.textPrimary)
-                            .clipShape(Capsule())
-                            .accessibilityLabel("You are here")
-                    }
-
-                    Spacer()
-                }
-
-                // OPTIONAL FIELDS
-                if let assignments = job.assignments?.trimmedNonEmpty {
-                    KeyValueRow(key: "Assignment:", value: assignments)
-                }
-                if let materials = job.materialsUsed?.trimmedNonEmpty {
-                    KeyValueRow(key: "Materials:", value: materials, lineLimit: 2)
-                }
-                if let notes = job.notes?.trimmedNonEmpty {
-                    KeyValueRow(key: "Notes:", value: notes, lineLimit: 2)
-                }
-
-                // STATUS + ACTIONS
-                HStack(spacing: 10) {
-                    Text("Status:")
-                        .foregroundStyle(JTColors.textPrimary)
-
-                    Button {
-                        showStatusDialog = true
-                    } label: {
-                        Text(job.status)
-                            .font(JTTypography.subheadline)
-                            .fontWeight(.semibold)
-                            .padding(.horizontal, 10).padding(.vertical, 6)
-                            .background(statusBackground(for: job.status))
-                            .foregroundStyle(JTColors.textPrimary)
-                            .clipShape(Capsule())
-                    }
-                    .confirmationDialog("Change Status",
-                                        isPresented: $showStatusDialog,
-                                        titleVisibility: .visible) {
-                        ForEach(statusOptions, id: \.self) { option in
-                            if option == "Custom" {
-                                Button("Custom…") { showCustomStatusEntry = true }
-                            } else {
-                                Button(option) { onStatusChange(option) }
-                            }
-                        }
-                    }
-
-                    Spacer()
-
-                    // Quick actions
-                    Button(action: onMapTap) {
-                        Image(systemName: "map")
-                            .imageScale(.medium)
-                            .foregroundStyle(JTColors.textPrimary)
-                            .padding(8)
-                            .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
-                    }
-                    .accessibilityLabel("Directions")
-                    Button(action: onShare) {
-                        Image(systemName: "square.and.arrow.up")
-                            .imageScale(.medium)
-                            .foregroundStyle(JTColors.textPrimary)
-                            .padding(8)
-                            .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
-                    }
-                    Button {
-                        showDeleteConfirm = true
-#if canImport(UIKit)
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-#endif
-                    } label: {
-                        Image(systemName: "trash")
-                            .imageScale(.medium)
-                            .foregroundColor(.red)
-                            .padding(8)
-                            .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
-                    }
-                }
-                .alert("Delete this job?", isPresented: $showDeleteConfirm) {
-                    Button("Delete", role: .destructive) { onDelete() }
-                    Button("Cancel", role: .cancel) { }
-                }
-            }
-            .padding()
-        }
-        .padding(.horizontal, 4)
-        // Swipe actions (keeps your buttons too)
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            Button(role: .destructive) { onDelete() } label: {
-                Label("Delete", systemImage: "trash")
-            }
-            Button { onShare() } label: {
-                Label("Share", systemImage: "square.and.arrow.up")
-            }.tint(.blue)
-        }
-        .contextMenu {
-            Button("Directions", systemImage: "map.fill", action: onMapTap)
-            Button("Share", systemImage: "square.and.arrow.up", action: onShare)
-            Button("Delete", role: .destructive, action: onDelete)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(houseNumber(job.address)), \(DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))")
-        .accessibilityHint("Double tap for details. Swipe actions for share and delete.")
-    }
-
-    private func statusBackground(for status: String) -> Color {
-        let s = status.lowercased()
-        if s == "done" { return JTColors.success.opacity(0.7) }
-        if s == "pending" { return JTColors.warning.opacity(0.6) }
-        if s.contains("needs") { return JTColors.info.opacity(0.6) }
-        return JTColors.glassHighlight
-    }
-
-    private func houseNumber(_ full: String) -> String {
-        if let comma = full.firstIndex(of: ",") {
-            return String(full[..<comma])
-        }
-        return full
-    }
-}
-
-// Tiny helper view
-private struct KeyValueRow: View {
-    let key: String
-    let value: String
-    var lineLimit: Int = 1
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 6) {
-            Text(key)
-                .font(JTTypography.caption)
-                .foregroundStyle(JTColors.textSecondary)
-            Text(value)
-                .font(JTTypography.caption)
-                .foregroundStyle(JTColors.textPrimary)
-                .lineLimit(lineLimit)
-                .truncationMode(.tail)
-        }
-    }
-}
-
-private extension String {
-    var trimmedNonEmpty: String? {
-        let s = trimmingCharacters(in: .whitespacesAndNewlines)
-        return s.isEmpty ? nil : s
-    }
-}
-
-
-// MARK: - Sync Banner (water progress)
-private struct SyncBanner: View {
-    let done: Int
-    let total: Int
-    let inFlight: Int
-    let phase: CGFloat
-
-    private var progress: CGFloat {
-        guard total > 0 else { return 0 }
-        return CGFloat(done) / CGFloat(total)
-    }
-
-    var body: some View {
-        ZStack {
-            // Background capsule with subtle border
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.black.opacity(0.76))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
-                )
-
-            // Water fill (masked to rounded rect)
-            GeometryReader { geo in
-                ZStack {
-                    // Lower, slower wave
-                    WaterWave(progress: progress, phase: phase, amplitude: 6)
-                        .fill(Color.accentColor.opacity(0.55))
-                        .blur(radius: 0.4)
-
-                    // Upper, faster wave with slight offset for "sloshing"
-                    WaterWave(progress: progress, phase: phase * 1.6 + 0.2, amplitude: 4)
-                        .fill(Color.accentColor.opacity(0.75))
-                }
-                .mask(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                )
-            }
-
-            // Text overlay
-            HStack(spacing: 8) {
-                Image(systemName: "arrow.up.arrow.down.circle.fill")
-                    .imageScale(.medium)
-                    .foregroundColor(.white.opacity(0.95))
-                Text(syncTitle)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
-                Spacer(minLength: 0)
-                Text("\(max(done,0))/\(max(total,0))")
-                    .font(.caption.weight(.semibold))
-                    .foregroundColor(.white.opacity(0.9))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.white.opacity(0.12))
-                    .clipShape(Capsule())
-            }
-            .padding(.horizontal, 12)
-        }
-        .frame(height: 44)
-        .padding(.horizontal, 16)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(syncTitle)
-    }
-
-    private var syncTitle: String {
-        if total == 0 { return "All changes are up to date" }
-        if done >= total { return "All changes uploaded" }
-        if inFlight > 0 { return "Uploading… (\(inFlight) in progress)" }
-        return "Syncing changes…"
-    }
-}
-
-/// A single sine-wave water fill. `phase` animates from 0→1 repeatedly, and we convert to radians inside.
-private struct WaterWave: Shape {
-    var progress: CGFloat    // 0…1 (fill level)
-    var phase: CGFloat       // 0…1 (animation cycle)
-    var amplitude: CGFloat   // wave height in points
-
-    // Animate by phase only
-    var animatableData: CGFloat {
-        get { phase }
-        set { phase = newValue }
-    }
-
-    func path(in rect: CGRect) -> Path {
-        let twoPi = CGFloat.pi * 2
-        let level = rect.height * (1 - max(0, min(progress, 1)))  // y where water meets air
-        let wavelength = max(rect.width / 1.2, 1)                  // a little wider than rect for smoother shape
-        let radians = phase * twoPi
-
-        var p = Path()
-        p.move(to: CGPoint(x: rect.minX, y: level))
-
-        // Draw the wave across the width
-        var x: CGFloat = 0
-        while x <= rect.width {
-            let relative = x / wavelength
-            let y = level + sin(relative * twoPi + radians) * amplitude
-            p.addLine(to: CGPoint(x: rect.minX + x, y: y))
-            x += 1
-        }
-
-        // Close the shape at the bottom
-        p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-        p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-        p.closeSubpath()
-        return p
-    }
-}
-
-
-
-// MARK: - Summary Card
-private struct SummaryCard: View {
-    let date: Date
-    let total: Int
-    let pending: Int
-    let completed: Int
-
-    var body: some View {
-        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
-            HStack(spacing: JTSpacing.md) {
-                VStack(alignment: .leading, spacing: JTSpacing.xs) {
-                    Text("Today")
-                        .font(JTTypography.caption)
-                        .foregroundStyle(JTColors.textSecondary)
-                    Text(formatted(date))
-                        .font(JTTypography.title3)
-                        .foregroundStyle(JTColors.textPrimary)
-                }
-
-                Spacer()
-
-                MetricPill(title: "Total", value: total)
-                MetricPill(title: "Pending", value: pending)
-                MetricPill(title: "Done", value: completed)
-            }
-            .padding(JTSpacing.lg)
-        }
-    }
-
-    private func formatted(_ d: Date) -> String {
-        let f = DateFormatter()
-        f.dateStyle = .medium
-        return f.string(from: d)
-    }
-
-    private struct MetricPill: View {
-        let title: String
-        let value: Int
-        var body: some View {
-            VStack(spacing: 4) {
-                Text(title)
-                    .font(JTTypography.caption)
-                    .foregroundStyle(JTColors.textSecondary)
-                Text("\(value)")
-                    .font(JTTypography.headline)
-                    .foregroundStyle(JTColors.textPrimary)
-            }
-            .padding(.horizontal, JTSpacing.sm)
-            .padding(.vertical, JTSpacing.xs)
-            .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassStroke)
         }
     }
 }

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -1,0 +1,522 @@
+import CoreLocation
+import SwiftUI
+import UIKit
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    struct Weekday: Identifiable {
+        let label: String
+        let offset: Int
+
+        var id: String { label }
+    }
+
+    struct JobSections {
+        let notCompleted: [Job]
+        let completed: [Job]
+        let distanceStrings: [String: String]
+
+        var allJobs: [Job] { notCompleted + completed }
+        var isEmpty: Bool { allJobs.isEmpty }
+    }
+
+    enum ActiveSheet: Identifiable {
+        case datePicker
+        case share
+        case createJob
+
+        var id: Int { hashValue }
+    }
+
+    // MARK: - Published State
+
+    @Published var selectedDate: Date {
+        didSet {
+            selectedOffset = Self.weekdayOffset(for: selectedDate)
+            jobsViewModel?.fetchJobsForWeek(selectedDate)
+        }
+    }
+    @Published private(set) var selectedOffset: Int?
+    @Published var activeSheet: ActiveSheet?
+    @Published var shareItems: [Any] = []
+    @Published var isPreparingDailyShare = false
+    @Published var isGeneratingShareLink = false
+    @Published var jobShareURL: URL?
+    @Published var showSystemShareForJob = false
+    @Published var showImportToast = false
+    @Published var importToastMessage = ""
+    @Published var importToastIsError = false
+    @Published var showSyncBanner = false
+    @Published var syncTotal: Int = 0
+    @Published var syncDone: Int = 0
+    @Published var syncInFlight: Int = 0
+    @Published var wavePhase: CGFloat = 0
+    @Published var nearestJobID: String?
+    @Published var selectedJob: Job?
+
+    // MARK: - Dependencies
+
+    private var jobsViewModel: JobsViewModel?
+
+    // MARK: - Constants
+
+    let weekdays: [Weekday] = [
+        .init(label: "Mon", offset: 0),
+        .init(label: "Tue", offset: 1),
+        .init(label: "Wed", offset: 2),
+        .init(label: "Thu", offset: 3),
+        .init(label: "Fri", offset: 4)
+    ]
+
+    let statusOptions: [String] = [
+        "Pending",
+        "Needs Aerial",
+        "Needs Underground",
+        "Needs Nid",
+        "Needs Can",
+        "Done",
+        "Talk to Rick",
+        "Custom"
+    ]
+
+    // MARK: - Init
+
+    init(selectedDate: Date = Date()) {
+        self.selectedDate = selectedDate
+        self.selectedOffset = Self.weekdayOffset(for: selectedDate)
+    }
+
+    func configureIfNeeded(jobsViewModel: JobsViewModel) {
+        guard self.jobsViewModel !== jobsViewModel else { return }
+        self.jobsViewModel = jobsViewModel
+        jobsViewModel.fetchJobsForWeek(selectedDate)
+    }
+
+    // MARK: - Date Helpers
+
+    func selectWeekday(offset: Int) {
+        let newDate = dateForOffset(offset)
+        selectedDate = newDate
+    }
+
+    func dateForOffset(_ offset: Int) -> Date {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 2 // Monday
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: selectedDate)
+        guard let startOfWeek = calendar.date(from: components) else { return selectedDate }
+        return calendar.date(byAdding: .day, value: offset, to: startOfWeek) ?? selectedDate
+    }
+
+    static func weekdayOffset(for date: Date) -> Int? {
+        let weekday = Calendar.current.component(.weekday, from: date)
+        let mondayBased = (weekday + 5) % 7
+        return mondayBased < 5 ? mondayBased : nil
+    }
+
+    // MARK: - Job Computations
+
+    func filteredJobs(from jobs: [Job]) -> [Job] {
+        let dayFiltered = jobs.filter { job in
+            Calendar.current.isDate(job.date, inSameDayAs: selectedDate)
+        }
+        var seen = Set<String>()
+        var uniqueReversed: [Job] = []
+        for job in dayFiltered.reversed() {
+            if seen.insert(job.id).inserted {
+                uniqueReversed.append(job)
+            }
+        }
+        return uniqueReversed.reversed()
+    }
+
+    func sections(
+        for jobs: [Job],
+        smartRoutingEnabled: Bool,
+        sortClosest: Bool,
+        currentLocation: CLLocation?
+    ) -> JobSections {
+        let filtered = filteredJobs(from: jobs)
+        let rawNotCompleted = filtered.filter { $0.status.lowercased() == "pending" }
+        let completed = filtered.filter { $0.status.lowercased() != "pending" }
+
+        guard smartRoutingEnabled, let here = currentLocation else {
+            return JobSections(
+                notCompleted: rawNotCompleted,
+                completed: completed,
+                distanceStrings: [:]
+            )
+        }
+
+        let pairs: [(Job, CLLocationDistance)] = rawNotCompleted.map { job in
+            let distance = job.clLocation?.distance(from: here) ?? .greatestFiniteMagnitude
+            return (job, distance)
+        }
+
+        let sortedPairs = pairs.sorted { lhs, rhs in
+            sortClosest ? lhs.1 < rhs.1 : lhs.1 > rhs.1
+        }
+
+        var map: [String: String] = [:]
+        for (job, distance) in sortedPairs where distance.isFinite && distance < .greatestFiniteMagnitude {
+            map[job.id] = formatDistance(distance)
+        }
+
+        return JobSections(
+            notCompleted: sortedPairs.map { $0.0 },
+            completed: completed,
+            distanceStrings: map
+        )
+    }
+
+    func summaryCounts(from jobs: [Job]) -> (total: Int, pending: Int, completed: Int) {
+        let filtered = filteredJobs(from: jobs)
+        let pending = filtered.filter { $0.status.lowercased() == "pending" }.count
+        let completed = max(0, filtered.count - pending)
+        return (filtered.count, pending, completed)
+    }
+
+    func updateNearestJob(with jobs: [Job], currentLocation: CLLocation?) {
+        guard let here = currentLocation else {
+            nearestJobID = nil
+            return
+        }
+        let nearest = jobs
+            .compactMap { job -> (String, CLLocationDistance)? in
+                guard let distance = job.clLocation?.distance(from: here) else { return nil }
+                return (job.id, distance)
+            }
+            .min { $0.1 < $1.1 }
+
+        let identifier: String?
+        if let candidate = nearest, candidate.1 < 90 {
+            identifier = candidate.0
+        } else {
+            identifier = nil
+        }
+        if identifier != nearestJobID {
+            nearestJobID = identifier
+        }
+    }
+
+    func handleJobsListChange(_ jobs: [Job], currentLocation: CLLocation?) {
+        activeSheet = nil
+        updateNearestJob(with: jobs, currentLocation: currentLocation)
+    }
+
+    // MARK: - Sharing
+
+    var shareSubject: String {
+        "Jobs for \(formattedDate(selectedDate))"
+    }
+
+    func handleDailyShareTap() async {
+        guard let jobsViewModel else { return }
+        guard jobsViewModel.hasLoadedInitialJobs else {
+            showJobsStillLoadingToast()
+            return
+        }
+        guard !isPreparingDailyShare else { return }
+
+        isPreparingDailyShare = true
+        defer { isPreparingDailyShare = false }
+
+        await waitForLatestJobsData()
+        presentDailyShareSheet()
+    }
+
+    func share(job: Job) async {
+        guard !isGeneratingShareLink else { return }
+        isGeneratingShareLink = true
+        defer { isGeneratingShareLink = false }
+
+        do {
+            let url = try await SharedJobService.shared.publishShareLink(job: job)
+            jobShareURL = url
+            showSystemShareForJob = true
+        } catch {
+            presentShareError(message: "Couldn't create link: \(error.localizedDescription)")
+        }
+    }
+
+    private func waitForLatestJobsData(maxWait: TimeInterval = 1.0) async {
+        guard maxWait > 0 else { return }
+        let deadline = Date().addingTimeInterval(maxWait)
+        while Date() < deadline {
+            if Task.isCancelled { return }
+            let ready = !filteredJobs(from: jobsViewModel?.jobs ?? []).isEmpty || jobsViewModel?.lastServerSync != nil
+            if ready { return }
+            try? await Task.sleep(nanoseconds: 80_000_000)
+        }
+    }
+
+    private func presentDailyShareSheet(limitImages: Int = 20) {
+        let jobs = filteredJobs(from: jobsViewModel?.jobs ?? [])
+        shareItems = buildDailyShareItems(for: jobs, limitImages: limitImages)
+        activeSheet = nil
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.activeSheet = .share
+        }
+    }
+
+    private func buildDailyShareItems(for jobs: [Job], limitImages: Int) -> [Any] {
+        let summarySource = DailyJobsSummaryItemSource(
+            textProvider: { [weak self] in self?.shareText(for: jobs) ?? "" },
+            fallbackProvider: { [weak self] in self?.shareEmptyFallbackText() ?? "" },
+            subjectProvider: { [weak self] in self?.shareSubject ?? "" }
+        )
+
+        var items: [Any] = [summarySource]
+        let completedJobs = jobs.filter { $0.status.lowercased() != "pending" }
+        var attachments: [Any] = []
+        for job in completedJobs {
+            attachments.append(contentsOf: shareableAttachments(for: job))
+            if attachments.count >= limitImages { break }
+        }
+        if !attachments.isEmpty {
+            items.append(contentsOf: attachments.prefix(limitImages))
+        }
+        return items
+    }
+
+    private func shareText(for jobs: [Job]) -> String {
+        let completedJobs = jobs.filter { $0.status.lowercased() != "pending" }
+        guard !completedJobs.isEmpty else {
+            return shareEmptyFallbackText() ?? ""
+        }
+        let header = "\(shareSubject):"
+        let lines = completedJobs.map { job in
+            let address = houseNumberAndStreet(from: job.address)
+            var entry = "\(address) – \(job.status)"
+            if let noteText = job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !noteText.isEmpty {
+                entry += " (Notes: \(noteText))"
+            }
+            return entry
+        }
+        return ([header] + lines).joined(separator: "\n")
+    }
+
+    private func shareEmptyFallbackText() -> String? {
+        "No jobs to share for \(formattedDate(selectedDate))."
+    }
+
+    private func shareableAttachments(for job: Job) -> [Any] {
+        var out: [Any] = []
+        let mirror = Mirror(reflecting: job)
+        for child in mirror.children {
+            guard let label = child.label?.lowercased() else { continue }
+            if label.contains("photo") || label.contains("image") || label.contains("picture") {
+                switch child.value {
+                case let array as [UIImage]:
+                    out.append(contentsOf: array)
+                case let image as UIImage:
+                    out.append(image)
+                case let array as [Data]:
+                    out.append(contentsOf: array.compactMap { UIImage(data: $0) })
+                case let data as Data:
+                    if let image = UIImage(data: data) { out.append(image) }
+                case let array as [URL]:
+                    out.append(contentsOf: array)
+                case let array as [String]:
+                    out.append(contentsOf: array.compactMap { URL(string: $0) })
+                case let string as String:
+                    if let url = URL(string: string) { out.append(url) }
+                default:
+                    break
+                }
+            }
+        }
+        return out
+    }
+
+    func presentDatePicker() {
+        activeSheet = .datePicker
+    }
+
+    func presentCreateJob() {
+        activeSheet = .createJob
+    }
+
+    func dismissSheets() {
+        activeSheet = nil
+        showSystemShareForJob = false
+    }
+
+    // MARK: - Toasts & Sync
+
+    func showJobsStillLoadingToast() {
+        importToastIsError = true
+        importToastMessage = "Jobs are still loading…"
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+            showImportToast = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            withAnimation(.easeInOut(duration: 0.25)) {
+                self?.showImportToast = false
+            }
+        }
+    }
+
+    func presentImportSuccessToast() {
+        importToastIsError = false
+        importToastMessage = "Job imported to your dashboard"
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+            showImportToast = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            withAnimation(.easeInOut(duration: 0.25)) {
+                self?.showImportToast = false
+            }
+        }
+    }
+
+    func presentImportFailureToast(message: String) {
+        importToastIsError = true
+        importToastMessage = message
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+            showImportToast = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+            withAnimation(.easeInOut(duration: 0.25)) {
+                self?.showImportToast = false
+            }
+        }
+    }
+
+    func handleSyncStateChange(total: Int, done: Int, inFlight: Int) {
+        syncTotal = max(total, 0)
+        syncDone = max(min(done, total), 0)
+        syncInFlight = max(inFlight, 0)
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+            showSyncBanner = (syncTotal > 0) && (syncDone < syncTotal)
+        }
+        if syncTotal > 0 && syncDone >= syncTotal {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    self?.showSyncBanner = false
+                }
+            }
+        }
+    }
+
+    func startWaveAnimation() {
+        wavePhase = 0
+        withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
+            wavePhase = 1
+        }
+    }
+
+    func resetWave() {
+        wavePhase = 0
+    }
+
+    private func presentShareError(message: String) {
+        importToastIsError = true
+        importToastMessage = message
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+            showImportToast = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            withAnimation(.easeInOut(duration: 0.25)) {
+                self?.showImportToast = false
+            }
+        }
+    }
+
+    // MARK: - Utilities
+
+    func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+
+    private func formatDistance(_ meters: CLLocationDistance) -> String {
+        guard meters.isFinite else { return "" }
+        let usesMetric = Locale.current.usesMetricSystem
+        if !usesMetric {
+            let miles = meters / 1609.344
+            if miles < 0.1 { return "<0.1 mi" }
+            return String(format: "%.1f mi", miles)
+        } else {
+            if meters < 1000 { return "\(Int(meters.rounded())) m" }
+            let kilometers = meters / 1000
+            return String(format: "%.1f km", kilometers)
+        }
+    }
+
+    private func houseNumberAndStreet(from full: String) -> String {
+        if let comma = full.firstIndex(of: ",") {
+            return String(full[..<comma]).trimmingCharacters(in: .whitespaces)
+        }
+        let suffixes: Set<String> = [
+            "st", "street", "rd", "road", "ave", "avenue", "blvd", "circle", "cir", "ln", "lane",
+            "dr", "drive", "ct", "court", "pkwy", "pl", "place", "ter", "terrace"
+        ]
+        var tokens: [Substring] = []
+        for token in full.split(separator: " ") {
+            tokens.append(token)
+            let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: ",.")).lowercased()
+            if suffixes.contains(cleaned) { break }
+        }
+        return tokens.joined(separator: " ")
+    }
+
+    func openJobInMaps(_ job: Job, suggestionProviderRaw: String) {
+        guard let encoded = job.address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+        if suggestionProviderRaw == "google" {
+            if let url = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") {
+                UIApplication.shared.open(url, options: [:]) { success in
+                    if success { return }
+                    if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
+                        UIApplication.shared.open(appleURL)
+                    }
+                }
+                return
+            }
+        }
+        if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
+            UIApplication.shared.open(appleURL)
+        }
+    }
+}
+
+private final class DailyJobsSummaryItemSource: NSObject, UIActivityItemSource {
+    private let textProvider: () -> String
+    private let fallbackProvider: () -> String
+    private let subjectProvider: () -> String
+
+    init(textProvider: @escaping () -> String,
+         fallbackProvider: @escaping () -> String,
+         subjectProvider: @escaping () -> String) {
+        self.textProvider = textProvider
+        self.fallbackProvider = fallbackProvider
+        self.subjectProvider = subjectProvider
+        super.init()
+    }
+
+    private func resolvedText() -> NSString {
+        let trimmed = textProvider().trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return NSString(string: trimmed)
+        }
+        let fallback = fallbackProvider().trimmingCharacters(in: .whitespacesAndNewlines)
+        if fallback.isEmpty {
+            return NSString(string: " ")
+        }
+        return NSString(string: fallback)
+    }
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        resolvedText()
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController,
+                                itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        resolvedText()
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController,
+                                subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+        subjectProvider().trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary
- add a DashboardViewModel to own date selection, job filtering, sharing, and sync banner state for the dashboard screen
- rewrite DashboardView to consume the view model and compose new header, summary, weekday picker, job list, and share sheet components
- introduce reusable dashboard component subviews with previews for the header, summary card, weekday pills, job sections, sync banner, and share flows

## Testing
- `xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbf6e5f3c832d8550268dda29c7f1