### PR TITLE
Improve job search token matching

### DIFF
--- a/Job TrackerTests/JobSearchMatcherTests.swift
+++ b/Job TrackerTests/JobSearchMatcherTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Job_Tracker
+
+final class JobSearchMatcherTests: XCTestCase {
+    private let sampleJob = Job(
+        id: "job-1",
+        address: "123 Main Street",
+        date: Date(timeIntervalSince1970: 1_700_000_000),
+        status: "Completed",
+        createdBy: "user-1",
+        notes: "",
+        jobNumber: "123"
+    )
+
+    private let creator = AppUser(
+        id: "user-1",
+        firstName: "Taylor",
+        lastName: "Foreman",
+        email: "taylor@example.com",
+        position: "Technician"
+    )
+
+    func testMatchesAllTokensRegardlessOfOrder() {
+        XCTAssertTrue(JobSearchMatcher.matches(job: sampleJob, query: "completed 123", creator: creator))
+        XCTAssertTrue(JobSearchMatcher.matches(job: sampleJob, query: " 123   completed ", creator: creator))
+    }
+
+    func testMatchFailsWhenAnyTokenMissing() {
+        XCTAssertFalse(JobSearchMatcher.matches(job: sampleJob, query: "completed 999", creator: creator))
+    }
+
+    func testCreatorNameIncludedInHaystack() {
+        XCTAssertTrue(JobSearchMatcher.matches(job: sampleJob, query: "foreman", creator: creator))
+        XCTAssertFalse(JobSearchMatcher.matches(job: sampleJob, query: "foreman", creator: nil))
+    }
+}


### PR DESCRIPTION
## Summary
- tokenize job search queries so every term must be present in the normalized haystack
- extract the reusable `JobSearchMatcher` helper for matching logic
- add unit tests covering multi-term queries, missing tokens, and creator-name matching

## Testing
- xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'platform=iOS Simulator,name=iPhone 14' test *(fails: xcodebuild unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceea3a1894832d9c2bd19021d28b89