### PR TITLE
Hide shell chrome when job search detail views are active

### DIFF
--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -2,12 +2,18 @@ import SwiftUI
 import UIKit
 
 struct JobSearchView: View {
-    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var jobsViewModel: JobsViewModel
     @EnvironmentObject var usersViewModel: UsersViewModel
+    @EnvironmentObject private var navigation: AppNavigationViewModel
     @Environment(\.shellChromeHeight) private var shellChromeHeight
 
     @State private var searchText: String = ""
+    @State private var path = NavigationPath()
+
+    enum Route: Hashable {
+        case aggregate(JobAggregate)
+        case job(Job)
+    }
 
     // MARK: - Filter + Group
 
@@ -76,8 +82,12 @@ struct JobSearchView: View {
         max(0, JTSpacing.lg - shellChromeHeight)
     }
 
+    private func updateShellChrome(for depth: Int) {
+        navigation.shouldShowShellChrome = depth == 0
+    }
+
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ZStack(alignment: .top) {
                 JTGradients.background
                     .ignoresSafeArea()
@@ -101,11 +111,28 @@ struct JobSearchView: View {
                 }
             }
         }
+        .navigationDestination(for: Route.self) { route in
+            switch route {
+            case .aggregate(let aggregate):
+                AggregatedDetailView(aggregate: aggregate)
+                    .environmentObject(usersViewModel)
+                    .environmentObject(jobsViewModel)
+            case .job(let job):
+                destination(for: job)
+            }
+        }
         .safeAreaInset(edge: .top) {
             Color.clear.frame(height: shellChromeHeight)
         }
         .onAppear {
             jobsViewModel.startSearchIndexForAllJobs()
+            updateShellChrome(for: path.count)
+        }
+        .onChange(of: path.count) { newDepth in
+            updateShellChrome(for: newDepth)
+        }
+        .onDisappear {
+            navigation.shouldShowShellChrome = true
         }
     }
 
@@ -146,16 +173,40 @@ struct JobSearchView: View {
         } else {
             LazyVStack(spacing: JTSpacing.md) {
                 ForEach(aggregatedResults) { agg in
-                    NavigationLink {
-                        AggregatedDetailView(aggregate: agg)
-                            .environmentObject(usersViewModel)
-                    } label: {
+                    NavigationLink(value: Route.aggregate(agg)) {
                         AggregatedJobCard(aggregate: agg)
                             .contentShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
                     }
                     .buttonStyle(.plain)
                 }
             }
+        }
+    }
+
+    // MARK: - Navigation
+
+    private func binding(for job: Job) -> Binding<Job>? {
+        guard jobsViewModel.jobs.contains(where: { $0.id == job.id }) else { return nil }
+        return Binding(
+            get: {
+                jobsViewModel.jobs.first(where: { $0.id == job.id }) ?? job
+            },
+            set: { newValue in
+                if let index = jobsViewModel.jobs.firstIndex(where: { $0.id == job.id }) {
+                    var copy = jobsViewModel.jobs
+                    copy[index] = newValue
+                    jobsViewModel.jobs = copy
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func destination(for job: Job) -> some View {
+        if let binding = binding(for: job) {
+            JobDetailView(job: binding)
+        } else {
+            JobSearchDetailView(job: job)
         }
     }
 
@@ -323,7 +374,6 @@ private struct AggregatedJobCard: View {
 // MARK: - Aggregated Detail
 private struct AggregatedDetailView: View {
     @EnvironmentObject var usersViewModel: UsersViewModel
-    @EnvironmentObject var jobsViewModel: JobsViewModel
     let aggregate: JobSearchView.JobAggregate
 
     @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
@@ -391,31 +441,6 @@ private struct AggregatedDetailView: View {
                     isGeneratingShareLink = false
                 }
             }
-        }
-    }
-
-    private func binding(for job: Job) -> Binding<Job>? {
-        guard jobsViewModel.jobs.contains(where: { $0.id == job.id }) else { return nil }
-        return Binding(
-            get: {
-                jobsViewModel.jobs.first(where: { $0.id == job.id }) ?? job
-            },
-            set: { newValue in
-                if let index = jobsViewModel.jobs.firstIndex(where: { $0.id == job.id }) {
-                    var copy = jobsViewModel.jobs
-                    copy[index] = newValue
-                    jobsViewModel.jobs = copy
-                }
-            }
-        )
-    }
-
-    @ViewBuilder
-    private func destination(for job: Job) -> some View {
-        if let binding = binding(for: job) {
-            JobDetailView(job: binding)
-        } else {
-            JobSearchDetailView(job: job)
         }
     }
 
@@ -502,9 +527,7 @@ private struct AggregatedDetailView: View {
                     // Timeline of all entries (newest first)
                     VStack(alignment: .leading, spacing: JTSpacing.md) {
                         ForEach(aggregate.jobs, id: \.id) { job in
-                            NavigationLink {
-                                destination(for: job)
-                            } label: {
+                            NavigationLink(value: JobSearchView.Route.job(job)) {
                                 GlassCard(cornerRadius: JTShapes.smallCardCornerRadius,
                                           strokeColor: JTColors.glassSoftStroke,
                                           shadow: JTShadow.none) {
@@ -562,5 +585,17 @@ private struct AggregatedDetailView: View {
                 Text(message)
             }
         })
+    }
+}
+
+// MARK: - Hashable support
+
+extension JobSearchView.JobAggregate: Hashable {
+    static func == (lhs: JobSearchView.JobAggregate, rhs: JobSearchView.JobAggregate) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -108,6 +108,7 @@ final class AppNavigationViewModel: ObservableObject {
     @Published var activeDestination: Destination = .dashboard
     @Published var isPrimaryMenuPresented: Bool = false
     @Published private(set) var morePath: [Destination] = []
+    @Published var shouldShowShellChrome: Bool = true
 
     var primaryDestinations: [Destination] {
         PrimaryDestination.allCases.map { $0.destination }

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -14,6 +14,11 @@ struct MainTabView: View {
     private var shouldShowShellButtons: Bool {
         guard navigation.selectedPrimary != .timesheets else { return false }
 
+        if navigation.selectedPrimary == .search,
+           !navigation.shouldShowShellChrome {
+            return false
+        }
+
         if navigation.selectedPrimary == .more,
            navigation.activeDestination.isMoreStackDestination,
            navigation.activeDestination != .more {

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -62,6 +62,16 @@ struct Job: Identifiable, Codable {
     }
 }
 
+extension Job: Hashable {
+    static func == (lhs: Job, rhs: Job) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
 extension Job {
     /// Returns the first component of the address (before any commas) as a "short address."
     var shortAddress: String {


### PR DESCRIPTION
## Summary
- track the Job Search navigation stack with a route enum so we can tell when the user is in a pushed detail view
- expose a show-shell flag on AppNavigationViewModel and hide the shell buttons whenever the Job Search tab is not at its root
- make Job/JobAggregate hashable so route values can carry job data between destinations
- store the navigation path in a NavigationPath so tapping results once again pushes the correct detail views

## Testing
- not run (iOS project; Xcode unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ced38ac928832d8178531b58e2f0d1