### PR TITLE
Scope navigation bar hiding to compact size classes

### DIFF
--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DashboardView: View {
     @EnvironmentObject var jobsViewModel: JobsViewModel
     @EnvironmentObject var locationService: LocationService
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @AppStorage("smartRoutingEnabled") private var smartRoutingEnabled = false
     @AppStorage("routingOptimizeBy") private var routingOptimizeBy = "closest"
@@ -11,6 +12,10 @@ struct DashboardView: View {
     @StateObject private var viewModel = DashboardViewModel()
 
     private var sortClosest: Bool { routingOptimizeBy == "closest" }
+
+    private var navigationBarVisibility: Visibility {
+        horizontalSizeClass == .compact ? .hidden : .automatic
+    }
 
     private var sections: DashboardViewModel.JobSections {
         viewModel.sections(
@@ -135,7 +140,7 @@ struct DashboardView: View {
                 }
                 .padding(.top, JTSpacing.md)
             }
-            .toolbar(.hidden, for: .navigationBar)
+            .toolbar(navigationBarVisibility, for: .navigationBar)
             .safeAreaInset(edge: .top) {
                 Color.clear.frame(height: 66)
             }

--- a/Job Tracker/Features/Help/HelpCenterView.swift
+++ b/Job Tracker/Features/Help/HelpCenterView.swift
@@ -14,6 +14,7 @@ struct HelpCenterView: View {
     @EnvironmentObject var usersViewModel: UsersViewModel
     @EnvironmentObject var jobsViewModel: JobsViewModel
     @EnvironmentObject var navigation: AppNavigationViewModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var query: String = ""
     @State private var showingCreateJob = false
@@ -152,6 +153,10 @@ struct HelpCenterView: View {
         }
     }
 
+    private var navigationBarVisibility: Visibility {
+        horizontalSizeClass == .compact ? .hidden : .automatic
+    }
+
     var body: some View {
         ZStack(alignment: .top) {
             JTGradients.background
@@ -218,7 +223,7 @@ struct HelpCenterView: View {
             TopicDetailSheet(topic: topic)
         }
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .navigationBar)
+        .toolbar(navigationBarVisibility, for: .navigationBar)
     }
 
     // Topic detail sheet

--- a/Job Tracker/Features/Shared/Messaging/ChatView.swift
+++ b/Job Tracker/Features/Shared/Messaging/ChatView.swift
@@ -19,7 +19,8 @@ struct ChatView: View {
     @Binding var inChat: Bool
     @EnvironmentObject private var authVM: AuthViewModel
     @Environment(\.dismiss) private var dismiss
-    
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     @StateObject private var vm: ChatViewModel
     
     // Build a deterministic roomID from the two UIDs
@@ -81,10 +82,14 @@ struct ChatView: View {
                 .background(.ultraThinMaterial)
             }
         }
-        .toolbar(.hidden, for: .navigationBar) // Hide system nav bar so hamburger can't overlap the back button
+        .toolbar(navigationBarVisibility, for: .navigationBar) // Hide system nav bar in compact to avoid hamburger overlap
         .gradientBackground()
         .onAppear { inChat = true }
         .onDisappear { inChat = false }
+    }
+
+    private var navigationBarVisibility: Visibility {
+        horizontalSizeClass == .compact ? .hidden : .automatic
     }
     
     // MARK: – Custom header


### PR DESCRIPTION
## Summary
- only hide the navigation bar in DashboardView when the horizontal size class is compact so split view navigation controls remain visible on iPad
- apply the same conditional visibility to HelpCenterView and ChatView to restore the system sidebar/back buttons while keeping the custom headers in compact layouts

## Testing
- Not tested (not available in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce98648f24832dbe393daf32eaf056