### PR TITLE
Fix arrival alert calendar and location auth usage

### DIFF
--- a/Job Tracker/Features/Shared/Services/ArrivalAlertManager.swift
+++ b/Job Tracker/Features/Shared/Services/ArrivalAlertManager.swift
@@ -47,7 +47,7 @@ final class ArrivalAlertManager: ObservableObject {
         locationService: LocationService,
         notificationCenter: UNUserNotificationCenter = .current(),
         userDefaults: UserDefaults = .standard,
-        calendar: Calendar = .current()
+        calendar: Calendar = .current
     ) {
         self.locationService = locationService
         self.notificationCenter = notificationCenter
@@ -158,7 +158,7 @@ final class ArrivalAlertManager: ObservableObject {
             return
         }
 
-        let locationStatus = CLLocationManager.authorizationStatus()
+        let locationStatus = CLLocationManager().authorizationStatus
         guard locationStatus == .authorizedAlways || locationStatus == .authorizedWhenInUse else {
             stopAllMonitors()
             switch locationStatus {


### PR DESCRIPTION
## Summary
- use Calendar.current property instead of calling it like a function
- replace deprecated CLLocationManager.authorizationStatus() usage with instance property access

## Testing
- not run (not specified)

------
https://chatgpt.com/codex/tasks/task_e_68d018f82828832db213f7a70e45a97d