### PR TITLE
Move job search into More menu

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -58,8 +58,8 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
             case .maps:        return .maps
-            case .search:      return .search
-            case .more,
+            case .search,
+                 .more,
                  .profile,
                  .findPartner,
                  .supervisor,
@@ -72,7 +72,7 @@ final class AppNavigationViewModel: ObservableObject {
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
+            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .search:
                 return true
             default:
                 return false
@@ -85,7 +85,6 @@ final class AppNavigationViewModel: ObservableObject {
         case timesheets
         case yellowSheet
         case maps
-        case search
         case more
 
         var id: String { rawValue }
@@ -96,7 +95,6 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
             case .maps:        return .maps
-            case .search:      return .search
             case .more:        return .more
             }
         }
@@ -130,9 +128,6 @@ final class AppNavigationViewModel: ObservableObject {
             morePath.removeAll()
         case .maps:
             activeDestination = .maps
-            morePath.removeAll()
-        case .search:
-            activeDestination = .search
             morePath.removeAll()
         case .more:
             if !activeDestination.isMoreStackDestination {

--- a/Job Tracker/Features/Shared/Shell/AppShellView.swift
+++ b/Job Tracker/Features/Shared/Shell/AppShellView.swift
@@ -86,9 +86,7 @@ private struct AppShellDetailView: View {
             YellowSheetView()
         case .maps:
             MapsView()
-        case .search:
-            JobSearchView()
-        case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
+        case .more, .search, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
             MoreTabView()
         }
     }

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -67,13 +67,6 @@ private struct PrimaryTabContainer: View {
                           systemImage: AppNavigationViewModel.PrimaryDestination.maps.systemImage)
                 }
 
-            JobSearchView()
-                .tag(AppNavigationViewModel.PrimaryDestination.search)
-                .tabItem {
-                    Label(AppNavigationViewModel.PrimaryDestination.search.title,
-                          systemImage: AppNavigationViewModel.PrimaryDestination.search.systemImage)
-                }
-
             MoreTabView()
                 .tag(AppNavigationViewModel.PrimaryDestination.more)
                 .tabItem {
@@ -144,6 +137,12 @@ private struct MoreMenuList: View {
                 }
             }
 
+            Section("Resources") {
+                NavigationLink(value: AppNavigationViewModel.Destination.search) {
+                    Label("Job Search", systemImage: AppNavigationViewModel.Destination.search.systemImage)
+                }
+            }
+
             if authViewModel.isSupervisorFlag {
                 Section("Supervisor") {
                     NavigationLink(value: AppNavigationViewModel.Destination.supervisor) {
@@ -190,6 +189,8 @@ private struct MoreDestinationView: View {
         switch destination {
         case .profile:
             ProfileView()
+        case .search:
+            JobSearchView()
         case .findPartner:
             FindPartnerView()
         case .supervisor:


### PR DESCRIPTION
## Summary
- remove the standalone Job Search tab and surface it under the More menu instead
- update navigation model so Job Search is treated as part of the More stack across compact and split layouts

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cde1f145f0832dbb23a986cbfb9f51