### PR TITLE
Dismiss onboarding tutorial sheet when tapping Get Started

### DIFF
--- a/Job Tracker/Features/Authentication/AuthFlowView.swift
+++ b/Job Tracker/Features/Authentication/AuthFlowView.swift
@@ -98,7 +98,15 @@ struct AuthFlowView: View {
         }
         .sheet(isPresented: $showingTutorial) {
             NavigationStack {
-                TutorialView()
+                TutorialView(onComplete: {
+                    if reduceMotion {
+                        showingTutorial = false
+                    } else {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showingTutorial = false
+                        }
+                    }
+                })
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Close") { showingTutorial = false }

--- a/Job Tracker/Features/Help/TutorialView.swift
+++ b/Job Tracker/Features/Help/TutorialView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct TutorialView: View {
     @AppStorage("hasSeenTutorial") private var hasSeenTutorial: Bool = false
     @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw: String = "apple" // "apple" or "google"
+    var onComplete: (() -> Void)? = nil
     
     var body: some View {
         TabView {
@@ -121,7 +122,10 @@ struct TutorialView: View {
                 Text("Start tracking your jobs now.")
                     .padding()
                 Spacer()
-                Button(action: { hasSeenTutorial = true }) {
+                Button(action: {
+                    hasSeenTutorial = true
+                    onComplete?()
+                }) {
                     Text("Get Started")
                         .bold()
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- add an optional completion callback to `TutorialView` so callers can respond when the walkthrough is finished
- use the completion callback in `AuthFlowView` to animate dismissing the tutorial preview sheet after tapping **Get Started**

## Testing
- Not run (iOS project requires Xcode)


------
https://chatgpt.com/codex/tasks/task_e_68d0392065d0832d97599d80bbc5b25b