### PR TITLE
Fix JobSearchViewModel actor isolation

### DIFF
--- a/Job Tracker/Features/Search/JobSearchViewModel.swift
+++ b/Job Tracker/Features/Search/JobSearchViewModel.swift
@@ -184,7 +184,7 @@ final class JobSearchViewModel: ObservableObject {
         }
     }
 
-    private static func performSearch(
+    private nonisolated static func performSearch(
         tokens: [String],
         trimmedQuery: String,
         indexEntries: [JobSearchIndexEntry],
@@ -236,7 +236,7 @@ final class JobSearchViewModel: ObservableObject {
         return (results, lookupResults, lookup, .results(query: trimmedQuery, items: results), results.count)
     }
 
-    private static func buildResults(
+    private nonisolated static func buildResults(
         from entries: [JobSearchIndexEntry],
         users: [String: AppUser],
         ownedIDs: Set<String>,
@@ -248,7 +248,7 @@ final class JobSearchViewModel: ObservableObject {
         }
     }
 
-    private static func buildResult(
+    private nonisolated static func buildResult(
         entry: JobSearchIndexEntry,
         creator: AppUser?,
         ownedIDs: Set<String>,
@@ -287,7 +287,7 @@ final class JobSearchViewModel: ObservableObject {
         )
     }
 
-    private static func snippet(for entry: JobSearchIndexEntry, tokens: [String]) -> Result.DetailSnippet? {
+    private nonisolated static func snippet(for entry: JobSearchIndexEntry, tokens: [String]) -> Result.DetailSnippet? {
         let candidates: [(String, String?)] = [
             ("Notes", entry.notes),
             ("Materials", entry.materialsUsed),
@@ -311,7 +311,7 @@ final class JobSearchViewModel: ObservableObject {
         return nil
     }
 
-    private static func matches(job: JobSearchMatchable, tokens: [String], creator: AppUser?) -> Bool {
+    private nonisolated static func matches(job: JobSearchMatchable, tokens: [String], creator: AppUser?) -> Bool {
         guard !tokens.isEmpty else { return true }
 
         var haystackParts: [String] = []
@@ -421,19 +421,19 @@ final class JobSearchViewModel: ObservableObject {
             .map { $0.lowercased() }
     }
 
-    private static func normalizedNonEmpty(_ value: String?) -> String? {
+    private nonisolated static func normalizedNonEmpty(_ value: String?) -> String? {
         guard let value = value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private static func displayValue(_ value: String?) -> String? {
+    private nonisolated static func displayValue(_ value: String?) -> String? {
         guard let value = value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private static func displayName(for user: AppUser) -> String {
+    private nonisolated static func displayName(for user: AppUser) -> String {
         "\(user.firstName) \(user.lastName)".trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## Summary
- mark pure search helper methods as nonisolated so they can run off the main actor
- allow the detached search task to reuse these helpers without actor isolation violations

## Testing
- Not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68cf0e1f5f88832d831c8d88899aaeb3