### PR TITLE
Revamp job search experience

### DIFF
--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -1,93 +1,352 @@
-//
-//  JobSearchDetailView.swift
-//  Job Tracker
-//
-//  Created by Quinton  Thompson  on 2/8/25.
-//
-
-
 import SwiftUI
+import UIKit
 
 struct JobSearchDetailView: View {
     let job: Job
-    @EnvironmentObject var usersViewModel: UsersViewModel
-    @Environment(\.dismiss) var dismiss
+    let metadata: JobSearchViewModel.Result
+
+    @EnvironmentObject private var usersViewModel: UsersViewModel
+    @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
+
+    @State private var isGeneratingShareLink = false
+    @State private var shareURL: URL? = nil
+    @State private var showShareSheet = false
+    @State private var shareErrorMessage: String? = nil
+
+    private var shareErrorBinding: Binding<Bool> {
+        Binding(
+            get: { shareErrorMessage != nil },
+            set: { newValue in
+                if !newValue { shareErrorMessage = nil }
+            }
+        )
+    }
+
+    private var assignedToText: String? {
+        guard let assignedID = job.assignedTo,
+              let user = usersViewModel.usersDict[assignedID] else { return nil }
+        return "\(user.firstName) \(user.lastName)".trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var creatorText: String? {
+        if let creator = metadata.creator {
+            if let role = creator.role, !role.isEmpty {
+                return "Added by \(creator.name) · \(role)"
+            } else {
+                return "Added by \(creator.name)"
+            }
+        }
+        if let creatorID = job.createdBy, let user = usersViewModel.usersDict[creatorID] {
+            return "Added by \(user.firstName) \(user.lastName)"
+        }
+        return nil
+    }
+
+    private var infoItems: [DetailInfoItem] {
+        var items: [DetailInfoItem] = []
+
+        if let assigned = assignedToText, !assigned.isEmpty {
+            items.append(.init(title: "Assigned to", value: assigned, systemImage: "person.crop.circle"))
+        }
+
+        if let assignments = displayValue(job.assignments) {
+            items.append(.init(title: "Assignment", value: assignments, systemImage: "list.number"))
+        }
+
+        if let nid = displayValue(job.nidFootage) {
+            items.append(.init(title: "NID Footage", value: nid, systemImage: "ruler"))
+        }
+
+        if let can = displayValue(job.canFootage) {
+            items.append(.init(title: "CAN Footage", value: can, systemImage: "ruler"))
+        }
+
+        if job.hours > 0 {
+            items.append(.init(title: "Hours logged", value: String(format: "%.1f hours", job.hours), systemImage: "clock"))
+        }
+
+        return items
+    }
+
+    private var notesText: String? { displayValue(job.notes) }
+    private var materialsText: String? { displayValue(job.materialsUsed) }
 
     var body: some View {
-        NavigationView {
-            ZStack {
-                JTGradients.background
-                    .ignoresSafeArea()
+        ZStack(alignment: .top) {
+            JTGradients.background
+                .ignoresSafeArea()
 
-                ScrollView {
-                    VStack(alignment: .leading, spacing: JTSpacing.lg) {
-                        Text("Job Details")
-                            .font(JTTypography.screenTitle)
-                            .foregroundStyle(JTColors.textPrimary)
-                            .padding(.top, JTSpacing.xl)
-                            .padding(.horizontal, JTSpacing.lg)
+            ScrollView {
+                VStack(alignment: .leading, spacing: JTSpacing.xl) {
+                    summaryCard
 
-                        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
-                                  strokeColor: JTColors.glassSoftStroke) {
-                            VStack(alignment: .leading, spacing: JTSpacing.md) {
-                                detailSection(title: "Address:", value: job.address)
-                                detailSection(title: "Job Number:", value: job.jobNumber ?? "N/A")
-                                detailSection(title: "Date:", value: DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))
-                                detailSection(title: "Status:", value: job.status)
+                    if !infoItems.isEmpty {
+                        DetailInfoCard(title: "Job information", items: infoItems)
+                    }
 
-                                if let materials = job.materialsUsed, !materials.isEmpty {
-                                    detailSection(title: "Materials:", value: materials)
-                                }
+                    if let materialsText {
+                        DetailTextCard(title: "Materials", systemImage: "shippingbox", text: materialsText)
+                    }
 
-                                if let can = job.canFootage, !can.isEmpty {
-                                    detailSection(title: "CAN Footage:", value: can)
-                                }
-                                if let nid = job.nidFootage, !nid.isEmpty {
-                                    detailSection(title: "NID Footage:", value: nid)
-                                }
+                    if let notesText {
+                        DetailTextCard(title: "Notes", systemImage: "note.text", text: notesText)
+                    }
 
-                                if let notes = job.notes, !notes.isEmpty {
-                                    detailSection(title: "Notes:", value: notes)
-                                }
-
-                                if !job.photos.isEmpty {
-                                    Text("Photos:")
-                                        .font(JTTypography.headline)
-                                        .foregroundStyle(JTColors.textPrimary)
-                                    ScrollView(.horizontal, showsIndicators: false) {
-                                        HStack(spacing: JTSpacing.sm) {
-                                            ForEach(job.photos, id: \.self) { urlString in
-                                                PhotoThumbnail(urlString: urlString)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            .padding(JTSpacing.lg)
-                        }
-                        .padding(.horizontal, JTSpacing.lg)
-                        .padding(.bottom, JTSpacing.xl)
+                    if !job.photos.isEmpty {
+                        PhotosSection(photos: job.photos)
                     }
                 }
+                .padding(.horizontal, JTSpacing.lg)
+                .padding(.vertical, JTSpacing.xl)
             }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") { dismiss() }
+        }
+        .navigationTitle("Job Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showShareSheet, onDismiss: { shareURL = nil }) {
+            if let url = shareURL {
+                let subject = metadata.address.primary
+                ActivityView(activityItems: [url], subject: "Job link for \(subject)")
+            }
+        }
+        .alert("Couldn't Share Job", isPresented: shareErrorBinding) {
+            Button("OK", role: .cancel) { shareErrorMessage = nil }
+        } message: {
+            if let shareErrorMessage {
+                Text(shareErrorMessage)
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                HStack(alignment: .top, spacing: JTSpacing.sm) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(metadata.address.primary)
+                            .font(JTTypography.title3)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .lineLimit(3)
+
+                        if let secondary = metadata.address.secondary {
+                            Text(secondary)
+                                .font(JTTypography.subheadline)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    Spacer(minLength: JTSpacing.sm)
+                    if let jobNumber = metadata.jobNumber {
+                        Text("#\(jobNumber)")
+                            .font(JTTypography.caption)
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 10)
+                            .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                            .foregroundStyle(JTColors.textPrimary)
+                    }
+                }
+
+                HStack(spacing: JTSpacing.sm) {
+                    Text(job.status)
+                        .font(JTTypography.caption)
+                        .fontWeight(.semibold)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 10)
+                        .background(statusColor(job.status).opacity(0.18), in: Capsule())
+                        .foregroundStyle(statusColor(job.status))
+
+                    Text(job.date, style: .date)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+
+                if let creatorText {
+                    Label(creatorText, systemImage: "person.crop.circle")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+
+                if !metadata.isOwnedByCurrentUser {
+                    Label("Found via team search", systemImage: "person.2")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+
+                quickActions
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var quickActions: some View {
+        HStack(spacing: JTSpacing.sm) {
+            QuickActionButton(title: "Directions", systemImage: "map") {
+                openInMaps(job: job)
+            }
+
+            QuickActionButton(title: "Share", systemImage: "square.and.arrow.up", isLoading: isGeneratingShareLink) {
+                share(job: job)
+            }
+            .disabled(isGeneratingShareLink)
+        }
+    }
+
+    private func openInMaps(job: Job) {
+        guard let encoded = job.address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+        if suggestionProviderRaw == "google" {
+            if let url = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") {
+                UIApplication.shared.open(url, options: [:]) { success in
+                    if success { return }
+                    if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
+                        UIApplication.shared.open(appleURL)
+                    }
+                }
+                return
+            }
+        }
+        if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
+            UIApplication.shared.open(appleURL)
+        }
+    }
+
+    private func share(job: Job) {
+        guard !isGeneratingShareLink else { return }
+        shareErrorMessage = nil
+        shareURL = nil
+        isGeneratingShareLink = true
+
+        Task {
+            do {
+                let url = try await SharedJobService.shared.publishShareLink(job: job)
+                await MainActor.run {
+                    shareURL = url
+                    isGeneratingShareLink = false
+                    showShareSheet = true
+                }
+            } catch {
+                await MainActor.run {
+                    shareErrorMessage = error.localizedDescription
+                    isGeneratingShareLink = false
                 }
             }
         }
     }
 
-    @ViewBuilder
-    private func detailSection(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: JTSpacing.xs) {
-            Text(title)
-                .font(JTTypography.headline)
-                .foregroundStyle(JTColors.textPrimary)
-            Text(value)
-                .font(JTTypography.body)
-                .foregroundStyle(JTColors.textSecondary)
+    private func statusColor(_ status: String) -> Color {
+        let lower = status.lowercased()
+        if lower.contains("done") || lower.contains("complete") {
+            return JTColors.success
+        }
+        if lower.contains("pending") {
+            return JTColors.warning
+        }
+        if lower.contains("hold") || lower.contains("blocked") || lower.contains("issue") {
+            return JTColors.error
+        }
+        if lower.contains("need") {
+            return JTColors.info
+        }
+        return JTColors.accent
+    }
+
+    private func displayValue(_ value: String?) -> String? {
+        guard let value = value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+// MARK: - Helpers
+
+private struct DetailInfoItem: Identifiable, Hashable {
+    let id = UUID()
+    let title: String
+    let value: String
+    let systemImage: String
+}
+
+private struct DetailInfoCard: View {
+    let title: String
+    let items: [DetailInfoItem]
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Text(title)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    HStack(alignment: .top, spacing: JTSpacing.sm) {
+                        Image(systemName: item.systemImage)
+                            .foregroundStyle(JTColors.textSecondary)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.title.uppercased())
+                                .font(JTTypography.caption)
+                                .foregroundStyle(JTColors.textSecondary)
+                            Text(item.value)
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textPrimary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    if index < items.count - 1 {
+                        Divider()
+                            .overlay(JTColors.glassSoftStroke.opacity(0.5))
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
+private struct DetailTextCard: View {
+    let title: String
+    let systemImage: String
+    let text: String
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Label(title, systemImage: systemImage)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Text(text)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
+private struct PhotosSection: View {
+    let photos: [String]
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Label("Photos", systemImage: "photo.on.rectangle")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: JTSpacing.sm) {
+                        ForEach(photos, id: \.self) { urlString in
+                            PhotoThumbnail(urlString: urlString)
+                        }
+                    }
+                    .padding(.vertical, JTSpacing.xs)
+                }
+            }
+            .padding(JTSpacing.lg)
         }
     }
 }
@@ -102,21 +361,60 @@ private struct PhotoThumbnail: View {
                     switch phase {
                     case .empty:
                         ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(JTColors.textSecondary)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                     case .success(let image):
                         image
                             .resizable()
                             .scaledToFill()
                     case .failure:
-                        Color.red
+                        ZStack {
+                            JTColors.error.opacity(0.15)
+                            Image(systemName: "exclamationmark.triangle")
+                                .foregroundStyle(JTColors.error)
+                        }
                     @unknown default:
-                        EmptyView()
+                        Color.clear
                     }
                 }
             } else {
-                Color.gray
+                ZStack {
+                    JTColors.glassSoftStroke.opacity(0.2)
+                    Image(systemName: "photo")
+                        .foregroundStyle(JTColors.textSecondary)
+                }
             }
         }
-        .frame(width: 100, height: 100)
+        .frame(width: 140, height: 140)
         .clipShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
+    }
+}
+
+private struct QuickActionButton: View {
+    let title: String
+    let systemImage: String
+    var isLoading: Bool = false
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: JTSpacing.xs) {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(JTColors.textPrimary)
+                } else {
+                    Image(systemName: systemImage)
+                }
+                Text(title)
+            }
+            .font(JTTypography.caption)
+            .foregroundStyle(JTColors.textPrimary)
+            .padding(.vertical, JTSpacing.xs)
+            .padding(.horizontal, JTSpacing.sm)
+            .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct JobSearchView: View {
     @EnvironmentObject private var jobsViewModel: JobsViewModel
@@ -8,173 +7,306 @@ struct JobSearchView: View {
     @Environment(\.shellChromeHeight) private var shellChromeHeight
 
     @StateObject private var viewModel: JobSearchViewModel
+    @State private var navigationPath: [JobSearchViewModel.Result] = []
 
     init(viewModel: JobSearchViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
 
-    private var scrollContentTopPadding: CGFloat {
+    private var topPadding: CGFloat {
         shellChromeHeight > 0 ? JTSpacing.xl : JTSpacing.lg
     }
 
-    private func updateShellChrome(for path: [JobSearchViewModel.Route]) {
-        navigation.shouldShowShellChrome = path.isEmpty
-    }
-
     var body: some View {
-        NavigationStack(path: $viewModel.navigationPath) {
+        NavigationStack(path: $navigationPath) {
             ZStack(alignment: .top) {
                 JTGradients.background
                     .ignoresSafeArea()
 
                 ScrollView {
-                    VStack(spacing: JTSpacing.lg) {
-                        Text("Search Jobs")
-                            .font(JTTypography.screenTitle)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .foregroundStyle(JTColors.textPrimary)
-
-                        JTTextField("Address, #, status, user…", text: $viewModel.query, icon: "magnifyingglass")
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-
-                        JobSearchResultsContent(viewState: viewModel.resultsState)
+                    VStack(alignment: .leading, spacing: JTSpacing.xl) {
+                        header
+                        searchField
+                        QuickFiltersSection(filters: viewModel.quickFilters) { filter in
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                viewModel.query = filter.suggestedQuery
+                            }
+                        }
+                        SearchContentView(state: viewModel.viewState, resultsCount: viewModel.resultsCount)
                     }
-                    .padding(.top, scrollContentTopPadding)
+                    .padding(.top, topPadding)
                     .padding(.horizontal, JTSpacing.lg)
-                    .padding(.bottom, JTSpacing.lg)
+                    .padding(.bottom, JTSpacing.xl)
                 }
             }
-        }
-        .navigationDestination(for: JobSearchViewModel.Route.self) { route in
-            destinationView(for: route)
+            .navigationDestination(for: JobSearchViewModel.Result.self) { result in
+                if let job = viewModel.job(for: result.id) {
+                    JobSearchDetailView(job: job, metadata: result)
+                        .environmentObject(usersViewModel)
+                } else {
+                    MissingSearchResultView()
+                }
+            }
         }
         .safeAreaInset(edge: .top) {
             Color.clear.frame(height: shellChromeHeight)
         }
         .onAppear {
             jobsViewModel.startSearchIndexForAllJobs()
-            updateShellChrome(for: viewModel.navigationPath)
+            updateChrome()
         }
-        .onChange(of: viewModel.navigationPath) { newValue in
-            updateShellChrome(for: newValue)
+        .onChange(of: navigationPath) { _ in
+            updateChrome()
         }
         .onDisappear {
             navigation.shouldShowShellChrome = true
         }
     }
 
-    // MARK: - Navigation
+    private func updateChrome() {
+        navigation.shouldShowShellChrome = navigationPath.isEmpty
+    }
 
-    @ViewBuilder
-    private func destinationView(for route: JobSearchViewModel.Route) -> some View {
-        if let destination = viewModel.destination(for: route) {
-            switch destination {
-            case .aggregate(let id):
-                AggregatedDetailView(aggregateID: id, viewModel: viewModel)
-                    .environmentObject(usersViewModel)
-            case .job(let jobDestination):
-                if let binding = jobDestination.binding {
-                    JobDetailView(job: binding)
-                } else {
-                    JobSearchDetailView(job: jobDestination.job)
-                }
-            }
+    private var header: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            Text("Job Search")
+                .font(JTTypography.screenTitle)
+                .foregroundStyle(JTColors.textPrimary)
+            Text("Look up any job across Cable South in seconds.")
+                .font(JTTypography.subheadline)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+    }
+
+    private var searchField: some View {
+        JTTextField("Address, job #, status, or teammate", text: $viewModel.query, icon: "magnifyingglass")
+            .textInputAutocapitalization(.never)
+            .disableAutocorrection(true)
+            .submitLabel(.search)
+    }
+}
+
+// MARK: - Quick Filters
+
+private struct QuickFiltersSection: View {
+    let filters: [JobSearchViewModel.QuickFilter]
+    var onSelect: (JobSearchViewModel.QuickFilter) -> Void
+
+    var body: some View {
+        if filters.isEmpty {
+            EmptyView()
         } else {
-            switch route {
-            case .aggregate:
-                MissingSearchDestinationView(message: "Job results are no longer available. Try running your search again.")
-            case .job:
-                MissingSearchDestinationView(message: "We couldn't load that job. It may have been removed.")
+            VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                Text("Quick filters")
+                    .font(JTTypography.subheadline)
+                    .foregroundStyle(JTColors.textSecondary)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: JTSpacing.sm) {
+                        ForEach(filters) { filter in
+                            Button {
+                                onSelect(filter)
+                            } label: {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack(spacing: JTSpacing.xs) {
+                                        Image(systemName: filter.iconSystemName)
+                                        Text(filter.title)
+                                    }
+                                    .font(JTTypography.caption)
+                                    .foregroundStyle(JTColors.textPrimary)
+
+                                    Text(filter.subtitle)
+                                        .font(JTTypography.caption)
+                                        .foregroundStyle(JTColors.textSecondary)
+                                }
+                                .padding(.vertical, 8)
+                                .padding(.horizontal, 12)
+                                .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
             }
         }
     }
 }
 
-// MARK: - Results
+// MARK: - Content States
 
-private struct JobSearchResultsContent: View {
-    let viewState: JobSearchViewModel.ResultsState
+private struct SearchContentView: View {
+    let state: JobSearchViewModel.ViewState
+    let resultsCount: Int
 
-    @ViewBuilder
     var body: some View {
-        switch viewState.content {
-        case .prompt:
-            VStack(spacing: JTSpacing.md) {
-                Spacer(minLength: 40)
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 42, weight: .semibold))
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(JTColors.textSecondary)
-                Text("Search all jobs")
-                    .font(JTTypography.title3)
-                    .foregroundStyle(JTColors.textPrimary)
-                Text("Type part of an address, job #, status (e.g. \"Completed\"), or the name of the person who added it — results include jobs from all users.")
-                    .multilineTextAlignment(.center)
-                    .font(JTTypography.body)
-                    .foregroundStyle(JTColors.textSecondary)
-                    .padding(.horizontal, JTSpacing.xl)
-                Spacer(minLength: 20)
-            }
+        switch state {
+        case .idle(let recents):
+            IdleSearchStateView(recents: recents)
         case .empty(let query):
-            VStack(spacing: JTSpacing.sm) {
-                Spacer(minLength: 40)
+            EmptyResultsView(query: query)
+        case .results(_, let items):
+            SearchResultsList(
+                title: "Results",
+                subtitle: "\(resultsCount) match\(resultsCount == 1 ? "" : "es")",
+                results: items
+            )
+        }
+    }
+}
+
+private struct IdleSearchStateView: View {
+    let recents: [JobSearchViewModel.Result]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xl) {
+            GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                      strokeColor: JTColors.glassSoftStroke,
+                      shadow: JTShadow.none) {
+                VStack(spacing: JTSpacing.md) {
+                    Image(systemName: "waveform.magnifyingglass")
+                        .font(.system(size: 42, weight: .semibold))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .frame(maxWidth: .infinity)
+
+                    Text("Search the entire company")
+                        .font(JTTypography.title3)
+                        .foregroundStyle(JTColors.textPrimary)
+                        .multilineTextAlignment(.center)
+
+                    Text("Type part of an address, job number, status, or teammate to explore every job in Job Tracker.")
+                        .font(JTTypography.body)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.vertical, JTSpacing.xl)
+                .padding(.horizontal, JTSpacing.xl)
+            }
+
+            if !recents.isEmpty {
+                SearchResultsList(
+                    title: "Recent activity",
+                    subtitle: "Jump back into the latest jobs from across your team.",
+                    results: recents
+                )
+            }
+        }
+    }
+}
+
+private struct SearchResultsList: View {
+    let title: String?
+    let subtitle: String?
+    let results: [JobSearchViewModel.Result]
+
+    init(title: String? = nil, subtitle: String? = nil, results: [JobSearchViewModel.Result]) {
+        self.title = title
+        self.subtitle = subtitle
+        self.results = results
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.md) {
+            if title != nil || subtitle != nil {
+                VStack(alignment: .leading, spacing: 2) {
+                    if let title {
+                        Text(title)
+                            .font(JTTypography.headline)
+                            .foregroundStyle(JTColors.textPrimary)
+                    }
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(JTTypography.caption)
+                            .foregroundStyle(JTColors.textSecondary)
+                    }
+                }
+            }
+
+            LazyVStack(spacing: JTSpacing.md) {
+                ForEach(results) { result in
+                    NavigationLink(value: result) {
+                        JobSearchResultRow(result: result)
+                            .contentShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+}
+
+private struct EmptyResultsView: View {
+    let query: String
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke,
+                  shadow: JTShadow.none) {
+            VStack(spacing: JTSpacing.md) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(JTColors.warning)
+
                 Text("No jobs found for “\(query)”")
                     .font(JTTypography.headline)
                     .foregroundStyle(JTColors.textPrimary)
-                Text("Try fewer keywords, or search by street, city, job #, status, or creator name.")
                     .multilineTextAlignment(.center)
+
+                Text("Try fewer keywords or search by street, city, job number, status, or teammate name.")
                     .font(JTTypography.body)
                     .foregroundStyle(JTColors.textSecondary)
-                    .padding(.horizontal, JTSpacing.xl)
-                Spacer(minLength: 20)
+                    .multilineTextAlignment(.center)
             }
-        case .aggregates(let aggregates):
-            JobSearchResultsList(aggregates: aggregates)
+            .padding(.vertical, JTSpacing.xl)
+            .padding(.horizontal, JTSpacing.xl)
         }
     }
 }
 
-private struct JobSearchResultsList: View {
-    let aggregates: [JobSearchViewModel.Aggregate]
+// MARK: - Result Row
 
-    var body: some View {
-        LazyVStack(spacing: JTSpacing.md) {
-            ForEach(aggregates) { aggregate in
-                NavigationLink(value: JobSearchViewModel.Route.aggregate(id: aggregate.id)) {
-                    JobSearchAggregateRow(aggregate: aggregate)
-                        .contentShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-}
-
-private struct JobSearchAggregateRow: View {
-    let aggregate: JobSearchViewModel.Aggregate
+private struct JobSearchResultRow: View {
+    let result: JobSearchViewModel.Result
 
     private func statusColor(_ status: String) -> Color {
-        switch status.lowercased() {
-        case "done", "completed": return JTColors.success
-        case "pending": return JTColors.warning
-        default: return JTColors.info
+        let lower = status.lowercased()
+        if lower.contains("done") || lower.contains("complete") {
+            return JTColors.success
         }
+        if lower.contains("pending") {
+            return JTColors.warning
+        }
+        if lower.contains("hold") || lower.contains("blocked") || lower.contains("issue") {
+            return JTColors.error
+        }
+        if lower.contains("need") {
+            return JTColors.info
+        }
+        return JTColors.accent
     }
 
     var body: some View {
         GlassCard(cornerRadius: JTShapes.smallCardCornerRadius,
                   strokeColor: JTColors.glassSoftStroke,
                   shadow: JTShadow.none) {
-            VStack(alignment: .leading, spacing: JTSpacing.sm) {
-                HStack(alignment: .firstTextBaseline) {
-                    Text(aggregate.address)
-                        .font(JTTypography.headline)
-                        .foregroundStyle(JTColors.textPrimary)
-                        .lineLimit(2)
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                HStack(alignment: .top, spacing: JTSpacing.sm) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(result.address.primary)
+                            .font(JTTypography.headline)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .lineLimit(2)
+
+                        if let secondary = result.address.secondary {
+                            Text(secondary)
+                                .font(JTTypography.caption)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .lineLimit(1)
+                        }
+                    }
                     Spacer(minLength: JTSpacing.sm)
-                    if !aggregate.jobNumber.isEmpty {
-                        Text("#\(aggregate.jobNumber)")
+                    if let jobNumber = result.jobNumber {
+                        Text("#\(jobNumber)")
                             .font(JTTypography.caption)
                             .padding(.vertical, 4)
                             .padding(.horizontal, 8)
@@ -183,340 +315,63 @@ private struct JobSearchAggregateRow: View {
                     }
                 }
 
-                if let recent = aggregate.jobs.first {
-                    HStack(spacing: JTSpacing.sm) {
-                        Label(recent.status, systemImage: "checkmark.seal")
-                            .font(JTTypography.caption)
-                            .foregroundStyle(statusColor(recent.status))
-                        Text(recent.date, style: .date)
-                            .font(JTTypography.caption)
-                            .foregroundStyle(JTColors.textSecondary)
-                    }
-                }
+                HStack(spacing: JTSpacing.sm) {
+                    Text(result.status)
+                        .font(JTTypography.caption)
+                        .fontWeight(.semibold)
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 8)
+                        .background(statusColor(result.status).opacity(0.15), in: Capsule())
+                        .foregroundStyle(statusColor(result.status))
 
-                if !aggregate.creators.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: JTSpacing.xs) {
-                            ForEach(aggregate.creators, id: \.id) { creator in
-                                Text(creator.displayName)
-                                    .font(JTTypography.caption)
-                                    .padding(.vertical, 4)
-                                    .padding(.horizontal, 8)
-                                    .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
-                                    .foregroundStyle(JTColors.textPrimary)
+                    Text(result.date, style: .date)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+
+                    if let creator = result.creator {
+                        Text("·")
+                            .foregroundStyle(JTColors.textMuted)
+                        Label {
+                            if let role = creator.role, !role.isEmpty {
+                                Text("Added by \(creator.name) · \(role)")
+                            } else {
+                                Text("Added by \(creator.name)")
                             }
+                        } icon: {
+                            Image(systemName: "person.crop.circle")
                         }
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .labelStyle(.titleAndIcon)
                     }
                 }
 
-                if aggregate.jobs.count > 1 {
-                    HStack(spacing: JTSpacing.xs) {
-                        Image(systemName: "square.stack.3d.down.right")
-                            .imageScale(.small)
-                            .foregroundStyle(JTColors.textSecondary)
-                        Text("\(aggregate.jobs.count) entries – latest shown")
+                if let snippet = result.snippet {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(snippet.title.uppercased())
                             .font(JTTypography.caption)
                             .foregroundStyle(JTColors.textSecondary)
+                        Text(snippet.value)
+                            .font(JTTypography.body)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .lineLimit(3)
                     }
+                }
+
+                if result.isOwnedByCurrentUser {
+                    Label("In your job list", systemImage: "checkmark.circle.fill")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.success)
                 }
             }
             .padding(JTSpacing.md)
         }
-        .overlay(
-            HStack {
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .foregroundStyle(JTColors.textMuted)
-                    .padding(.trailing, JTSpacing.md)
-            }
-            .allowsHitTesting(false)
-        )
     }
 }
 
-// MARK: - Row
+// MARK: - Missing Result
 
-private struct JobRow: View {
-    let job: Job
-    let creator: AppUser?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(job.address)
-                    .font(JTTypography.subheadline)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(JTColors.textPrimary)
-                    .lineLimit(2)
-                Spacer(minLength: 8)
-                if let num = job.jobNumber, !num.isEmpty {
-                    Text("#\(num)")
-                        .font(JTTypography.caption)
-                        .padding(.vertical, 3)
-                        .padding(.horizontal, 6)
-                        .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
-                        .foregroundStyle(JTColors.textPrimary)
-                }
-            }
-
-            HStack(spacing: 10) {
-                Label(job.status, systemImage: "checkmark.seal")
-                    .font(JTTypography.caption)
-                    .foregroundStyle(JTColors.textSecondary)
-                Text(job.date, style: .date)
-                    .font(JTTypography.caption)
-                    .foregroundStyle(JTColors.textSecondary)
-                if let creator {
-                    Text("·")
-                        .foregroundStyle(JTColors.textMuted)
-                    Text("\(creator.firstName) \(creator.lastName)")
-                        .font(JTTypography.caption)
-                        .foregroundStyle(JTColors.textSecondary)
-                }
-            }
-        }
-        .padding(.vertical, 6)
-    }
-}
-
-// MARK: - Aggregated Detail
-private struct AggregatedDetailView: View {
-    @EnvironmentObject var usersViewModel: UsersViewModel
-    let aggregateID: JobSearchViewModel.Aggregate.ID
-    @ObservedObject var viewModel: JobSearchViewModel
-
-    @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
-
-    @State private var isGeneratingShareLink = false
-    @State private var shareURL: URL? = nil
-    @State private var showShareSheet = false
-    @State private var shareErrorMessage: String? = nil
-    @State private var jobForShareSheet: Job? = nil
-
-    private var aggregate: JobSearchViewModel.Aggregate? {
-        viewModel.aggregate(forID: aggregateID)
-    }
-
-    private func primaryJob(for aggregate: JobSearchViewModel.Aggregate) -> Job? {
-        guard let id = aggregate.jobs.first?.id else { return nil }
-        return viewModel.job(forID: id)
-    }
-
-    private var shareErrorBinding: Binding<Bool> {
-        Binding(
-            get: { shareErrorMessage != nil },
-            set: { newValue in
-                if !newValue { shareErrorMessage = nil }
-            }
-        )
-    }
-
-    private func creator(for job: JobSearchViewModel.Aggregate.JobDigest) -> AppUser? {
-        guard let id = job.createdBy else { return nil }
-        return usersViewModel.usersDict[id]
-    }
-
-    private func openInMaps(job: Job) {
-        guard let encoded = job.address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
-        if suggestionProviderRaw == "google" {
-            if let url = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") {
-                UIApplication.shared.open(url, options: [:]) { success in
-                    if success { return }
-                    if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
-                        UIApplication.shared.open(appleURL)
-                    }
-                }
-                return
-            }
-        }
-        if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
-            UIApplication.shared.open(appleURL)
-        }
-    }
-
-    private func share(job: Job) {
-        guard !isGeneratingShareLink else { return }
-        shareErrorMessage = nil
-        jobForShareSheet = nil
-        shareURL = nil
-        isGeneratingShareLink = true
-
-        Task {
-            do {
-                let url = try await SharedJobService.shared.publishShareLink(job: job)
-                await MainActor.run {
-                    shareURL = url
-                    jobForShareSheet = job
-                    isGeneratingShareLink = false
-                    showShareSheet = true
-                }
-            } catch {
-                await MainActor.run {
-                    shareErrorMessage = error.localizedDescription
-                    jobForShareSheet = nil
-                    isGeneratingShareLink = false
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func quickActions(for job: Job) -> some View {
-        HStack(spacing: JTSpacing.sm) {
-            Button {
-                openInMaps(job: job)
-            } label: {
-                HStack(spacing: JTSpacing.xs) {
-                    Image(systemName: "map")
-                    Text("Directions")
-                }
-                .font(JTTypography.caption)
-                .foregroundStyle(JTColors.textPrimary)
-                .padding(.vertical, JTSpacing.xs)
-                .padding(.horizontal, JTSpacing.sm)
-                .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
-            }
-            .buttonStyle(.plain)
-
-            Button {
-                share(job: job)
-            } label: {
-                HStack(spacing: JTSpacing.xs) {
-                    if isGeneratingShareLink {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .tint(JTColors.textPrimary)
-                    } else {
-                        Image(systemName: "square.and.arrow.up")
-                    }
-                    Text("Share")
-                }
-                .font(JTTypography.caption)
-                .foregroundStyle(JTColors.textPrimary)
-                .padding(.vertical, JTSpacing.xs)
-                .padding(.horizontal, JTSpacing.sm)
-                .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
-            }
-            .buttonStyle(.plain)
-            .disabled(isGeneratingShareLink)
-        }
-    }
-
-    @ViewBuilder
-    private func content(for aggregate: JobSearchViewModel.Aggregate) -> some View {
-        ZStack(alignment: .top) {
-            JTGradients.background
-                .ignoresSafeArea()
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: JTSpacing.lg) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(aggregate.address)
-                            .font(JTTypography.screenTitle)
-                            .foregroundStyle(JTColors.textPrimary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        if !aggregate.jobNumber.isEmpty {
-                            Text("#\(aggregate.jobNumber)")
-                                .font(JTTypography.caption)
-                                .padding(.vertical, 4)
-                                .padding(.horizontal, 8)
-                                .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
-                                .foregroundStyle(JTColors.textPrimary)
-                        }
-
-                        if !aggregate.creators.isEmpty {
-                            HStack(spacing: JTSpacing.xs) {
-                                Image(systemName: "person.2")
-                                    .foregroundStyle(JTColors.textSecondary)
-                                Text("\(aggregate.creators.count) contributor\(aggregate.creators.count == 1 ? "" : "s")")
-                                    .foregroundStyle(JTColors.textSecondary)
-                                    .font(JTTypography.subheadline)
-                            }
-                        }
-
-                        if let job = primaryJob(for: aggregate) {
-                            quickActions(for: job)
-                                .padding(.top, JTSpacing.sm)
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: JTSpacing.md) {
-                        ForEach(aggregate.jobs, id: \.id) { entry in
-                            NavigationLink(value: JobSearchViewModel.Route.job(id: entry.id)) {
-                                GlassCard(cornerRadius: JTShapes.smallCardCornerRadius,
-                                          strokeColor: JTColors.glassSoftStroke,
-                                          shadow: JTShadow.none) {
-                                    VStack(alignment: .leading, spacing: JTSpacing.sm) {
-                                        HStack(alignment: .firstTextBaseline) {
-                                            Text(entry.status)
-                                                .font(JTTypography.headline)
-                                                .foregroundStyle(JTColors.textPrimary)
-                                            Spacer()
-                                            Text(entry.date, style: .date)
-                                                .font(JTTypography.caption)
-                                                .foregroundStyle(JTColors.textSecondary)
-                                        }
-
-                                        if let u = creator(for: entry) {
-                                            HStack(spacing: JTSpacing.xs) {
-                                                Image(systemName: "person.crop.circle")
-                                                Text("\(u.firstName) \(u.lastName)")
-                                            }
-                                            .font(JTTypography.caption)
-                                            .foregroundStyle(JTColors.textSecondary)
-                                        }
-                                    }
-                                    .padding(JTSpacing.md)
-                                }
-                                .overlay(
-                                    HStack {
-                                        Spacer()
-                                        Image(systemName: "chevron.right")
-                                            .font(.caption)
-                                            .foregroundStyle(JTColors.textMuted)
-                                            .padding(.trailing, JTSpacing.md)
-                                    }
-                                    .allowsHitTesting(false)
-                                )
-                                .contentShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                }
-                .padding(JTSpacing.lg)
-            }
-        }
-    }
-
-    var body: some View {
-        Group {
-            if let aggregate {
-                content(for: aggregate)
-            } else {
-                MissingSearchDestinationView(message: "Job results are no longer available. Try running your search again.")
-            }
-        }
-        .navigationBarTitleDisplayMode(.inline)
-        .sheet(isPresented: $showShareSheet, onDismiss: { shareURL = nil; jobForShareSheet = nil }) {
-            if let url = shareURL {
-                let subject = jobForShareSheet?.shortAddress ?? aggregate?.address ?? "Job"
-                ActivityView(activityItems: [url], subject: "Job link for \(subject)")
-            }
-        }
-        .alert("Couldn't Share Job", isPresented: shareErrorBinding, actions: {
-            Button("OK", role: .cancel) { shareErrorMessage = nil }
-        }, message: {
-            if let message = shareErrorMessage {
-                Text(message)
-            }
-        })
-    }
-}
-
-private struct MissingSearchDestinationView: View {
-    let message: String
-
+private struct MissingSearchResultView: View {
     var body: some View {
         ZStack {
             JTGradients.background
@@ -524,89 +379,20 @@ private struct MissingSearchDestinationView: View {
 
             VStack(spacing: JTSpacing.md) {
                 Image(systemName: "exclamationmark.triangle")
-                    .font(.system(size: 28, weight: .semibold))
+                    .font(.system(size: 32, weight: .semibold))
                     .foregroundStyle(JTColors.warning)
 
-                Text(message)
-                    .multilineTextAlignment(.center)
+                Text("Job unavailable")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Text("We couldn’t load that job. It may have been removed or you no longer have access to it.")
                     .font(JTTypography.body)
                     .foregroundStyle(JTColors.textSecondary)
+                    .multilineTextAlignment(.center)
                     .padding(.horizontal, JTSpacing.lg)
             }
             .padding(.horizontal, JTSpacing.lg)
         }
     }
 }
-
-// MARK: - Matching Helpers
-
-struct JobSearchMatcher {
-    static func matches(job: JobSearchMatchable, query: String, creator: AppUser?) -> Bool {
-        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let tokens = normalizedQuery
-            .split { $0.isWhitespace }
-            .map { String($0).lowercased() }
-
-        guard !tokens.isEmpty else { return false }
-
-        let haystack = normalizedHaystack(for: job, creator: creator)
-        return tokens.allSatisfy { haystack.contains($0) }
-    }
-
-    private static func normalizedHaystack(for job: JobSearchMatchable, creator: AppUser?) -> String {
-        var fields: [String] = []
-
-        if let address = normalizedNonEmpty(job.address) {
-            fields.append(address)
-        }
-
-        if let jobNumber = normalizedNonEmpty(job.jobNumber) {
-            fields.append(jobNumber)
-        }
-
-        if let status = normalizedNonEmpty(job.status) {
-            fields.append(status)
-        }
-
-        if let creator,
-           let creatorName = normalizedNonEmpty("\(creator.firstName) \(creator.lastName)") {
-            fields.append(creatorName)
-        }
-
-        if let date = normalizedNonEmpty(
-            DateFormatter.localizedString(from: job.date, dateStyle: .short, timeStyle: .none)
-        ) {
-            fields.append(date)
-        }
-
-        let optionalFields: [String?] = [
-            job.notes,
-            job.materialsUsed,
-            job.assignments,
-            job.nidFootage,
-            job.canFootage
-        ]
-
-        for field in optionalFields {
-            if let normalized = normalizedNonEmpty(field) {
-                fields.append(normalized)
-            }
-        }
-
-        return fields.joined(separator: " ")
-    }
-
-    private static func normalizedNonEmpty(_ value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return trimmed.lowercased()
-    }
-
-    private static func normalizedNonEmpty(_ value: String?) -> String? {
-        guard let value = value else { return nil }
-        return normalizedNonEmpty(value)
-    }
-}
-
-// MARK: - Hashable support
-

--- a/Job Tracker/Features/Search/JobSearchViewModel.swift
+++ b/Job Tracker/Features/Search/JobSearchViewModel.swift
@@ -3,122 +3,111 @@ import Combine
 
 @MainActor
 final class JobSearchViewModel: ObservableObject {
-    struct Aggregate: Identifiable, Hashable {
-        struct Creator: Identifiable, Hashable {
-            let id: String
-            let firstName: String
-            let lastName: String
-
-            var displayName: String {
-                "\(firstName) \(lastName)".trimmingCharacters(in: .whitespaces)
-            }
+    struct Result: Identifiable, Hashable, Equatable {
+        struct Address: Hashable, Equatable {
+            let primary: String
+            let secondary: String?
         }
 
-        struct JobDigest: Identifiable, Hashable {
+        struct Creator: Hashable, Equatable {
             let id: String
-            let status: String
-            let date: Date
-            let createdBy: String?
+            let name: String
+            let role: String?
+        }
+
+        struct DetailSnippet: Hashable, Equatable {
+            let title: String
+            let value: String
         }
 
         let id: String
-        let address: String
-        let jobNumber: String
-        let jobs: [JobDigest]
-        let creators: [Creator]
-
-        var mostRecentJob: JobDigest? { jobs.first }
+        let address: Address
+        let jobNumber: String?
+        let status: String
+        let date: Date
+        let creator: Creator?
+        let snippet: DetailSnippet?
+        let isOwnedByCurrentUser: Bool
     }
 
-    enum Route: Hashable {
-        case aggregate(id: String)
-        case job(id: String)
-    }
-
-    struct JobDestination {
-        let job: Job
-        let binding: Binding<Job>?
-    }
-
-    enum RouteDestination {
-        case aggregate(id: String)
-        case job(JobDestination)
-    }
-
-    struct ResultsState {
-        enum Content {
-            case prompt
-            case empty(query: String)
-            case aggregates([Aggregate])
+    struct QuickFilter: Identifiable, Hashable, Equatable {
+        enum Kind: Hashable {
+            case status
+            case creator
         }
 
-        let content: Content
+        let kind: Kind
+        let value: String
+        let count: Int
+
+        var id: String {
+            "\(kind)-\(value.lowercased())"
+        }
+
+        var iconSystemName: String {
+            switch kind {
+            case .status: return "tag"
+            case .creator: return "person.2"
+            }
+        }
+
+        var title: String { value }
+
+        var subtitle: String {
+            "\(count) job\(count == 1 ? "" : "s")"
+        }
+
+        var suggestedQuery: String { value }
+    }
+
+    enum ViewState: Equatable {
+        case idle(recents: [Result])
+        case empty(query: String)
+        case results(query: String, items: [Result])
     }
 
     @Published var query: String = ""
-    @Published private(set) var aggregates: [Aggregate] = []
-    @Published private(set) var resultsState: ResultsState = .init(content: .prompt)
-    @Published var navigationPath: [Route] = []
+    @Published private(set) var viewState: ViewState = .idle(recents: [])
+    @Published private(set) var resultsCount: Int = 0
+    @Published private(set) var quickFilters: [QuickFilter] = []
 
     private let jobsViewModel: JobsViewModel
     private let usersViewModel: UsersViewModel
 
-    private var aggregateLookup: [String: Aggregate] = [:]
-    private var jobLookup: [String: Job] = [:]
     private var cancellables: Set<AnyCancellable> = []
+    private var jobLookup: [String: Job] = [:]
+    private var resultLookup: [String: Result] = [:]
+    private var searchTask: Task<Void, Never>? = nil
 
     init(jobsViewModel: JobsViewModel, usersViewModel: UsersViewModel) {
         self.jobsViewModel = jobsViewModel
         self.usersViewModel = usersViewModel
 
         configureSubscriptions()
-        rebuildAggregates()
+        rebuildResults()
     }
 
-    func aggregate(forID id: String) -> Aggregate? {
-        aggregateLookup[id]
-    }
-
-    func destination(for route: Route) -> RouteDestination? {
-        switch route {
-        case .aggregate(let id):
-            guard aggregateLookup[id] != nil else { return nil }
-            return .aggregate(id: id)
-        case .job(let id):
-            guard let job = job(forID: id) else { return nil }
-            return .job(JobDestination(job: job, binding: binding(for: job)))
-        }
-    }
-
-    func job(forID id: String) -> Job? {
+    func job(for id: String) -> Job? {
         if let cached = jobLookup[id] {
             return cached
         }
+
         if let job = jobsViewModel.jobs.first(where: { $0.id == id }) {
+            jobLookup[id] = job
             return job
         }
+
         if let entry = jobsViewModel.searchJobs.first(where: { $0.id == id }) {
-            return entry.makePartialJob()
+            let partial = entry.makePartialJob()
+            jobLookup[id] = partial
+            return partial
         }
+
         return nil
     }
 
-    private func binding(for job: Job) -> Binding<Job>? {
-        guard jobsViewModel.jobs.contains(where: { $0.id == job.id }) else { return nil }
-        return Binding(
-            get: { [weak self] in
-                guard let self else { return job }
-                return self.jobsViewModel.jobs.first(where: { $0.id == job.id }) ?? job
-            },
-            set: { [weak self] newValue in
-                guard let self else { return }
-                if let index = self.jobsViewModel.jobs.firstIndex(where: { $0.id == job.id }) {
-                    var copy = self.jobsViewModel.jobs
-                    copy[index] = newValue
-                    self.jobsViewModel.jobs = copy
-                }
-            }
-        )
+    func result(for id: String) -> Result? {
+        resultLookup[id]
     }
 
     private func configureSubscriptions() {
@@ -126,139 +115,325 @@ final class JobSearchViewModel: ObservableObject {
             .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
             .removeDuplicates()
             .sink { [weak self] _ in
-                self?.rebuildAggregates()
-            }
-            .store(in: &cancellables)
-
-        jobsViewModel.$jobs
-            .sink { [weak self] _ in
-                self?.rebuildAggregates()
+                self?.rebuildResults()
             }
             .store(in: &cancellables)
 
         jobsViewModel.$searchJobs
             .sink { [weak self] _ in
-                self?.rebuildAggregates()
+                self?.rebuildResults()
+            }
+            .store(in: &cancellables)
+
+        jobsViewModel.$jobs
+            .sink { [weak self] _ in
+                self?.rebuildResults()
             }
             .store(in: &cancellables)
 
         usersViewModel.$usersDict
             .sink { [weak self] _ in
-                self?.rebuildAggregates()
+                self?.rebuildResults()
             }
             .store(in: &cancellables)
     }
 
-    private func rebuildAggregates() {
+    private func rebuildResults() {
+        searchTask?.cancel()
+
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tokens = Self.normalizedTokens(from: trimmedQuery)
         let users = usersViewModel.usersDict
-        let searchJobs = jobsViewModel.searchJobs
-        let jobs = jobsViewModel.jobs
+        let ownedJobs = jobsViewModel.jobs
+        let searchEntries = jobsViewModel.searchJobs
 
-        guard !trimmedQuery.isEmpty else {
-            var lookup: [String: Job] = [:]
-            for job in jobs {
-                lookup[job.id] = job
-            }
-            for entry in searchJobs {
-                if lookup[entry.id] == nil {
-                    lookup[entry.id] = entry.makePartialJob()
-                }
-            }
-
-            aggregates = []
-            aggregateLookup = [:]
-            jobLookup = lookup
-            resultsState = .init(content: .prompt)
-            return
+        let indexEntries: [JobSearchIndexEntry]
+        if searchEntries.isEmpty {
+            indexEntries = ownedJobs.map(JobSearchIndexEntry.init(job:))
+        } else {
+            indexEntries = searchEntries
         }
 
-        let source = searchJobs.isEmpty ? jobs.map(JobSearchIndexEntry.init(job:)) : searchJobs
+        quickFilters = Self.buildQuickFilters(from: indexEntries, users: users)
 
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let filtered = source
-                .filter { job in
-                    let creator = job.createdBy.flatMap { users[$0] }
-                    return JobSearchMatcher.matches(job: job, query: trimmedQuery, creator: creator)
-                }
-                .sorted { lhs, rhs in
-                    if lhs.date != rhs.date {
-                        return lhs.date > rhs.date
-                    }
-                    return lhs.address.localizedCaseInsensitiveCompare(rhs.address) == .orderedAscending
-                }
+        let ownedIDs = Set(ownedJobs.map { $0.id })
+        let baseLookup = Dictionary(uniqueKeysWithValues: ownedJobs.map { ($0.id, $0) })
 
-            let aggregates = Self.buildAggregates(from: filtered, users: users)
-            let aggregateLookup = Dictionary(uniqueKeysWithValues: aggregates.map { ($0.id, $0) })
+        searchTask = Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            if Task.isCancelled { return }
 
-            var jobLookup: [String: Job] = [:]
-            for job in jobs {
-                jobLookup[job.id] = job
-            }
-            for entry in filtered {
-                if jobLookup[entry.id] == nil {
-                    jobLookup[entry.id] = entry.makePartialJob()
-                }
-            }
-            for entry in searchJobs {
-                if jobLookup[entry.id] == nil {
-                    jobLookup[entry.id] = entry.makePartialJob()
-                }
-            }
+            let searchOutcome = Self.performSearch(
+                tokens: tokens,
+                trimmedQuery: trimmedQuery,
+                indexEntries: indexEntries,
+                users: users,
+                ownedIDs: ownedIDs,
+                baseLookup: baseLookup
+            )
 
-            let resultsState: ResultsState
-            if aggregates.isEmpty {
-                resultsState = .init(content: .empty(query: trimmedQuery))
-            } else {
-                resultsState = .init(content: .aggregates(aggregates))
-            }
+            if Task.isCancelled { return }
 
             await MainActor.run {
-                guard let self = self else { return }
-                self.aggregates = aggregates
-                self.aggregateLookup = aggregateLookup
-                self.jobLookup = jobLookup
-                self.resultsState = resultsState
+                guard !Task.isCancelled else { return }
+                self.jobLookup = searchOutcome.lookup
+                self.resultLookup = searchOutcome.resultLookup
+                self.viewState = searchOutcome.state
+                self.resultsCount = searchOutcome.count
             }
         }
     }
 
-    private nonisolated static func buildAggregates<T: JobSearchMatchable>(from jobs: [T], users: [String: AppUser]) -> [Aggregate] {
-        let grouped = Dictionary(grouping: jobs) { job -> String in
-            let number = (job.jobNumber ?? "").trimmingCharacters(in: .whitespaces)
-            return job.address.lowercased() + "|#" + number.lowercased()
-        }
+    private static func performSearch(
+        tokens: [String],
+        trimmedQuery: String,
+        indexEntries: [JobSearchIndexEntry],
+        users: [String: AppUser],
+        ownedIDs: Set<String>,
+        baseLookup: [String: Job]
+    ) -> (results: [Result], resultLookup: [String: Result], lookup: [String: Job], state: ViewState, count: Int) {
+        var lookup = baseLookup
 
-        let aggregates: [Aggregate] = grouped.map { key, jobs in
-            let address = jobs.first?.address ?? ""
-            let jobNumber = (jobs.first?.jobNumber ?? "").trimmingCharacters(in: .whitespaces)
-            let ordered = jobs.sorted { $0.date > $1.date }
-
-            var seenCreators: Set<String> = []
-            let creators: [Aggregate.Creator] = ordered.compactMap { job in
-                guard let id = job.createdBy, !seenCreators.contains(id), let user = users[id] else {
-                    return nil
+        if tokens.isEmpty {
+            let sortedEntries = indexEntries.sorted { lhs, rhs in
+                if lhs.date != rhs.date {
+                    return lhs.date > rhs.date
                 }
-                seenCreators.insert(id)
-                return Aggregate.Creator(id: user.id, firstName: user.firstName, lastName: user.lastName)
-            }
-
-            let digests = ordered.map { job in
-                Aggregate.JobDigest(id: job.id, status: job.status, date: job.date, createdBy: job.createdBy)
-            }
-
-            return Aggregate(id: key, address: address, jobNumber: jobNumber, jobs: digests, creators: creators)
-        }
-
-        return aggregates.sorted { lhs, rhs in
-            guard let leftDate = lhs.jobs.first?.date, let rightDate = rhs.jobs.first?.date else {
                 return lhs.address.localizedCaseInsensitiveCompare(rhs.address) == .orderedAscending
             }
 
-            if leftDate != rightDate {
-                return leftDate > rightDate
+            let limitedEntries = Array(sortedEntries.prefix(12))
+            let results = buildResults(from: limitedEntries, users: users, ownedIDs: ownedIDs, tokens: tokens)
+            for entry in limitedEntries where lookup[entry.id] == nil {
+                lookup[entry.id] = entry.makePartialJob()
+            }
+            let lookupResults = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
+            return (results, lookupResults, lookup, .idle(recents: results), 0)
+        }
+
+        let filteredEntries = indexEntries.filter { entry in
+            let creator = entry.createdBy.flatMap { users[$0] }
+            return matches(job: entry, tokens: tokens, creator: creator)
+        }
+
+        let orderedEntries = filteredEntries.sorted { lhs, rhs in
+            if lhs.date != rhs.date {
+                return lhs.date > rhs.date
             }
             return lhs.address.localizedCaseInsensitiveCompare(rhs.address) == .orderedAscending
         }
+
+        let results = buildResults(from: orderedEntries, users: users, ownedIDs: ownedIDs, tokens: tokens)
+        for entry in orderedEntries where lookup[entry.id] == nil {
+            lookup[entry.id] = entry.makePartialJob()
+        }
+        let lookupResults = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
+
+        if results.isEmpty {
+            return (results, lookupResults, lookup, .empty(query: trimmedQuery), 0)
+        }
+
+        return (results, lookupResults, lookup, .results(query: trimmedQuery, items: results), results.count)
+    }
+
+    private static func buildResults(
+        from entries: [JobSearchIndexEntry],
+        users: [String: AppUser],
+        ownedIDs: Set<String>,
+        tokens: [String]
+    ) -> [Result] {
+        entries.map { entry in
+            let creatorUser = entry.createdBy.flatMap { users[$0] }
+            return buildResult(entry: entry, creator: creatorUser, ownedIDs: ownedIDs, tokens: tokens)
+        }
+    }
+
+    private static func buildResult(
+        entry: JobSearchIndexEntry,
+        creator: AppUser?,
+        ownedIDs: Set<String>,
+        tokens: [String]
+    ) -> Result {
+        let addressComponents = entry.address
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        let primaryAddress = addressComponents.first ?? entry.address.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondaryAddress = addressComponents.dropFirst().joined(separator: ", ")
+
+        let creatorModel: Result.Creator?
+        if let creator {
+            let name = displayName(for: creator)
+            let role = displayValue(creator.normalizedPosition)
+            creatorModel = Result.Creator(id: creator.id, name: name, role: role)
+        } else {
+            creatorModel = nil
+        }
+
+        let snippet = snippet(for: entry, tokens: tokens)
+
+        return Result(
+            id: entry.id,
+            address: .init(
+                primary: primaryAddress.isEmpty ? entry.address : primaryAddress,
+                secondary: secondaryAddress.isEmpty ? nil : secondaryAddress
+            ),
+            jobNumber: displayValue(entry.jobNumber),
+            status: entry.status.trimmingCharacters(in: .whitespacesAndNewlines),
+            date: entry.date,
+            creator: creatorModel,
+            snippet: snippet,
+            isOwnedByCurrentUser: ownedIDs.contains(entry.id)
+        )
+    }
+
+    private static func snippet(for entry: JobSearchIndexEntry, tokens: [String]) -> Result.DetailSnippet? {
+        let candidates: [(String, String?)] = [
+            ("Notes", entry.notes),
+            ("Materials", entry.materialsUsed),
+            ("Assignments", entry.assignments),
+            ("NID Footage", entry.nidFootage),
+            ("CAN Footage", entry.canFootage)
+        ]
+
+        for (title, rawValue) in candidates {
+            guard let displayText = displayValue(rawValue) else { continue }
+            if tokens.isEmpty {
+                return Result.DetailSnippet(title: title, value: displayText)
+            }
+
+            let normalized = displayText.lowercased()
+            if tokens.contains(where: { normalized.contains($0) }) {
+                return Result.DetailSnippet(title: title, value: displayText)
+            }
+        }
+
+        return nil
+    }
+
+    private static func matches(job: JobSearchMatchable, tokens: [String], creator: AppUser?) -> Bool {
+        guard !tokens.isEmpty else { return true }
+
+        var haystackParts: [String] = []
+
+        if let normalized = normalizedNonEmpty(job.address) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.jobNumber) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.status) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.notes) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.assignments) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.materialsUsed) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.nidFootage) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.canFootage) {
+            haystackParts.append(normalized)
+        }
+
+        let dateString = DateFormatter.localizedString(from: job.date, dateStyle: .short, timeStyle: .none)
+        if let normalized = normalizedNonEmpty(dateString) {
+            haystackParts.append(normalized)
+        }
+
+        if let creator {
+            let name = displayName(for: creator).lowercased()
+            if !name.isEmpty {
+                haystackParts.append(name)
+            }
+            if let role = normalizedNonEmpty(creator.normalizedPosition) {
+                haystackParts.append(role)
+            }
+        }
+
+        let haystack = haystackParts.joined(separator: " ")
+        return tokens.allSatisfy { haystack.contains($0) }
+    }
+
+    private static func buildQuickFilters(from entries: [JobSearchIndexEntry], users: [String: AppUser]) -> [QuickFilter] {
+        guard !entries.isEmpty else { return [] }
+
+        var statusCounts: [String: (display: String, count: Int)] = [:]
+        var creatorCounts: [String: (display: String, count: Int)] = [:]
+
+        for entry in entries {
+            let status = entry.status.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !status.isEmpty {
+                let key = status.lowercased()
+                if var existing = statusCounts[key] {
+                    existing.count += 1
+                    statusCounts[key] = existing
+                } else {
+                    statusCounts[key] = (status, 1)
+                }
+            }
+
+            if let creatorID = entry.createdBy, let user = users[creatorID] {
+                let name = displayName(for: user)
+                guard !name.isEmpty else { continue }
+                let key = name.lowercased()
+                if var existing = creatorCounts[key] {
+                    existing.count += 1
+                    creatorCounts[key] = existing
+                } else {
+                    creatorCounts[key] = (name, 1)
+                }
+            }
+        }
+
+        let topStatuses = statusCounts.values
+            .sorted { lhs, rhs in
+                if lhs.count != rhs.count {
+                    return lhs.count > rhs.count
+                }
+                return lhs.display.localizedCaseInsensitiveCompare(rhs.display) == .orderedAscending
+            }
+            .prefix(4)
+            .map { QuickFilter(kind: .status, value: $0.display, count: $0.count) }
+
+        let topCreators = creatorCounts.values
+            .sorted { lhs, rhs in
+                if lhs.count != rhs.count {
+                    return lhs.count > rhs.count
+                }
+                return lhs.display.localizedCaseInsensitiveCompare(rhs.display) == .orderedAscending
+            }
+            .prefix(4)
+            .map { QuickFilter(kind: .creator, value: $0.display, count: $0.count) }
+
+        let combined = topStatuses + topCreators
+        return Array(combined.prefix(8))
+    }
+
+    private static func normalizedTokens(from query: String) -> [String] {
+        query
+            .split(whereSeparator: { $0.isWhitespace })
+            .map { $0.lowercased() }
+    }
+
+    private static func normalizedNonEmpty(_ value: String?) -> String? {
+        guard let value = value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func displayValue(_ value: String?) -> String? {
+        guard let value = value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func displayName(for user: AppUser) -> String {
+        "\(user.firstName) \(user.lastName)".trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## Summary
- replace the search view model with streamlined result types, quick filters, and async matching so searches span the full dataset consistently
- redesign the job search screen with a hero header, quick filter chips, contextual empty/idle states, and a tappable results list for every user’s jobs
- rebuild the job detail surface shown from search with glass cards, quick share/maps actions, rich metadata sections, and refreshed photo thumbnails

## Testing
- not run (Xcode tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf097775a0832da4f193fe5dc36a13