### PR TITLE
Resolve main actor isolation for glass stroke defaults

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -7,15 +7,19 @@ private struct JTGlassBackgroundModifier<S: Shape>: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .background(.ultraThinMaterial, in: shape)
-            .overlay(shape.stroke(strokeColor, lineWidth: strokeWidth))
+            .background {
+                shape.fill(.ultraThinMaterial)
+            }
+            .overlay {
+                shape.stroke(strokeColor, lineWidth: strokeWidth)
+            }
             .clipShape(shape)
     }
 }
 
 @MainActor public extension View {
     func jtGlassBackground(cornerRadius: CGFloat = JTShapes.cardCornerRadius,
-                           strokeColor: Color = JTColors.glassStroke,
+                           strokeColor: Color? = nil,
                            strokeWidth: CGFloat = 1) -> some View {
         jtGlassBackground(
             shape: JTShapes.roundedRectangle(cornerRadius: cornerRadius),
@@ -25,9 +29,15 @@ private struct JTGlassBackgroundModifier<S: Shape>: ViewModifier {
     }
 
     func jtGlassBackground<S: Shape>(shape: S,
-                                     strokeColor: Color = JTColors.glassStroke,
+                                     strokeColor: Color? = nil,
                                      strokeWidth: CGFloat = 1) -> some View {
-        modifier(JTGlassBackgroundModifier(shape: shape, strokeColor: strokeColor, strokeWidth: strokeWidth))
+        modifier(
+            JTGlassBackgroundModifier(
+                shape: shape,
+                strokeColor: strokeColor ?? JTColors.glassStroke,
+                strokeWidth: strokeWidth
+            )
+        )
     }
 }
 
@@ -41,12 +51,12 @@ struct GlassCard<Content: View>: View {
     private let content: () -> Content
 
     init(cornerRadius: CGFloat = JTShapes.cardCornerRadius,
-         strokeColor: Color = JTColors.glassStroke,
+         strokeColor: Color? = nil,
          strokeWidth: CGFloat = 1,
          shadow: JTShadow = JTElevations.card,
          @ViewBuilder content: @escaping () -> Content) {
         self.cornerRadius = cornerRadius
-        self.strokeColor = strokeColor
+        self.strokeColor = strokeColor ?? JTColors.glassStroke
         self.strokeWidth = strokeWidth
         self.shadow = shadow
         self.content = content


### PR DESCRIPTION
## Summary
- make jtGlassBackground overloads accept an optional stroke color and resolve defaults inside the main actor scope
- update GlassCard to lazily resolve the default stroke color from JTColors on initialization

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce072623d4832d89cb5ad82665dc3c