### PR TITLE
Expand job search optional fields

### DIFF
--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -633,24 +633,57 @@ struct JobSearchMatcher {
     }
 
     private static func normalizedHaystack(for job: Job, creator: AppUser?) -> String {
-        let creatorName: String
-        if let creator {
-            creatorName = "\(creator.firstName) \(creator.lastName)"
-        } else {
-            creatorName = ""
+        var fields: [String] = []
+
+        if let address = normalizedNonEmpty(job.address) {
+            fields.append(address)
         }
 
-        let fields: [String] = [
-            job.address,
-            job.jobNumber ?? "",
-            job.status,
-            creatorName,
+        if let jobNumber = normalizedNonEmpty(job.jobNumber) {
+            fields.append(jobNumber)
+        }
+
+        if let status = normalizedNonEmpty(job.status) {
+            fields.append(status)
+        }
+
+        if let creator,
+           let creatorName = normalizedNonEmpty("\(creator.firstName) \(creator.lastName)") {
+            fields.append(creatorName)
+        }
+
+        if let date = normalizedNonEmpty(
             DateFormatter.localizedString(from: job.date, dateStyle: .short, timeStyle: .none)
+        ) {
+            fields.append(date)
+        }
+
+        let optionalFields: [String?] = [
+            job.notes,
+            job.materialsUsed,
+            job.assignments,
+            job.nidFootage,
+            job.canFootage
         ]
 
-        return fields
-            .joined(separator: " ")
-            .lowercased()
+        for field in optionalFields {
+            if let normalized = normalizedNonEmpty(field) {
+                fields.append(normalized)
+            }
+        }
+
+        return fields.joined(separator: " ")
+    }
+
+    private static func normalizedNonEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.lowercased()
+    }
+
+    private static func normalizedNonEmpty(_ value: String?) -> String? {
+        guard let value = value else { return nil }
+        return normalizedNonEmpty(value)
     }
 }
 

--- a/Job TrackerTests/JobSearchMatcherTests.swift
+++ b/Job TrackerTests/JobSearchMatcherTests.swift
@@ -33,4 +33,26 @@ final class JobSearchMatcherTests: XCTestCase {
         XCTAssertTrue(JobSearchMatcher.matches(job: sampleJob, query: "foreman", creator: creator))
         XCTAssertFalse(JobSearchMatcher.matches(job: sampleJob, query: "foreman", creator: nil))
     }
+
+    func testOptionalFieldsIncludedInHaystack() {
+        let jobWithOptionals = Job(
+            id: "job-optional",
+            address: "456 Elm Street",
+            date: Date(timeIntervalSince1970: 1_700_100_000),
+            status: "Pending",
+            createdBy: "user-1",
+            notes: "   Needs Ladder   ",
+            jobNumber: nil,
+            assignments: "  42.7.1  ",
+            materialsUsed: "  Fiber Cable  ",
+            nidFootage: "  150FT  ",
+            canFootage: "  200 FT  "
+        )
+
+        XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "ladder", creator: creator))
+        XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "fiber", creator: creator))
+        XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "42.7.1", creator: creator))
+        XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "150ft", creator: creator))
+        XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "200 ft", creator: creator))
+    }
 }


### PR DESCRIPTION
## Summary
- extend the job search haystack to normalize text and include notes, materials, assignments, and footage details
- add unit coverage confirming searches can find jobs via the newly indexed optional fields

## Testing
- not run (requires Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceec999da0832daa18bd35ce39e966