### PR TITLE
Manage partner request listener lifecycles

### DIFF
--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -169,8 +169,9 @@ class FirebaseService {
         doc.setData(payload) { err in completion(err == nil) }
     }
 
-    func listenIncomingRequests(for uid: String, handler: @escaping ([PartnerRequest]) -> Void) {
-        db.collection("partnerRequests")
+    @discardableResult
+    func listenIncomingRequests(for uid: String, handler: @escaping ([PartnerRequest]) -> Void) -> ListenerRegistration {
+        return db.collection("partnerRequests")
             .whereField("toUid", isEqualTo: uid)
             .whereField("status", isEqualTo: "pending")
             .addSnapshotListener { snap, _ in
@@ -179,8 +180,9 @@ class FirebaseService {
             }
     }
 
-    func listenOutgoingRequests(for uid: String, handler: @escaping ([PartnerRequest]) -> Void) {
-        db.collection("partnerRequests")
+    @discardableResult
+    func listenOutgoingRequests(for uid: String, handler: @escaping ([PartnerRequest]) -> Void) -> ListenerRegistration {
+        return db.collection("partnerRequests")
             .whereField("fromUid", isEqualTo: uid)
             .whereField("status", isEqualTo: "pending")
             .addSnapshotListener { snap, _ in


### PR DESCRIPTION
## Summary
- return ListenerRegistration handles from FirebaseService partner request listeners
- retain and clean up partner request listeners in FindPartnerView so they can be removed before re-subscribing or on disappear
- refresh partner pairing state after accepting a request without re-registering listeners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d012d2f970832d9d5b0a0cea63cf88