### PR TITLE
Add admin panel management tools and tests

### DIFF
--- a/Job Tracker/Features/Admin/AdminPanelViewModel.swift
+++ b/Job Tracker/Features/Admin/AdminPanelViewModel.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Combine
+
+protocol AdminPanelService: AnyObject {
+    func updateUserFlags(
+        uid: String,
+        isAdmin: Bool,
+        isSupervisor: Bool,
+        completion: @escaping (Result<Void, Error>) -> Void
+    )
+
+    func adminBackfillParticipantsForAllJobs(
+        progress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?,
+        completion: @escaping (Result<Int, Error>) -> Void
+    )
+
+    func refreshCustomClaims(for uid: String?, completion: ((Error?) -> Void)?)
+}
+
+@MainActor
+final class AdminPanelViewModel: ObservableObject {
+    struct AlertItem: Identifiable, Equatable {
+        enum Kind: Equatable {
+            case success
+            case error
+        }
+
+        let id = UUID()
+        let title: String
+        let message: String
+        let kind: Kind
+    }
+
+    struct MaintenanceStatus: Equatable {
+        struct Progress: Equatable {
+            let processed: Int
+            let total: Int
+            let message: String
+
+            var fractionComplete: Double? {
+                guard total > 0 else { return nil }
+                return Double(processed) / Double(total)
+            }
+        }
+
+        var isRunning: Bool = false
+        var progress: Progress? = nil
+        var lastRunCount: Int? = nil
+        var lastErrorMessage: String? = nil
+
+        static var idle: MaintenanceStatus { MaintenanceStatus() }
+    }
+
+    @Published private(set) var roster: [AppUser]
+    @Published private(set) var updatingAdminIDs: Set<String> = []
+    @Published private(set) var updatingSupervisorIDs: Set<String> = []
+    @Published var alert: AlertItem?
+    @Published private(set) var maintenanceStatus: MaintenanceStatus = .idle
+
+    var onUserFlagsUpdated: ((String) -> Void)?
+
+    private let service: AdminPanelService
+    private let currentUserIDProvider: () -> String?
+    private var rosterCancellable: AnyCancellable?
+    private var observedUsersViewModel: UsersViewModel?
+
+    init(
+        service: AdminPanelService = FirebaseService.shared,
+        currentUserIDProvider: @escaping () -> String? = { FirebaseService.shared.currentUserID() },
+        initialRoster: [AppUser] = [],
+        usersPublisher: AnyPublisher<[AppUser], Never>? = nil
+    ) {
+        self.service = service
+        self.currentUserIDProvider = currentUserIDProvider
+        self.roster = initialRoster.sorted { lhs, rhs in
+            lhs.lastName.lowercased() < rhs.lastName.lowercased()
+        }
+
+        if let publisher = usersPublisher {
+            subscribe(to: publisher)
+        }
+    }
+
+    func attach(usersViewModel: UsersViewModel) {
+        if let observed = observedUsersViewModel, observed === usersViewModel { return }
+        observedUsersViewModel = usersViewModel
+        roster = usersViewModel.allUsers
+        let publisher = usersViewModel.$usersDict
+            .map { dict in
+                dict.values.sorted { lhs, rhs in
+                    lhs.lastName.lowercased() < rhs.lastName.lowercased()
+                }
+            }
+            .eraseToAnyPublisher()
+        subscribe(to: publisher)
+    }
+
+    func refreshRosterSnapshot() {
+        if let observedUsersViewModel {
+            roster = observedUsersViewModel.allUsers
+        }
+    }
+
+    func setAdmin(_ isAdmin: Bool, for user: AppUser) {
+        updateFlags(for: user, admin: isAdmin, supervisor: user.isSupervisor, changedFlag: .admin)
+    }
+
+    func setSupervisor(_ isSupervisor: Bool, for user: AppUser) {
+        updateFlags(for: user, admin: user.isAdmin, supervisor: isSupervisor, changedFlag: .supervisor)
+    }
+
+    func isMutating(userID: String) -> Bool {
+        updatingAdminIDs.contains(userID) || updatingSupervisorIDs.contains(userID)
+    }
+
+    func runParticipantsBackfill() {
+        guard !maintenanceStatus.isRunning else { return }
+
+        maintenanceStatus = MaintenanceStatus(
+            isRunning: true,
+            progress: MaintenanceStatus.Progress(processed: 0, total: 0, message: "Preparing…"),
+            lastRunCount: maintenanceStatus.lastRunCount,
+            lastErrorMessage: nil
+        )
+
+        service.adminBackfillParticipantsForAllJobs(progress: { [weak self] update in
+            guard let self else { return }
+            Task { @MainActor in
+                var status = self.maintenanceStatus
+                status.isRunning = true
+                status.progress = MaintenanceStatus.Progress(
+                    processed: update.processed,
+                    total: update.total,
+                    message: update.message
+                )
+                status.lastErrorMessage = nil
+                self.maintenanceStatus = status
+            }
+        }, completion: { [weak self] result in
+            guard let self else { return }
+            Task { @MainActor in
+                var status = self.maintenanceStatus
+                status.isRunning = false
+                status.progress = nil
+                switch result {
+                case .success(let count):
+                    status.lastRunCount = count
+                    status.lastErrorMessage = nil
+                    self.alert = AlertItem(
+                        title: "Backfill Complete",
+                        message: "Updated \(count) job\(count == 1 ? "" : "s").",
+                        kind: .success
+                    )
+                case .failure(let error):
+                    status.lastErrorMessage = error.localizedDescription
+                    self.alert = AlertItem(
+                        title: "Backfill Failed",
+                        message: error.localizedDescription,
+                        kind: .error
+                    )
+                }
+                self.maintenanceStatus = status
+            }
+        })
+    }
+
+    private enum ChangedFlag {
+        case admin
+        case supervisor
+    }
+
+    private func subscribe(to publisher: AnyPublisher<[AppUser], Never>) {
+        rosterCancellable = publisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] users in
+                self?.roster = users.sorted { lhs, rhs in
+                    lhs.lastName.lowercased() < rhs.lastName.lowercased()
+                }
+            }
+    }
+
+    private func updateFlags(
+        for user: AppUser,
+        admin: Bool,
+        supervisor: Bool,
+        changedFlag: ChangedFlag
+    ) {
+        let userID = user.id
+        if updatingAdminIDs.contains(userID) || updatingSupervisorIDs.contains(userID) {
+            return
+        }
+
+        switch changedFlag {
+        case .admin:
+            updatingAdminIDs.insert(userID)
+        case .supervisor:
+            updatingSupervisorIDs.insert(userID)
+        }
+
+        service.updateUserFlags(uid: userID, isAdmin: admin, isSupervisor: supervisor) { [weak self] result in
+            guard let self else { return }
+            Task { @MainActor in
+                self.updatingAdminIDs.remove(userID)
+                self.updatingSupervisorIDs.remove(userID)
+
+                switch result {
+                case .success:
+                    if self.currentUserIDProvider() == userID {
+                        self.service.refreshCustomClaims(for: userID, completion: nil)
+                    }
+                    self.onUserFlagsUpdated?(userID)
+                case .failure(let error):
+                    self.alert = AlertItem(
+                        title: "Update Failed",
+                        message: error.localizedDescription,
+                        kind: .error
+                    )
+                }
+            }
+        }
+    }
+}
+
+extension AdminPanelViewModel.MaintenanceStatus.Progress {
+    init(processed: Int, total: Int, message: String) {
+        self.processed = processed
+        self.total = total
+        self.message = message
+    }
+}

