### PR TITLE
Expose jtPrimary button style via PrimitiveButtonStyle extension

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -113,7 +113,7 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension ButtonStyle where Self == JTPrimaryButtonStyle {
+extension PrimitiveButtonStyle where Self == JTPrimaryButtonStyle {
     static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle() }
 }
 


### PR DESCRIPTION
## Summary
- expose the `jtPrimary` helper on `PrimitiveButtonStyle` so the style is available to `buttonStyle(_:)`

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d04a52254c832d97e57fbc807ae36c