### PR TITLE
Add partner ID listener and update FindPartnerView to use it

### DIFF
--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -241,6 +241,23 @@ class FirebaseService {
             completion(partner)
         }
     }
+
+    @discardableResult
+    func listenPartnerId(for uid: String, handler: @escaping (String?) -> Void) -> ListenerRegistration {
+        return db.collection("partnerships")
+            .whereField("members", arrayContains: uid)
+            .limit(to: 1)
+            .addSnapshotListener { snapshot, error in
+                guard error == nil,
+                      let doc = snapshot?.documents.first,
+                      let members = doc["members"] as? [String],
+                      let partner = members.first(where: { $0 != uid }) else {
+                    handler(nil)
+                    return
+                }
+                handler(partner)
+            }
+    }
     
     // MARK: - Jobs
     


### PR DESCRIPTION
## Summary
- add a snapshot-based `listenPartnerId` helper in `FirebaseService`
- update `FindPartnerView` to attach the new listener and keep its registration so pairing changes propagate immediately

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68d015205fec832d851292d659c676e9