### PR TITLE
Fix Dashboard job preview initializer argument order

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -347,9 +347,9 @@ private struct DashboardJobSectionsPreviewContainer: View {
             address: "123 Main Street, Springfield, IL",
             date: today,
             status: "Pending",
+            notes: "Call ahead",
             assignments: "12.3.2",
-            materialsUsed: "Coax, Splitter",
-            notes: "Call ahead"
+            materialsUsed: "Coax, Splitter"
         )
         let done = Job(
             id: "2",


### PR DESCRIPTION
## Summary
- reorder the preview job arguments so notes is provided before assignments to match the Job initializer

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdcccf03b8832d995bba584104fd44