### PR TITLE
Wrap primary button style in primitive style

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -113,8 +113,23 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension PrimitiveButtonStyle where Self == JTPrimaryButtonStyle {
+extension ButtonStyle where Self == JTPrimaryButtonStyle {
     static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle() }
+}
+
+@MainActor
+private struct JTPrimaryPrimitiveButtonStyle: PrimitiveButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button(role: configuration.role, action: configuration.trigger) {
+            configuration.label
+        }
+        .buttonStyle(JTPrimaryButtonStyle())
+    }
+}
+
+@MainActor
+extension PrimitiveButtonStyle where Self == JTPrimaryPrimitiveButtonStyle {
+    static var jtPrimary: JTPrimaryPrimitiveButtonStyle { JTPrimaryPrimitiveButtonStyle() }
 }
 
 /// Text input that sits on top of the glass surface styling.


### PR DESCRIPTION
## Summary
- restore the jtPrimary static helper on JTPrimaryButtonStyle
- add a primitive button style wrapper that builds a Button using JTPrimaryButtonStyle
- expose the wrapper via a PrimitiveButtonStyle convenience to keep existing call sites intact

## Testing
- not run (xcodebuild not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d04d48661c832db6f8ef49673ae8e0