### PR TITLE
Replace Swift.Task usage in AdminPanelViewModel

### DIFF
--- a/Job Tracker/Features/Admin/AdminPanelViewModel.swift
+++ b/Job Tracker/Features/Admin/AdminPanelViewModel.swift
@@ -125,7 +125,7 @@ final class AdminPanelViewModel: ObservableObject {
 
         service.adminBackfillParticipantsForAllJobs(progress: { [weak self] update in
             guard let self else { return }
-            Swift.Task { @MainActor in
+            Task { @MainActor in
                 var status = self.maintenanceStatus
                 status.isRunning = true
                 status.progress = MaintenanceStatus.Progress(
@@ -138,7 +138,7 @@ final class AdminPanelViewModel: ObservableObject {
             }
         }, completion: { [weak self] result in
             guard let self else { return }
-            Swift.Task { @MainActor in
+            Task { @MainActor in
                 var status = self.maintenanceStatus
                 status.isRunning = false
                 status.progress = nil
@@ -199,7 +199,7 @@ final class AdminPanelViewModel: ObservableObject {
 
         service.updateUserFlags(uid: userID, isAdmin: admin, isSupervisor: supervisor) { [weak self] result in
             guard let self else { return }
-            Swift.Task { @MainActor in
+            Task { @MainActor in
                 self.updatingAdminIDs.remove(userID)
                 self.updatingSupervisorIDs.remove(userID)
 


### PR DESCRIPTION
## Summary
- replace fully qualified Swift.Task invocations with Task to match supported API surface
- retain main-actor dispatch for admin maintenance and flag updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf5ac72f6c832d97e9f74482c492fd