### PR TITLE
Fix Swift 6 compatibility issues in tutorial overlay and button style

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -113,7 +113,7 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension ButtonStyle where Self == JTPrimaryButtonStyle {
+extension PrimitiveButtonStyle where Self == JTPrimaryButtonStyle {
     static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle() }
 }
 

--- a/Job Tracker/Features/Help/TutorialHighlightOverlay.swift
+++ b/Job Tracker/Features/Help/TutorialHighlightOverlay.swift
@@ -261,11 +261,11 @@ struct TutorialHighlightOverlay: View {
 }
 
 private struct AnyShape: Shape {
-    private let pathBuilder: (CGRect) -> Path
+    private let pathBuilder: @Sendable (CGRect) -> Path
 
     init<S: Shape>(_ wrapped: S) {
         pathBuilder = { rect in
-            Path(wrapped.path(in: rect))
+            wrapped.path(in: rect)
         }
     }
 


### PR DESCRIPTION
## Summary
- expose the `jtPrimary` helper on `PrimitiveButtonStyle` so `.buttonStyle(.jtPrimary)` remains available on newer toolchains
- mark the tutorial overlay's `AnyShape` wrapper closure as `@Sendable` and remove the invalid `Path` reinitialisation for Swift 6

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0419e6d3c832da2b8f8f243d06333