### PR TITLE
Standardize shell navigation button appearance

### DIFF
--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -243,15 +243,15 @@ struct RoundedActionButton: View {
         Button(action: action) {
             Label(label, systemImage: icon)
                 .font(.subheadline.bold())
-                .foregroundStyle(.white)
+                .foregroundStyle(JTColors.textPrimary)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
                 .background(
                     Capsule()
-                        .fill(.ultraThinMaterial)
+                        .fill(JTColors.glassHighlight)
                         .overlay(
                             Capsule()
-                                .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                                .stroke(JTColors.glassStroke, lineWidth: 1)
                         )
                 )
         }


### PR DESCRIPTION
## Summary
- update the shell action buttons to use design system colors for their text and capsule backgrounds
- ensure the menu/help buttons render with a consistent contrast across all tabs

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdfb0f69a0832dbbd07f185c7f3a63