### PR TITLE
Make design tokens public for external access

### DIFF
--- a/Job Tracker/DesignSystem/JTColors.swift
+++ b/Job Tracker/DesignSystem/JTColors.swift
@@ -1,35 +1,35 @@
 import SwiftUI
 
 /// Centralized color tokens for the Job Tracker design system.
-enum JTColors {
+public enum JTColors {
     // MARK: App chroma
-    static let backgroundTop = Color(red: 0.1725, green: 0.2431, blue: 0.3137)
-    static let backgroundBottom = Color(red: 0.2980, green: 0.6314, blue: 0.6863)
+    public static let backgroundTop = Color(red: 0.1725, green: 0.2431, blue: 0.3137)
+    public static let backgroundBottom = Color(red: 0.2980, green: 0.6314, blue: 0.6863)
 
-    static let accent = Color.accentColor
-    static let onAccent = Color.white
+    public static let accent = Color.accentColor
+    public static let onAccent = Color.white
 
     // MARK: Text
-    static let textPrimary = Color.white
-    static let textSecondary = Color.white.opacity(0.85)
-    static let textMuted = Color.white.opacity(0.6)
+    public static let textPrimary = Color.white
+    public static let textSecondary = Color.white.opacity(0.85)
+    public static let textMuted = Color.white.opacity(0.6)
 
     // MARK: Surfaces
-    static let glassStroke = Color.white.opacity(0.18)
-    static let glassSoftStroke = Color.white.opacity(0.06)
-    static let glassHighlight = Color.white.opacity(0.12)
-    static let fieldPlaceholder = Color.white.opacity(0.5)
+    public static let glassStroke = Color.white.opacity(0.18)
+    public static let glassSoftStroke = Color.white.opacity(0.06)
+    public static let glassHighlight = Color.white.opacity(0.12)
+    public static let fieldPlaceholder = Color.white.opacity(0.5)
 
     // MARK: Semantic status
-    static let success = Color.green.opacity(0.9)
-    static let warning = Color.yellow.opacity(0.9)
-    static let info = Color.blue.opacity(0.9)
-    static let error = Color(red: 0.96, green: 0.33, blue: 0.33)
+    public static let success = Color.green.opacity(0.9)
+    public static let warning = Color.yellow.opacity(0.9)
+    public static let info = Color.blue.opacity(0.9)
+    public static let error = Color(red: 0.96, green: 0.33, blue: 0.33)
 }
 
 /// Gradients that compose reusable backgrounds.
-enum JTGradients {
-    static let background = LinearGradient(
+public enum JTGradients {
+    public static let background = LinearGradient(
         colors: [JTColors.backgroundTop, JTColors.backgroundBottom],
         startPoint: .topLeading,
         endPoint: .bottomTrailing

--- a/Job Tracker/DesignSystem/JTShapes.swift
+++ b/Job Tracker/DesignSystem/JTShapes.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
 /// Component shapes used throughout the app.
-enum JTShapes {
-    static let cardCornerRadius: CGFloat = 16
-    static let smallCardCornerRadius: CGFloat = 14
-    static let largeCardCornerRadius: CGFloat = 20
-    static let buttonCornerRadius: CGFloat = 12
-    static let fieldCornerRadius: CGFloat = 12
-    static let chipCornerRadius: CGFloat = 10
+public enum JTShapes {
+    public static let cardCornerRadius: CGFloat = 16
+    public static let smallCardCornerRadius: CGFloat = 14
+    public static let largeCardCornerRadius: CGFloat = 20
+    public static let buttonCornerRadius: CGFloat = 12
+    public static let fieldCornerRadius: CGFloat = 12
+    public static let chipCornerRadius: CGFloat = 10
 
-    static func roundedRectangle(cornerRadius: CGFloat) -> RoundedRectangle {
+    public static func roundedRectangle(cornerRadius: CGFloat) -> RoundedRectangle {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
     }
 }


### PR DESCRIPTION
## Summary
- mark JTShapes, JTColors, and JTGradients as public
- expose their static members so they can be used in public APIs
- ensure the glass background defaults compile when imported from other modules

## Testing
- not run (requires macOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdcaf457f4832d96a2510c6ee689f2