### PR TITLE
Fix Job Search view tap handling and header spacing

### DIFF
--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -79,7 +79,7 @@ struct JobSearchView: View {
     }
 
     private var scrollContentTopPadding: CGFloat {
-        max(0, JTSpacing.lg - shellChromeHeight)
+        shellChromeHeight > 0 ? JTSpacing.xl : JTSpacing.lg
     }
 
     private func updateShellChrome(for path: [Route]) {
@@ -367,6 +367,7 @@ private struct AggregatedJobCard: View {
                     .foregroundStyle(JTColors.textMuted)
                     .padding(.trailing, JTSpacing.md)
             }
+            .allowsHitTesting(false)
         )
     }
 }
@@ -561,6 +562,7 @@ private struct AggregatedDetailView: View {
                                             .foregroundStyle(JTColors.textMuted)
                                             .padding(.trailing, JTSpacing.md)
                                     }
+                                    .allowsHitTesting(false)
                                 )
                                 .contentShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
                             }


### PR DESCRIPTION
## Summary
- ensure the Job Search header gains extra top padding when the shell chrome is visible so the title no longer overlaps the menu button
- disable hit testing on chevron overlays so aggregated results and job entries respond to taps again

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cedbeb2ce8832d935fa8b92b01325d