### PR TITLE
Add debounce to job search query updates

### DIFF
--- a/Job Tracker/Features/Search/JobSearchViewModel.swift
+++ b/Job Tracker/Features/Search/JobSearchViewModel.swift
@@ -120,6 +120,7 @@ final class JobSearchViewModel: ObservableObject {
 
     private func configureSubscriptions() {
         $query
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.rebuildAggregates()


### PR DESCRIPTION
## Summary
- debounce query updates in the search view model so updates wait 200ms before triggering
- keep work on the main run loop to remain compatible with SwiftUI bindings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf0644dc4c832dbad004954c523775