### PR TITLE
Fix JTPrimaryButtonStyle static accessor

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -113,7 +113,7 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension PrimitiveButtonStyle where Self == JTPrimaryButtonStyle {
+extension ButtonStyle where Self == JTPrimaryButtonStyle {
     static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle() }
 }
 


### PR DESCRIPTION
## Summary
- update the jtPrimary static accessor to extend ButtonStyle instead of PrimitiveButtonStyle so the constraint matches the style

## Testing
- Not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68d046f8a174832d88ef2e72e37733bf