### PR TITLE
Adjust glass background modifier for broader availability

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -7,8 +7,12 @@ private struct JTGlassBackgroundModifier<S: Shape>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .background(.ultraThinMaterial, in: shape)
-            .overlay(shape.stroke(strokeColor, lineWidth: strokeWidth))
+            .background {
+                shape.fill(.ultraThinMaterial)
+            }
+            .overlay {
+                shape.stroke(strokeColor, lineWidth: strokeWidth)
+            }
             .clipShape(shape)
     }
 }


### PR DESCRIPTION
## Summary
- replace the JTGlassBackgroundModifier background and overlay calls with closure-based variants to avoid availability issues

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce072623d4832d89cb5ad82665dc3c