### PR TITLE
Improve partner request pending state handling

### DIFF
--- a/Job Tracker/Features/Shared/Team/FindPartnerView.swift
+++ b/Job Tracker/Features/Shared/Team/FindPartnerView.swift
@@ -17,8 +17,15 @@ struct FindPartnerView: View {
     @State private var partnerUid: String? = nil
     @State private var isLoading = false
     @State private var searchText: String = ""
-    @State private var errorText: String? = nil
-    @State private var cancellingRequestIDs: Set<String> = []
+    @State private var pendingRequestUserIDs: Set<String> = []
+    @State private var pendingAcceptRequestIDs: Set<String> = []
+    @State private var pendingDeclineRequestIDs: Set<String> = []
+    @State private var pendingCancelRequestIDs: Set<String> = []
+    @State private var requestErrors: [String: String] = [:]
+    @State private var incomingRequestErrors: [String: String] = [:]
+    @State private var cancelErrors: [String: String] = [:]
+    @State private var unpairError: String? = nil
+    @State private var isUnpairing = false
     @State private var incomingListener: ListenerRegistration? = nil
     @State private var outgoingListener: ListenerRegistration? = nil
     @State private var partnerListener: ListenerRegistration? = nil
@@ -32,16 +39,30 @@ struct FindPartnerView: View {
                 // Current partner
                 Section(header: Text("Current Partner")) {
                     if let pid = partnerUid, let p = usersViewModel.user(id: pid) {
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text("\(p.firstName) \(p.lastName)")
-                                    .font(.headline)
-                                Text(p.email)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text("\(p.firstName) \(p.lastName)")
+                                        .font(.headline)
+                                    Text(p.email)
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                Button(role: .destructive) { unpair() } label: {
+                                    if isUnpairing {
+                                        ProgressView()
+                                    } else {
+                                        Text("Unpair")
+                                    }
+                                }
+                                .disabled(isUnpairing)
                             }
-                            Spacer()
-                            Button(role: .destructive) { unpair() } label: { Text("Unpair") }
+                            if let message = unpairError {
+                                Text(message)
+                                    .font(.footnote)
+                                    .foregroundColor(.red)
+                            }
                         }
                     } else {
                         Text("No partner selected")
@@ -57,14 +78,44 @@ struct FindPartnerView: View {
                     } else {
                         ForEach(incoming) { req in
                             if let u = usersViewModel.user(id: req.fromUid) {
-                                HStack {
-                                    VStack(alignment: .leading) {
-                                        Text("\(u.firstName) \(u.lastName)")
-                                        Text(u.email).font(.footnote).foregroundColor(.secondary)
+                                let key = requestKey(for: req)
+                                let isAccepting = pendingAcceptRequestIDs.contains(key)
+                                let isDeclining = pendingDeclineRequestIDs.contains(key)
+                                VStack(alignment: .leading, spacing: 6) {
+                                    HStack {
+                                        VStack(alignment: .leading) {
+                                            Text("\(u.firstName) \(u.lastName)")
+                                            Text(u.email)
+                                                .font(.footnote)
+                                                .foregroundColor(.secondary)
+                                        }
+                                        Spacer()
+                                        Button {
+                                            accept(req)
+                                        } label: {
+                                            if isAccepting {
+                                                ProgressView()
+                                            } else {
+                                                Text("Approve")
+                                            }
+                                        }
+                                        .disabled(isAccepting || isDeclining)
+                                        Button(role: .destructive) {
+                                            decline(req)
+                                        } label: {
+                                            if isDeclining {
+                                                ProgressView()
+                                            } else {
+                                                Text("Decline")
+                                            }
+                                        }
+                                        .disabled(isAccepting || isDeclining)
                                     }
-                                    Spacer()
-                                    Button("Approve") { accept(req) }
-                                    Button("Decline", role: .destructive) { decline(req) }
+                                    if let message = incomingRequestErrors[key] {
+                                        Text(message)
+                                            .font(.footnote)
+                                            .foregroundColor(.red)
+                                    }
                                 }
                             }
                         }
@@ -79,23 +130,33 @@ struct FindPartnerView: View {
                     } else {
                         ForEach(outgoing) { req in
                             if let u = usersViewModel.user(id: req.toUid) {
-                                let isCancelling = req.id.map { cancellingRequestIDs.contains($0) } ?? false
-                                HStack {
-                                    VStack(alignment: .leading) {
-                                        Text("\(u.firstName) \(u.lastName)")
-                                        Text(u.email).font(.footnote).foregroundColor(.secondary)
-                                    }
-                                    Spacer()
-                                    Button(role: .destructive) {
-                                        cancel(req)
-                                    } label: {
-                                        if isCancelling {
-                                            ProgressView()
-                                        } else {
-                                            Text("Cancel")
+                                let key = requestKey(for: req)
+                                let isCancelling = pendingCancelRequestIDs.contains(key)
+                                VStack(alignment: .leading, spacing: 6) {
+                                    HStack {
+                                        VStack(alignment: .leading) {
+                                            Text("\(u.firstName) \(u.lastName)")
+                                            Text(u.email)
+                                                .font(.footnote)
+                                                .foregroundColor(.secondary)
                                         }
+                                        Spacer()
+                                        Button(role: .destructive) {
+                                            cancel(req)
+                                        } label: {
+                                            if isCancelling {
+                                                ProgressView()
+                                            } else {
+                                                Text("Cancel")
+                                            }
+                                        }
+                                        .disabled(isCancelling || req.id == nil)
                                     }
-                                    .disabled(isCancelling || req.id == nil)
+                                    if let message = cancelErrors[key] {
+                                        Text(message)
+                                            .font(.footnote)
+                                            .foregroundColor(.red)
+                                    }
                                 }
                                 .opacity(isCancelling ? 0.5 : 1.0)
                             }
@@ -110,33 +171,46 @@ struct FindPartnerView: View {
                             .foregroundColor(.secondary)
                     } else {
                         ForEach(visibleUsers) { user in
-                            HStack {
-                                VStack(alignment: .leading) {
-                                    Text("\(user.firstName) \(user.lastName)")
-                                    Text(user.email).font(.footnote).foregroundColor(.secondary)
-                                }
-                                Spacer()
+                            let isRequesting = pendingRequestUserIDs.contains(user.id)
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    VStack(alignment: .leading) {
+                                        Text("\(user.firstName) \(user.lastName)")
+                                        Text(user.email)
+                                            .font(.footnote)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    Spacer()
 
-                                if partnerUid == user.id {
-                                    Label("Partnered", systemImage: "checkmark.circle.fill")
-                                        .foregroundColor(.green)
-                                } else if outgoing.contains(where: { $0.toUid == user.id }) {
-                                    Text("Requested").foregroundColor(.secondary)
-                                } else if incoming.contains(where: { $0.fromUid == user.id }) {
-                                    Text("Requested you").foregroundColor(.secondary)
-                                } else {
-                                    Button("Request") { request(user.id) }
+                                    if partnerUid == user.id {
+                                        Label("Partnered", systemImage: "checkmark.circle.fill")
+                                            .foregroundColor(.green)
+                                    } else if outgoing.contains(where: { $0.toUid == user.id }) {
+                                        Text("Requested")
+                                            .foregroundColor(.secondary)
+                                    } else if incoming.contains(where: { $0.fromUid == user.id }) {
+                                        Text("Requested you")
+                                            .foregroundColor(.secondary)
+                                    } else {
+                                        Button {
+                                            request(user)
+                                        } label: {
+                                            if isRequesting {
+                                                ProgressView()
+                                            } else {
+                                                Text("Request")
+                                            }
+                                        }
+                                        .disabled(isRequesting)
+                                    }
+                                }
+                                if let message = requestErrors[user.id] {
+                                    Text(message)
+                                        .font(.footnote)
+                                        .foregroundColor(.red)
                                 }
                             }
                         }
-                    }
-                }
-
-                if let errorText = errorText {
-                    Section {
-                        Text(errorText)
-                            .foregroundColor(.red)
-                            .font(.footnote)
                     }
                 }
             }
@@ -184,10 +258,16 @@ struct FindPartnerView: View {
             }
         }
         incomingListener = FirebaseService.shared.listenIncomingRequests(for: uid) { reqs in
-            DispatchQueue.main.async { self.incoming = reqs }
+            DispatchQueue.main.async {
+                self.incoming = reqs
+                self.synchronizeIncomingState(with: reqs)
+            }
         }
         outgoingListener = FirebaseService.shared.listenOutgoingRequests(for: uid) { reqs in
-            DispatchQueue.main.async { self.outgoing = reqs }
+            DispatchQueue.main.async {
+                self.outgoing = reqs
+                self.synchronizeOutgoingState(with: reqs)
+            }
         }
     }
 
@@ -200,58 +280,159 @@ struct FindPartnerView: View {
         outgoingListener = nil
     }
 
-    private func request(_ toUid: String) {
+    private func request(_ user: AppUser) {
         guard let uid = authViewModel.currentUser?.id else { return }
-        errorText = nil
+        let toUid = user.id
+        guard !pendingRequestUserIDs.contains(toUid) else { return }
+
+        requestErrors[toUid] = nil
+        pendingRequestUserIDs.insert(toUid)
+
+        let displayName = "\(user.firstName) \(user.lastName)".trimmingCharacters(in: .whitespaces)
+
         FirebaseService.shared.sendPartnerRequest(from: uid, to: toUid) { ok in
-            if !ok { DispatchQueue.main.async { self.errorText = "Failed to send request." } }
+            DispatchQueue.main.async {
+                self.pendingRequestUserIDs.remove(toUid)
+                if ok {
+                    self.requestErrors[toUid] = nil
+                } else {
+                    let fallbackName = displayName.isEmpty ? "that teammate" : displayName
+                    self.requestErrors[toUid] = "Couldn't send an invite to \(fallbackName)."
+                }
+            }
         }
     }
 
     private func accept(_ req: PartnerRequest) {
-        errorText = nil
+        let key = requestKey(for: req)
+        guard !pendingAcceptRequestIDs.contains(key) else { return }
+
+        incomingRequestErrors[key] = nil
+
+        guard req.id != nil else {
+            incomingRequestErrors[key] = "Missing information needed to approve this invite."
+            return
+        }
+
+        pendingAcceptRequestIDs.insert(key)
+        pendingDeclineRequestIDs.remove(key)
+
+        let senderDisplayName = usersViewModel.user(id: req.fromUid).map { "\($0.firstName) \($0.lastName)".trimmingCharacters(in: .whitespaces) }
+
         FirebaseService.shared.acceptPartnerRequest(request: req) { ok in
             DispatchQueue.main.async {
-                if !ok {
-                    self.errorText = "Failed to approve request."
+                self.pendingAcceptRequestIDs.remove(key)
+                if ok {
+                    self.incoming.removeAll { self.requestKey(for: $0) == key }
+                    self.incomingRequestErrors[key] = nil
+                    if let currentId = self.authViewModel.currentUser?.id {
+                        self.partnerUid = currentId == req.fromUid ? req.toUid : req.fromUid
+                    }
+                } else {
+                    let name = senderDisplayName?.isEmpty == false ? senderDisplayName! : "that invite"
+                    self.incomingRequestErrors[key] = "Couldn't approve \(name)."
                 }
             }
         }
     }
 
     private func decline(_ req: PartnerRequest) {
-        errorText = nil
+        let key = requestKey(for: req)
+        guard !pendingDeclineRequestIDs.contains(key) else { return }
+
+        incomingRequestErrors[key] = nil
+
+        guard req.id != nil else {
+            incomingRequestErrors[key] = "Missing information needed to decline this invite."
+            return
+        }
+
+        pendingDeclineRequestIDs.insert(key)
+        pendingAcceptRequestIDs.remove(key)
+
+        let senderDisplayName = usersViewModel.user(id: req.fromUid).map { "\($0.firstName) \($0.lastName)".trimmingCharacters(in: .whitespaces) }
+
         FirebaseService.shared.declinePartnerRequest(request: req) { ok in
-            if !ok { DispatchQueue.main.async { self.errorText = "Failed to decline request." } }
+            DispatchQueue.main.async {
+                self.pendingDeclineRequestIDs.remove(key)
+                if ok {
+                    self.incoming.removeAll { self.requestKey(for: $0) == key }
+                    self.incomingRequestErrors[key] = nil
+                } else {
+                    let name = senderDisplayName?.isEmpty == false ? senderDisplayName! : "that invite"
+                    self.incomingRequestErrors[key] = "Couldn't decline \(name)."
+                }
+            }
         }
     }
 
     private func cancel(_ req: PartnerRequest) {
-        guard let reqId = req.id else {
-            errorText = "Unable to cancel request."
+        let key = requestKey(for: req)
+        guard !pendingCancelRequestIDs.contains(key) else { return }
+
+        cancelErrors[key] = nil
+
+        guard req.id != nil else {
+            cancelErrors[key] = "Missing information needed to cancel this invite."
             return
         }
-        errorText = nil
-        cancellingRequestIDs.insert(reqId)
+
+        pendingCancelRequestIDs.insert(key)
+
+        let recipientDisplayName = usersViewModel.user(id: req.toUid).map { "\($0.firstName) \($0.lastName)".trimmingCharacters(in: .whitespaces) }
+
         FirebaseService.shared.cancelPartnerRequest(request: req) { ok in
             DispatchQueue.main.async {
-                self.cancellingRequestIDs.remove(reqId)
+                self.pendingCancelRequestIDs.remove(key)
                 if ok {
-                    self.outgoing.removeAll { $0.id == reqId }
+                    self.outgoing.removeAll { self.requestKey(for: $0) == key }
+                    self.cancelErrors[key] = nil
                 } else {
-                    self.errorText = "Failed to cancel request."
+                    let name = recipientDisplayName?.isEmpty == false ? recipientDisplayName! : "that teammate"
+                    self.cancelErrors[key] = "Couldn't cancel the invite to \(name)."
                 }
             }
         }
     }
 
     private func unpair() {
-        guard let uid = authViewModel.currentUser?.id, let pid = partnerUid else { return }
-        errorText = nil
+        guard let uid = authViewModel.currentUser?.id,
+              let pid = partnerUid,
+              !isUnpairing else { return }
+
+        unpairError = nil
+        isUnpairing = true
+
+        let partnerDisplayName = usersViewModel.user(id: pid).map { "\($0.firstName) \($0.lastName)".trimmingCharacters(in: .whitespaces) }
+
         FirebaseService.shared.unpair(uid: uid, partnerUid: pid) { ok in
             DispatchQueue.main.async {
-                if ok { self.partnerUid = nil } else { self.errorText = "Failed to unpair." }
+                self.isUnpairing = false
+                if ok {
+                    self.partnerUid = nil
+                    self.unpairError = nil
+                } else {
+                    let name = partnerDisplayName?.isEmpty == false ? partnerDisplayName! : "your partner"
+                    self.unpairError = "Couldn't unpair from \(name)."
+                }
             }
         }
+    }
+
+    private func requestKey(for request: PartnerRequest) -> String {
+        request.id ?? "\(request.fromUid)-\(request.toUid)"
+    }
+
+    private func synchronizeIncomingState(with requests: [PartnerRequest]) {
+        let keys = Set(requests.map { requestKey(for: $0) })
+        incomingRequestErrors = Dictionary(uniqueKeysWithValues: incomingRequestErrors.filter { keys.contains($0.key) })
+        pendingAcceptRequestIDs = pendingAcceptRequestIDs.intersection(keys)
+        pendingDeclineRequestIDs = pendingDeclineRequestIDs.intersection(keys)
+    }
+
+    private func synchronizeOutgoingState(with requests: [PartnerRequest]) {
+        let keys = Set(requests.map { requestKey(for: $0) })
+        cancelErrors = Dictionary(uniqueKeysWithValues: cancelErrors.filter { keys.contains($0.key) })
+        pendingCancelRequestIDs = pendingCancelRequestIDs.intersection(keys)
     }
 }


### PR DESCRIPTION
## Summary
- add per-request pending state tracking in `FindPartnerView` so buttons disable and show progress while Firebase calls run
- surface contextual error messaging for partner actions and update view state when asynchronous calls complete
- synchronize listener updates with local pending state to avoid stale spinners and errors

## Testing
- xcodebuild -list -project "Job Tracker.xcodeproj" *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d01652ed18832d8efee9a32b0d450f