### PR TITLE
Measure shell chrome height and fix job search spacing

### DIFF
--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -4,6 +4,7 @@ struct DashboardView: View {
     @EnvironmentObject var jobsViewModel: JobsViewModel
     @EnvironmentObject var locationService: LocationService
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.shellChromeHeight) private var shellChromeHeight
 
     @AppStorage("smartRoutingEnabled") private var smartRoutingEnabled = false
     @AppStorage("routingOptimizeBy") private var routingOptimizeBy = "closest"
@@ -142,7 +143,7 @@ struct DashboardView: View {
             }
             .toolbar(navigationBarVisibility, for: .navigationBar)
             .safeAreaInset(edge: .top) {
-                Color.clear.frame(height: 66)
+                Color.clear.frame(height: shellChromeHeight)
             }
             .sheet(item: selectedJobBinding) { job in
                 if let index = jobsViewModel.jobs.firstIndex(where: { $0.id == job.id }) {

--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -5,6 +5,7 @@ struct JobSearchView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var jobsViewModel: JobsViewModel
     @EnvironmentObject var usersViewModel: UsersViewModel
+    @Environment(\.shellChromeHeight) private var shellChromeHeight
 
     @State private var searchText: String = ""
 
@@ -71,6 +72,10 @@ struct JobSearchView: View {
         }
     }
 
+    private var scrollContentTopPadding: CGFloat {
+        max(0, JTSpacing.lg - shellChromeHeight)
+    }
+
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
@@ -90,12 +95,14 @@ struct JobSearchView: View {
 
                         resultsContent
                     }
-                    .padding(JTSpacing.lg)
+                    .padding(.top, scrollContentTopPadding)
+                    .padding(.horizontal, JTSpacing.lg)
+                    .padding(.bottom, JTSpacing.lg)
                 }
             }
         }
         .safeAreaInset(edge: .top) {
-            Color.clear.frame(height: 66)
+            Color.clear.frame(height: shellChromeHeight)
         }
         .onAppear {
             jobsViewModel.startSearchIndexForAllJobs()

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainTabView: View {
     @EnvironmentObject private var navigation: AppNavigationViewModel
+    @State private var measuredShellChromeHeight: CGFloat = 0
 
     private var menuPresentation: Binding<Bool> {
         Binding(
@@ -24,17 +25,22 @@ struct MainTabView: View {
 
     var body: some View {
         PrimaryTabContainer()
+            .environment(\.shellChromeHeight, shouldShowShellButtons ? measuredShellChromeHeight : 0)
             .safeAreaInset(edge: .top) {
                 if shouldShowShellButtons {
                     ShellActionButtons(
                         onShowMenu: { navigation.isPrimaryMenuPresented = true },
                         onOpenHelp: { navigation.navigate(to: .helpCenter) }
                     )
+                    .measureShellChromeHeight()
                 }
             }
             .sheet(isPresented: menuPresentation) {
                 PrimaryDestinationMenu()
                     .presentationDetents([.medium, .large])
+            }
+            .onPreferenceChange(ShellChromeHeightPreferenceKey.self) { height in
+                measuredShellChromeHeight = height
             }
     }
 }

--- a/Job Tracker/Features/Shared/Shell/ShellChromeHeight.swift
+++ b/Job Tracker/Features/Shared/Shell/ShellChromeHeight.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Preference key used to capture the rendered height of the shell chrome overlay.
+struct ShellChromeHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private struct ShellChromeHeightEnvironmentKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    /// The measured height of the shell chrome overlay, including the status-bar inset.
+    var shellChromeHeight: CGFloat {
+        get { self[ShellChromeHeightEnvironmentKey.self] }
+        set { self[ShellChromeHeightEnvironmentKey.self] = newValue }
+    }
+}
+
+extension View {
+    /// Reads the global frame of the current view to report the shell chrome height.
+    func measureShellChromeHeight() -> some View {
+        background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(
+                        key: ShellChromeHeightPreferenceKey.self,
+                        value: max(0, proxy.frame(in: .global).maxY)
+                    )
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared shell chrome height measurement and environment helper
- publish the overlay height from MainTabView and consume it in the job search and dashboard screens
- adjust job search padding so the title aligns just below the measured overlay

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cece78f73c832d9f6cba19bdb46dd0