--- a/Job TrackerTests/AdminPanelViewModelTests.swift
+++ b/Job TrackerTests/AdminPanelViewModelTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import Combine
+@testable import Job_Tracker
+
+@MainActor
+final class AdminPanelViewModelTests: XCTestCase {
+    private let sampleUsers: [AppUser] = [
+        AppUser(id: "1", firstName: "Alex", lastName: "Anderson", email: "alex@example.com", position: "Tech"),
+        AppUser(id: "2", firstName: "Blair", lastName: "Barnes", email: "blair@example.com", position: "Lead"),
+        AppUser(id: "3", firstName: "Casey", lastName: "Chambers", email: "casey@example.com", position: "Supervisor")
+    ]
+
+    func testRosterUpdatesFromPublisher() async {
+        let subject = CurrentValueSubject<[AppUser], Never>([sampleUsers[1], sampleUsers[0]])
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(
+            service: mockService,
+            currentUserIDProvider: { nil },
+            initialRoster: [],
+            usersPublisher: subject.eraseToAnyPublisher()
+        )
+
+        await Task.yield()
+        XCTAssertEqual(viewModel.roster.map(\.id), [sampleUsers[0].id, sampleUsers[1].id])
+
+        subject.send([sampleUsers[2], sampleUsers[1]])
+        await Task.yield()
+        XCTAssertEqual(viewModel.roster.map(\.id), [sampleUsers[1].id, sampleUsers[2].id])
+    }
+
+    func testToggleAdminSuccessUpdatesState() async {
+        let user = AppUser(id: "42", firstName: "Jamie", lastName: "Quinn", email: "jamie@example.com", position: "Tech")
+        let subject = CurrentValueSubject<[AppUser], Never>([user])
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(
+            service: mockService,
+            currentUserIDProvider: { user.id },
+            initialRoster: [user],
+            usersPublisher: subject.eraseToAnyPublisher()
+        )
+
+        var updatedUserIDs: [String] = []
+        viewModel.onUserFlagsUpdated = { updatedUserIDs.append($0) }
+
+        viewModel.setAdmin(true, for: user)
+        XCTAssertTrue(viewModel.updatingAdminIDs.contains(user.id))
+        XCTAssertEqual(mockService.lastUpdate?.uid, user.id)
+        XCTAssertEqual(mockService.lastUpdate?.isAdmin, true)
+        XCTAssertEqual(mockService.lastUpdate?.isSupervisor, user.isSupervisor)
+
+        mockService.completeLastUpdate(with: .success(()))
+        await Task.yield()
+
+        XCTAssertTrue(updatedUserIDs.contains(user.id))
+        XCTAssertTrue(mockService.didRefreshClaims)
+        XCTAssertFalse(viewModel.updatingAdminIDs.contains(user.id))
+        XCTAssertNil(viewModel.alert)
+    }
+
+    func testToggleSupervisorFailureShowsAlert() async {
+        var user = AppUser(id: "55", firstName: "Morgan", lastName: "Reeves", email: "morgan@example.com", position: "Supervisor")
+        user.isSupervisor = true
+        let subject = CurrentValueSubject<[AppUser], Never>([user])
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(
+            service: mockService,
+            currentUserIDProvider: { "other" },
+            initialRoster: [user],
+            usersPublisher: subject.eraseToAnyPublisher()
+        )
+
+        viewModel.setSupervisor(false, for: user)
+        let expectedError = NSError(domain: "test", code: 99, userInfo: [NSLocalizedDescriptionKey: "Firestore write failed"])
+        mockService.completeLastUpdate(with: .failure(expectedError))
+        await Task.yield()
+
+        XCTAssertNotNil(viewModel.alert)
+        XCTAssertEqual(viewModel.alert?.message, expectedError.localizedDescription)
+        XCTAssertFalse(mockService.didRefreshClaims)
+    }
+
+    func testBackfillProgressAndCompletion() async {
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(service: mockService)
+
+        XCTAssertFalse(viewModel.maintenanceStatus.isRunning)
+        viewModel.runParticipantsBackfill()
+        XCTAssertTrue(viewModel.maintenanceStatus.isRunning)
+
+        let firstProgress = FirebaseService.AdminMaintenanceProgress(processed: 10, total: 50, message: "Batch 1 complete")
+        mockService.sendProgress(firstProgress)
+        await Task.yield()
+        XCTAssertEqual(viewModel.maintenanceStatus.progress?.processed, firstProgress.processed)
+        XCTAssertEqual(viewModel.maintenanceStatus.progress?.total, firstProgress.total)
+
+        mockService.finishBackfill(.success(50))
+        await Task.yield()
+
+        XCTAssertFalse(viewModel.maintenanceStatus.isRunning)
+        XCTAssertEqual(viewModel.maintenanceStatus.lastRunCount, 50)
+        XCTAssertNil(viewModel.maintenanceStatus.progress)
+        XCTAssertEqual(viewModel.alert?.kind, .success)
+    }
+}
+
+private final class MockAdminPanelService: AdminPanelService {
+    private(set) var lastUpdate: (uid: String, isAdmin: Bool, isSupervisor: Bool)?
+    private var updateCompletion: ((Result<Void, Error>) -> Void)?
+    private var backfillProgress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?
+    private var backfillCompletion: ((Result<Int, Error>) -> Void)?
+    private(set) var didRefreshClaims = false
+
+    func updateUserFlags(uid: String, isAdmin: Bool, isSupervisor: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
+        lastUpdate = (uid, isAdmin, isSupervisor)
+        updateCompletion = completion
+    }
+
+    func adminBackfillParticipantsForAllJobs(progress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?, completion: @escaping (Result<Int, Error>) -> Void) {
+        backfillProgress = progress
+        backfillCompletion = completion
+    }
+
+    func refreshCustomClaims(for uid: String?, completion: ((Error?) -> Void)?) {
+        didRefreshClaims = true
+        completion?(nil)
+    }
+
+    func completeLastUpdate(with result: Result<Void, Error>) {
+        updateCompletion?(result)
+        updateCompletion = nil
+    }
+
+    func sendProgress(_ progress: FirebaseService.AdminMaintenanceProgress) {
+        backfillProgress?(progress)
+    }
+
+    func finishBackfill(_ result: Result<Int, Error>) {
+        backfillCompletion?(result)
+        backfillCompletion = nil
+    }
+}


### PR DESCRIPTION
## Summary
- add an AdminPanelViewModel that watches the team roster, tracks in-flight role updates, and surfaces admin maintenance state
- extend FirebaseService with helpers to update user flags, refresh custom claims, and stream progress from the global participants backfill
- replace the Admin panel placeholder with a management list, confirmation flows, and maintenance controls, plus add unit coverage for the new view model logic

## Testing
- not run (xcodebuild is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68cf50342084832d98fa52df3adc0515