### PR TITLE
Add top inset to JobSearchView to avoid shell overlap

### DIFF
--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -94,6 +94,9 @@ struct JobSearchView: View {
                 }
             }
         }
+        .safeAreaInset(edge: .top) {
+            Color.clear.frame(height: 66)
+        }
         .onAppear {
             jobsViewModel.startSearchIndexForAllJobs()
         }


### PR DESCRIPTION
## Summary
- add a top safe-area inset to JobSearchView so shell buttons no longer overlap the view content

## Testing
- not run (requires Xcode on macOS)

------
https://chatgpt.com/codex/tasks/task_e_68cec6abf168832daaaab665f8869af0