### PR TITLE
Ensure shared job payload supports Equatable comparisons

### DIFF
--- a/Job Tracker/Features/Jobs/Sharing/SharedJobPayload.swift
+++ b/Job Tracker/Features/Jobs/Sharing/SharedJobPayload.swift
@@ -14,7 +14,7 @@ import FirebaseAuth
 /// We removed the old includeMaterials/Notes/Photos flags. Now we only share:
 ///  - address, date, status, jobNumber
 ///  - assignment (but only applied if sender **and** receiver are CAN users)
-struct SharedJobPayload: Codable {
+struct SharedJobPayload: Codable, Equatable {
     let v: Int               // schema version
     let createdAt: Timestamp
     let fromUserId: String?
@@ -28,6 +28,20 @@ struct SharedJobPayload: Codable {
     // Conditional field: carried in payload but only applied when allowed
     let assignment: String?
     let senderIsCan: Bool
+
+    static func == (lhs: SharedJobPayload, rhs: SharedJobPayload) -> Bool {
+        lhs.v == rhs.v &&
+        lhs.createdAt.seconds == rhs.createdAt.seconds &&
+        lhs.createdAt.nanoseconds == rhs.createdAt.nanoseconds &&
+        lhs.fromUserId == rhs.fromUserId &&
+        lhs.address == rhs.address &&
+        lhs.date.seconds == rhs.date.seconds &&
+        lhs.date.nanoseconds == rhs.date.nanoseconds &&
+        lhs.status == rhs.status &&
+        lhs.jobNumber == rhs.jobNumber &&
+        lhs.assignment == rhs.assignment &&
+        lhs.senderIsCan == rhs.senderIsCan
+    }
 }
 
 struct SharedJobPreview: Identifiable, Equatable {


### PR DESCRIPTION
## Summary
- add Equatable conformance to `SharedJobPayload` so `SharedJobPreview` can synthesize Equatable
- compare timestamp fields using seconds and nanoseconds to keep equality precise

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d036bd73bc832daf77257e5ee150e3