### PR TITLE
Swap job search and route mapper navigation

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -23,8 +23,8 @@ final class AppNavigationViewModel: ObservableObject {
             case .dashboard:   return "Dashboard"
             case .timesheets:  return "Timesheets"
             case .yellowSheet: return "Yellow Sheet"
-            case .maps:        return "Maps"
-            case .search:      return "Search"
+            case .maps:        return "Route Mapper"
+            case .search:      return "Job Search"
             case .more:        return "More"
             case .profile:     return "Profile"
             case .findPartner: return "Find Partner"
@@ -57,9 +57,9 @@ final class AppNavigationViewModel: ObservableObject {
             case .dashboard:   return .dashboard
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
-            case .maps:        return .maps
-            case .search,
-                 .more,
+            case .maps:        return .more
+            case .search:      return .search
+            case .more,
                  .profile,
                  .findPartner,
                  .supervisor,
@@ -72,7 +72,7 @@ final class AppNavigationViewModel: ObservableObject {
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .search:
+            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps:
                 return true
             default:
                 return false
@@ -84,7 +84,7 @@ final class AppNavigationViewModel: ObservableObject {
         case dashboard
         case timesheets
         case yellowSheet
-        case maps
+        case search
         case more
 
         var id: String { rawValue }
@@ -94,7 +94,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .dashboard:   return .dashboard
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
-            case .maps:        return .maps
+            case .search:      return .search
             case .more:        return .more
             }
         }
@@ -126,8 +126,8 @@ final class AppNavigationViewModel: ObservableObject {
         case .yellowSheet:
             activeDestination = .yellowSheet
             morePath.removeAll()
-        case .maps:
-            activeDestination = .maps
+        case .search:
+            activeDestination = .search
             morePath.removeAll()
         case .more:
             if !activeDestination.isMoreStackDestination {

--- a/Job Tracker/Features/Shared/Shell/AppShellView.swift
+++ b/Job Tracker/Features/Shared/Shell/AppShellView.swift
@@ -84,9 +84,11 @@ private struct AppShellDetailView: View {
             WeeklyTimesheetView()
         case .yellowSheet:
             YellowSheetView()
+        case .search:
+            JobSearchView()
         case .maps:
             MapsView()
-        case .more, .search, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
+        case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter:
             MoreTabView()
         }
     }

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -62,11 +62,11 @@ private struct PrimaryTabContainer: View {
                           systemImage: AppNavigationViewModel.PrimaryDestination.yellowSheet.systemImage)
                 }
 
-            MapsView()
-                .tag(AppNavigationViewModel.PrimaryDestination.maps)
+            JobSearchView()
+                .tag(AppNavigationViewModel.PrimaryDestination.search)
                 .tabItem {
-                    Label(AppNavigationViewModel.PrimaryDestination.maps.title,
-                          systemImage: AppNavigationViewModel.PrimaryDestination.maps.systemImage)
+                    Label(AppNavigationViewModel.PrimaryDestination.search.title,
+                          systemImage: AppNavigationViewModel.PrimaryDestination.search.systemImage)
                 }
 
             MoreTabView()
@@ -140,8 +140,9 @@ private struct MoreMenuList: View {
             }
 
             Section("Resources") {
-                NavigationLink(value: AppNavigationViewModel.Destination.search) {
-                    Label("Job Search", systemImage: AppNavigationViewModel.Destination.search.systemImage)
+                NavigationLink(value: AppNavigationViewModel.Destination.maps) {
+                    Label(AppNavigationViewModel.Destination.maps.title,
+                          systemImage: AppNavigationViewModel.Destination.maps.systemImage)
                 }
             }
 
@@ -193,6 +194,8 @@ private struct MoreDestinationView: View {
             ProfileView()
         case .search:
             JobSearchView()
+        case .maps:
+            MapsView()
         case .findPartner:
             FindPartnerView()
         case .supervisor:


### PR DESCRIPTION
## Summary
- move Job Search into the primary tab bar in place of Maps
- update the More menu to show Route Mapper and adjust navigation labels
- ensure split view routing opens Job Search directly and keeps Route Mapper accessible from More

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdf5fea624832da14704217916ad89