### PR TITLE
Fix admin confirmation dialog binding

### DIFF
--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -340,9 +340,17 @@ struct AdminPanelView: View {
         }
         .confirmationDialog(
             "Confirm role change",
-            item: $pendingToggle,
-            titleVisibility: .visible,
-            actions: { pending in
+            isPresented: Binding(
+                get: { pendingToggle != nil },
+                set: { newValue in
+                    if !newValue {
+                        pendingToggle = nil
+                    }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let pending = pendingToggle {
                 Button(role: .destructive) {
                     finalizePendingToggle(pending)
                 } label: {
@@ -353,14 +361,13 @@ struct AdminPanelView: View {
                         Text("Remove supervisor for \(pending.user.firstName)")
                     }
                 }
-                Button("Cancel", role: .cancel) {
-                    pendingToggle = nil
-                }
-            },
-            message: { _ in
-                Text("This updates Firebase immediately and may change the user's access right away.")
             }
-        )
+            Button("Cancel", role: .cancel) {
+                pendingToggle = nil
+            }
+        } message: {
+            Text("This updates Firebase immediately and may change the user's access right away.")
+        }
         .confirmationDialog(
             "Run participants backfill?",
             isPresented: $showingBackfillConfirmation,


### PR DESCRIPTION
## Summary
- replace the admin role confirmation dialog to use a Boolean binding instead of an Identifiable item
- keep the pending toggle cancellation and destructive actions using the stored pending toggle

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf5b8d2758832dbe503170bb88f506