### PR TITLE
Add save workflow for weekly timesheets

### DIFF
--- a/Job Tracker/Features/Timesheets/TimesheetViewModel.swift
+++ b/Job Tracker/Features/Timesheets/TimesheetViewModel.swift
@@ -41,19 +41,24 @@ class TimesheetViewModel: ObservableObject {
     }
     
     /// Save (or update) the timesheet.
-    func saveTimesheet(_ timesheet: Timesheet) {
+    func saveTimesheet(_ timesheet: Timesheet, completion: @escaping (Result<Void, Error>) -> Void = { _ in }) {
         let partnerComponent = timesheet.partnerId ?? ""
         let docId = "\(timesheet.userId)\(partnerComponent.isEmpty ? "" : "_\(partnerComponent)")_\(weekStartString(from: timesheet.weekStart))"
         do {
             try db.collection("timesheets").document(docId).setData(from: timesheet) { error in
-                if let error = error {
-                    print("Error saving timesheet: \(error)")
-                } else {
-                    print("Timesheet saved successfully.")
+                DispatchQueue.main.async {
+                    if let error = error {
+                        completion(.failure(error))
+                    } else {
+                        self.timesheet = timesheet
+                        completion(.success(()))
+                    }
                 }
             }
         } catch {
-            print("Error encoding timesheet: \(error)")
+            DispatchQueue.main.async {
+                completion(.failure(error))
+            }
         }
     }
     

--- a/Job Tracker/Features/Timesheets/UserTimesheetsViewModel.swift
+++ b/Job Tracker/Features/Timesheets/UserTimesheetsViewModel.swift
@@ -46,18 +46,23 @@ class UserTimesheetsViewModel: ObservableObject {
         listenerRegistration?.remove()
     }
     
-    func saveTimesheet(_ timesheet: Timesheet) {
-        let docId = "\(timesheet.userId)_\(weekStartString(from: timesheet.weekStart))"
+    func saveTimesheet(_ timesheet: Timesheet, completion: @escaping (Result<Void, Error>) -> Void = { _ in }) {
+        let partnerComponent = timesheet.partnerId ?? ""
+        let docId = "\(timesheet.userId)\(partnerComponent.isEmpty ? "" : "_\(partnerComponent)")_\(weekStartString(from: timesheet.weekStart))"
         do {
             try db.collection("timesheets").document(docId).setData(from: timesheet) { error in
-                if let error = error {
-                    print("Error saving timesheet: \(error)")
-                } else {
-                    print("Timesheet saved successfully.")
+                DispatchQueue.main.async {
+                    if let error = error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(()))
+                    }
                 }
             }
         } catch {
-            print("Error encoding timesheet: \(error)")
+            DispatchQueue.main.async {
+                completion(.failure(error))
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- add a save action to WeeklyTimesheetView that builds a Timesheet from the current form, generates the weekly PDF, uploads it to Firebase Storage, and persists it via TimesheetViewModel
- normalize saved daily totals and worker data so previously saved weeks reload into the editor and surface feedback for save success or failure
- extend TimesheetViewModel and UserTimesheetsViewModel save helpers with completion handlers and consistent document IDs that include partner IDs

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68ceb3e723d0832d887e03c4c3671b2a