### PR TITLE
Handle MapKit overlay initializers for markup renderers

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -330,6 +330,16 @@ struct MapCanvas: UIViewRepresentable {
                 applyBaseAppearance()
             }
 
+            override init(overlay: MKOverlay) {
+                self.shape = MarkupShape(kind: .line,
+                                         points: [],
+                                         lineWidth: 1,
+                                         strokeColor: .clear)
+                self.isHighlighted = false
+                super.init(overlay: overlay)
+                applyBaseAppearance()
+            }
+
             required init?(coder: NSCoder) {
                 fatalError("init(coder:) has not been implemented")
             }
@@ -381,6 +391,16 @@ struct MapCanvas: UIViewRepresentable {
                 self.shape = shape
                 self.isHighlighted = highlighted
                 super.init(polygon: polygon)
+                applyBaseAppearance()
+            }
+
+            override init(overlay: MKOverlay) {
+                self.shape = MarkupShape(kind: .polygon,
+                                         points: [],
+                                         lineWidth: 1,
+                                         strokeColor: .clear)
+                self.isHighlighted = false
+                super.init(overlay: overlay)
                 applyBaseAppearance()
             }
 


### PR DESCRIPTION
## Summary
- override the overlay-based initializer for the custom markup polyline renderer so MapKit can safely instantiate it
- do the same for the custom markup polygon renderer to provide a stable default appearance when created by the system

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cde89d279c832dbcf06fbae7a065f4