### PR TITLE
Add cancellation flow for partner requests

### DIFF
--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -209,6 +209,20 @@ class FirebaseService {
         }
     }
 
+    func cancelPartnerRequest(request: PartnerRequest, completion: @escaping (Bool) -> Void) {
+        guard let reqId = request.id else { completion(false); return }
+        let ref = db.collection("partnerRequests").document(reqId)
+        ref.delete { err in
+            if let _ = err {
+                ref.updateData(["status": "cancelled"]) { updateErr in
+                    completion(updateErr == nil)
+                }
+            } else {
+                completion(true)
+            }
+        }
+    }
+
     func unpair(uid: String, partnerUid: String, completion: @escaping (Bool) -> Void) {
         let pairId = [uid, partnerUid].sorted().joined(separator: "_")
         db.collection("partnerships").document(pairId).delete { err in

--- a/Job Tracker/Models/PartnerRequest.swift
+++ b/Job Tracker/Models/PartnerRequest.swift
@@ -14,6 +14,6 @@ struct PartnerRequest: Identifiable, Hashable {
     var id: String?            // Firestore document ID
     let fromUid: String
     let toUid: String
-    var status: String         // "pending", "accepted", or "declined"
+    var status: String         // "pending", "accepted", "declined", or "cancelled"
     let createdAt: Date
 }


### PR DESCRIPTION
## Summary
- add a FirebaseService helper to cancel outgoing partner requests by deleting or flagging the document
- update FindPartnerView to show a cancel action for pending outgoing requests and optimistically remove them after success
- document the new cancelled status on PartnerRequest models

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d011b17208832db9fd5679fce11008