### PR TITLE
Fix menu/help overlay for weekly timesheet navigation

### DIFF
--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -13,10 +13,12 @@ struct MainTabView: View {
     var body: some View {
         PrimaryTabContainer()
             .safeAreaInset(edge: .top) {
-                ShellActionButtons(
-                    onShowMenu: { navigation.isPrimaryMenuPresented = true },
-                    onOpenHelp: { navigation.navigate(to: .helpCenter) }
-                )
+                if navigation.selectedPrimary != .timesheets {
+                    ShellActionButtons(
+                        onShowMenu: { navigation.isPrimaryMenuPresented = true },
+                        onOpenHelp: { navigation.navigate(to: .helpCenter) }
+                    )
+                }
             }
             .sheet(isPresented: menuPresentation) {
                 PrimaryDestinationMenu()
@@ -210,9 +212,11 @@ private struct MoreDestinationView: View {
 
 // MARK: - Action buttons & menu
 
-private struct ShellActionButtons: View {
+struct ShellActionButtons: View {
     var onShowMenu: () -> Void
     var onOpenHelp: () -> Void
+    var horizontalPadding: CGFloat = 16
+    var topPadding: CGFloat = 12
 
     var body: some View {
         HStack(spacing: 12) {
@@ -220,13 +224,13 @@ private struct ShellActionButtons: View {
             Spacer()
             RoundedActionButton(icon: "questionmark.circle", label: "Help", action: onOpenHelp)
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 12)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.top, topPadding)
         .background(Color.clear)
     }
 }
 
-private struct RoundedActionButton: View {
+struct RoundedActionButton: View {
     let icon: String
     let label: String
     let action: () -> Void

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -14,9 +14,10 @@ struct WorkerHours: Identifiable, Hashable {
 }
 
 struct WeeklyTimesheetView: View {
-    // Clearance so the floating hamburger/side-menu button never overlaps the first content row
-    private let menuClearanceTop: CGFloat = 76
+    // Top padding to provide breathing room above the week picker and action buttons.
+    private let topContentPadding: CGFloat = 20
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject private var navigation: AppNavigationViewModel
     // Use an independent view model for timesheet jobs.
     @StateObject private var timesheetJobsVM = TimesheetJobsViewModel()
     @StateObject private var timesheetVM = TimesheetViewModel()
@@ -150,10 +151,18 @@ struct WeeklyTimesheetView: View {
                 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
-                        
+
                         // Minimal week picker.
                         minimalWeekPicker
-                        
+
+                        // Global quick actions placed below the week picker to avoid overlaps.
+                        ShellActionButtons(
+                            onShowMenu: { navigation.isPrimaryMenuPresented = true },
+                            onOpenHelp: { navigation.navigate(to: .helpCenter) },
+                            horizontalPadding: 0,
+                            topPadding: 0
+                        )
+
                         // Timesheet header.
                         timesheetHeader
                         
@@ -185,8 +194,8 @@ struct WeeklyTimesheetView: View {
                         
                         Spacer().frame(height: 100)
                     }
-                    // Push content below the floating hamburger button
-                    .padding(.top, menuClearanceTop)
+                    // Provide consistent spacing above the week picker and action buttons
+                    .padding(.top, topContentPadding)
                     .padding()
                 }
                 .scrollIndicators(.hidden)


### PR DESCRIPTION
## Summary
- hide the global menu/help safe-area inset while the Timesheets tab is active
- reuse the shared shell action buttons under the week picker so the navigation arrows remain tappable
- allow the action button component to accept custom padding for inline placements

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68cde26c99b8832d928a9a7d167e5a97