### PR TITLE
Refine navigation shell layout and move job search

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -58,7 +58,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
             case .maps:        return .maps
-            case .search:      return .search
+            case .search:      return .more
             case .more,
                  .profile,
                  .findPartner,
@@ -72,7 +72,7 @@ final class AppNavigationViewModel: ObservableObject {
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
+            case .search, .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
                 return true
             default:
                 return false
@@ -85,7 +85,6 @@ final class AppNavigationViewModel: ObservableObject {
         case timesheets
         case yellowSheet
         case maps
-        case search
         case more
 
         var id: String { rawValue }
@@ -96,7 +95,6 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
             case .maps:        return .maps
-            case .search:      return .search
             case .more:        return .more
             }
         }
@@ -130,9 +128,6 @@ final class AppNavigationViewModel: ObservableObject {
             morePath.removeAll()
         case .maps:
             activeDestination = .maps
-            morePath.removeAll()
-        case .search:
-            activeDestination = .search
             morePath.removeAll()
         case .more:
             if !activeDestination.isMoreStackDestination {


### PR DESCRIPTION
## Summary
- reposition the shell menu/help controls into a dedicated top action bar to prevent overlap with screen content
- refresh the tab bar styling for stronger contrast and relocate the Job Search flow into the More menu
- update navigation routing so Job Search is treated as part of the More stack across compact and split layouts

## Testing
- Not run (Xcode unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdae35758c832dbcdea0b65d64f0c9