### PR TITLE
Hide shell chrome when job search detail views are active

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -108,6 +108,7 @@ final class AppNavigationViewModel: ObservableObject {
     @Published var activeDestination: Destination = .dashboard
     @Published var isPrimaryMenuPresented: Bool = false
     @Published private(set) var morePath: [Destination] = []
+    @Published var shouldShowShellChrome: Bool = true
 
     var primaryDestinations: [Destination] {
         PrimaryDestination.allCases.map { $0.destination }

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -14,6 +14,11 @@ struct MainTabView: View {
     private var shouldShowShellButtons: Bool {
         guard navigation.selectedPrimary != .timesheets else { return false }
 
+        if navigation.selectedPrimary == .search,
+           !navigation.shouldShowShellChrome {
+            return false
+        }
+
         if navigation.selectedPrimary == .more,
            navigation.activeDestination.isMoreStackDestination,
            navigation.activeDestination != .more {

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -62,6 +62,16 @@ struct Job: Identifiable, Codable {
     }
 }
 
+extension Job: Hashable {
+    static func == (lhs: Job, rhs: Job) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
 extension Job {
     /// Returns the first component of the address (before any commas) as a "short address."
     var shortAddress: String {


### PR DESCRIPTION
## Summary
- track the Job Search navigation stack with a route enum so we can tell when the user is in a pushed detail view
- expose a show-shell flag on AppNavigationViewModel and hide the shell buttons whenever the Job Search tab is not at its root
- make Job/JobAggregate hashable so route values can carry job data between destinations

## Testing
- not run (iOS project; Xcode unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ced38ac928832d8178531b58e2f0d1