### PR TITLE
Ensure yellow sheets updates occur on main thread

### DIFF
--- a/Job Tracker/Features/YellowSheet/UserYellowSheetsViewModel.swift
+++ b/Job Tracker/Features/YellowSheet/UserYellowSheetsViewModel.swift
@@ -34,10 +34,14 @@ class UserYellowSheetsViewModel: ObservableObject {
 
                     guard let documents = snapshot?.documents else { return }
 
-                    self?.yellowSheets = documents.compactMap { document in
+                    let sheets: [YellowSheet] = documents.compactMap { document in
                         var sheet = try? document.data(as: YellowSheet.self)
                         sheet?.id = document.documentID
                         return sheet
+                    }
+
+                    DispatchQueue.main.async { [weak self] in
+                        self?.yellowSheets = sheets.sorted { $0.weekStart > $1.weekStart }
                     }
                 }
         }


### PR DESCRIPTION
## Summary
- wrap snapshot updates in DispatchQueue.main.async to ensure UI updates occur on the main thread
- sort yellow sheets by weekStart descending for stable ordering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb9b407b0832dae5233345d32ec15