### PR TITLE
Fix deep link router guard returns

### DIFF
--- a/Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift
+++ b/Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift
@@ -19,7 +19,7 @@ enum DeepLinkRouter {
             #if DEBUG
             print("[DeepLink] Ignored non-jobtracker scheme: \(url.scheme ?? "nil")")
             #endif
-            return
+            return nil
         }
 
         // Accept both forms:
@@ -33,7 +33,7 @@ enum DeepLinkRouter {
             #if DEBUG
             print("[DeepLink] Unknown route. host=\(host ?? "nil"), path=\(path)")
             #endif
-            return
+            return nil
         }
 
         let token = URLComponents(url: url, resolvingAgainstBaseURL: false)?


### PR DESCRIPTION
## Summary
- ensure the deep link router returns nil when the URL scheme or route doesn't match the expected import job route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d035c0847c832da283cf562259532b