### PR TITLE
Annotate theme colors with MainActor

### DIFF
--- a/Job Tracker/DesignSystem/JTColors.swift
+++ b/Job Tracker/DesignSystem/JTColors.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 /// Centralized color tokens for the Job Tracker design system.
+@MainActor
 public enum JTColors {
     private static var theme: JTTheme { JTThemeManager.shared.theme }
 
@@ -30,6 +31,7 @@ public enum JTColors {
 }
 
 /// Gradients that compose reusable backgrounds.
+@MainActor
 public enum JTGradients {
     public static var background: LinearGradient { background(stops: 2) }
 


### PR DESCRIPTION
## Summary
- mark JTColors and JTGradients enums as MainActor-isolated so they can access JTThemeManager

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce05abf920832da0d64206af33f36b