### PR TITLE
Ensure jtPrimary style works with PrimitiveButtonStyle

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -97,7 +97,7 @@ struct JTPrimaryButton: View {
 }
 
 @MainActor
-private struct JTPrimaryButtonStyle: ButtonStyle {
+struct JTPrimaryButtonStyle: PrimitiveButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(JTColors.onAccent)
@@ -113,7 +113,7 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension ButtonStyle where Self == JTPrimaryButtonStyle {
+extension PrimitiveButtonStyle {
     static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle() }
 }
 

--- a/Job Tracker/Features/Help/TutorialHighlightOverlay.swift
+++ b/Job Tracker/Features/Help/TutorialHighlightOverlay.swift
@@ -261,11 +261,11 @@ struct TutorialHighlightOverlay: View {
 }
 
 private struct AnyShape: Shape {
-    private let pathBuilder: (CGRect) -> Path
+    private let pathBuilder: @Sendable (CGRect) -> Path
 
     init<S: Shape>(_ wrapped: S) {
         pathBuilder = { rect in
-            Path(wrapped.path(in: rect))
+            wrapped.path(in: rect)
         }
     }
 


### PR DESCRIPTION
## Summary
- expose the `jtPrimary` convenience accessor directly on `PrimitiveButtonStyle` so it can be referenced without running afoul of Swift 6 `Self` constraints
- make `JTPrimaryButtonStyle` non-private so the accessor can vend the concrete style

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d0419e6d3c832da2b8f8f243d06333