### PR TITLE
Fix tutorial page description formatting

### DIFF
--- a/Job Tracker/Features/Help/TutorialView.swift
+++ b/Job Tracker/Features/Help/TutorialView.swift
@@ -29,7 +29,7 @@ struct TutorialView: View {
                 description: """
 - From **Jobs**, tap **Create Job** to open the new job form.
 - Fill **Enter address**, adjust **Select Date**, and pick a status from the **Status** menu before saving.
-- Enter the required number in **Job Number \***; CAN roles should add dotted codes in **Assignments** using the provided formatter.
+- Enter the required number in **Job Number** (required); CAN roles should add dotted codes in **Assignments** using the provided formatter.
 - Capture context with **Materials Used** and **Notes**, then hit **Save Job**. After saving, open the job and use **Add Photo** under **New Photos** to attach images.
 """,
                 imageName: "plus.circle.fill"


### PR DESCRIPTION
## Summary
- adjust the Create Jobs tutorial bullet point to avoid invalid escape sequences by rephrasing the required Job Number note

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb8176e70832da4f305c28eff1929