### PR TITLE
Fix Swift warnings in mapping, authentication, and dashboard components

### DIFF
--- a/Job Tracker/Features/Authentication/AuthFlowView.swift
+++ b/Job Tracker/Features/Authentication/AuthFlowView.swift
@@ -304,7 +304,7 @@ private struct AuthLoginForm: View {
     }
 
     private func state(for error: String?, text: String) -> JTInputState {
-        if let error, hasAttemptedSubmit {
+        if hasAttemptedSubmit && error != nil {
             return .error
         }
         if hasAttemptedSubmit && !text.isEmpty {
@@ -489,7 +489,7 @@ private struct AuthSignUpForm: View {
     }
 
     private func state(for error: String?, text: String) -> JTInputState {
-        if let error, hasAttemptedSubmit {
+        if hasAttemptedSubmit && error != nil {
             return .error
         }
         if hasAttemptedSubmit && !text.isEmpty {
@@ -568,7 +568,7 @@ private struct PasswordResetForm: View {
     }
 
     private var state: JTInputState {
-        if let emailError, hasAttemptedSubmit {
+        if hasAttemptedSubmit && emailError != nil {
             return .error
         }
         if hasAttemptedSubmit && !email.isEmpty {

--- a/Job Tracker/Features/Dashboard/Components/DashboardHeaderToolbar.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardHeaderToolbar.swift
@@ -73,11 +73,9 @@ private struct DashboardHeaderToolbarPreviewContainer: View {
 
 #Preview("Header – iPhone 15 Pro") {
     DashboardHeaderToolbarPreviewContainer(isPreparingShare: false)
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }
 
 #Preview("Header – iPad Pro 11") {
     DashboardHeaderToolbarPreviewContainer(isPreparingShare: true)
-        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
         .frame(maxWidth: 600)
 }

--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -384,11 +384,9 @@ private struct DashboardJobSectionsPreviewContainer: View {
 
 #Preview("Job Sections – iPhone") {
     DashboardJobSectionsPreviewContainer()
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }
 
 #Preview("Job Sections – iPad") {
     DashboardJobSectionsPreviewContainer()
-        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
         .frame(maxWidth: 820)
 }

--- a/Job Tracker/Features/Dashboard/Components/DashboardShareSheets.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardShareSheets.swift
@@ -50,15 +50,12 @@ private struct DashboardDatePickerSheetPreviewContainer: View {
 
 #Preview("Date Picker Sheet") {
     DashboardDatePickerSheetPreviewContainer()
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }
 
 #Preview("Daily Share Sheet") {
     DashboardDailyShareSheet(items: [NSString(string: "Jobs for May 1, 2025" )], subject: "Jobs for May 1, 2025")
-        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
 }
 
 #Preview("Job Share Sheet") {
     DashboardJobShareSheet(url: URL(string: "https://example.com/job")!, subject: "Job link for May 1, 2025")
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }

--- a/Job Tracker/Features/Dashboard/Components/DashboardSummaryCard.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSummaryCard.swift
@@ -80,11 +80,9 @@ private struct DashboardSummaryCardPreviewContainer: View {
 
 #Preview("Summary – iPhone 15 Pro") {
     DashboardSummaryCardPreviewContainer()
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }
 
 #Preview("Summary – iPad Pro 11") {
     DashboardSummaryCardPreviewContainer()
-        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
         .frame(maxWidth: 700)
 }

--- a/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
@@ -104,13 +104,11 @@ struct WaterWave: Shape {
     DashboardSyncBanner(done: 2, total: 5, inFlight: 1, phase: 0.3)
         .padding(.vertical)
         .background(JTGradients.background.ignoresSafeArea())
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }
 
 #Preview("Sync Banner – Complete") {
     DashboardSyncBanner(done: 5, total: 5, inFlight: 0, phase: 0.9)
         .padding(.vertical)
         .background(JTGradients.background.ignoresSafeArea())
-        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
         .frame(maxWidth: 600)
 }

--- a/Job Tracker/Features/Dashboard/Components/DashboardWeekdayPicker.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardWeekdayPicker.swift
@@ -45,7 +45,6 @@ struct DashboardWeekdayPicker: View {
     )
     .padding()
     .background(JTGradients.background.ignoresSafeArea())
-    .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
 }
 
 #Preview("Weekday Picker – iPad") {
@@ -57,5 +56,4 @@ struct DashboardWeekdayPicker: View {
     .padding()
     .frame(maxWidth: 600)
     .background(JTGradients.background.ignoresSafeArea())
-    .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
 }

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -432,12 +432,16 @@ final class DashboardViewModel: ObservableObject {
 
     private func formatDistance(_ meters: CLLocationDistance) -> String {
         guard meters.isFinite else { return "" }
-        let usesMetric = Locale.current.usesMetricSystem
-        if !usesMetric {
+        switch Locale.current.measurementSystem {
+        case .us:
             let miles = meters / 1609.344
             if miles < 0.1 { return "<0.1 mi" }
             return String(format: "%.1f mi", miles)
-        } else {
+        case .metric, .uk:
+            if meters < 1000 { return "\(Int(meters.rounded())) m" }
+            let kilometers = meters / 1000
+            return String(format: "%.1f km", kilometers)
+        @unknown default:
             if meters < 1000 { return "\(Int(meters.rounded())) m" }
             let kilometers = meters / 1000
             return String(format: "%.1f km", kilometers)

--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -1413,8 +1413,8 @@ struct MapsView: View {
                 get: { pendingMarkupDeletion != nil },
                 set: { newValue in if !newValue { pendingMarkupDeletion = nil } }
             ),
-            presenting: pendingMarkupDeletion,
-            titleVisibility: .visible
+            titleVisibility: .visible,
+            presenting: pendingMarkupDeletion
         ) { action in
             Button(action.confirmButtonTitle, role: .destructive) {
                 performMarkupDeletion(action)

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -415,7 +415,7 @@ class FirebaseService {
         db.runTransaction({ txn, errorPointer in
             do {
                 let snap = try txn.getDocument(ref)
-                guard var data = snap.data() else {
+                guard let data = snap.data() else {
                     throw NSError(domain: "FirebaseService", code: 404, userInfo: [NSLocalizedDescriptionKey: "Job not found"])
                 }
                 var participants = data["participants"] as? [String] ?? []


### PR DESCRIPTION
## Summary
- reorder the confirmationDialog parameter list to match the latest SwiftUI API
- adjust authentication state helpers to avoid unused optional binding warnings
- drop deprecated previewDevice modifiers, update distance formatting to use Locale.measurementSystem, and clean up Firebase transaction data usage

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cdcdaca5f8832d93183de34de55ffe