### PR TITLE
Fix aggregated job navigation

### DIFF
--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -557,9 +557,7 @@ private struct AggregatedDetailView: View {
                     // Timeline of all entries (newest first)
                     VStack(alignment: .leading, spacing: JTSpacing.md) {
                         ForEach(aggregate.jobs, id: \.id) { job in
-                            NavigationLink {
-                                destination(for: job)
-                            } label: {
+                            NavigationLink(value: JobSearchView.Route.job(id: job.id)) {
                                 GlassCard(cornerRadius: JTShapes.smallCardCornerRadius,
                                           strokeColor: JTColors.glassSoftStroke,
                                           shadow: JTShadow.none) {
@@ -618,6 +616,18 @@ private struct AggregatedDetailView: View {
                 Text(message)
             }
         })
+        .navigationDestination(for: JobSearchView.Route.self) { route in
+            switch route {
+            case .job(let jobID):
+                if let job = aggregate.jobs.first(where: { $0.id == jobID }) {
+                    destination(for: job)
+                } else {
+                    MissingSearchDestinationView(message: "We couldn't load that job. It may have been removed.")
+                }
+            case .aggregate:
+                EmptyView()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- restore value-based navigation for aggregated job rows so taps emit `JobSearchView.Route.job`
- handle nested job routes inside `AggregatedDetailView` using the existing destination helper and a missing-job fallback

## Testing
- not run (requires iOS simulator for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68cef409cdd0832da597b405c3eac6ef