### PR TITLE
Hide shell action buttons on nested more tab screens

### DIFF
--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -10,10 +10,22 @@ struct MainTabView: View {
         )
     }
 
+    private var shouldShowShellButtons: Bool {
+        guard navigation.selectedPrimary != .timesheets else { return false }
+
+        if navigation.selectedPrimary == .more,
+           navigation.activeDestination.isMoreStackDestination,
+           navigation.activeDestination != .more {
+            return false
+        }
+
+        return true
+    }
+
     var body: some View {
         PrimaryTabContainer()
             .safeAreaInset(edge: .top) {
-                if navigation.selectedPrimary != .timesheets {
+                if shouldShowShellButtons {
                     ShellActionButtons(
                         onShowMenu: { navigation.isPrimaryMenuPresented = true },
                         onOpenHelp: { navigation.navigate(to: .helpCenter) }


### PR DESCRIPTION
## Summary
- add logic to suppress the global shell action buttons when viewing nested destinations inside the More tab
- prevent the custom menu/help controls from overlapping the system back button

## Testing
- Not run (iOS project requires Xcode tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cec00d0778832d8efeaa6cadeb8379