### PR TITLE
Move JTPrimaryButtonStyle factory onto struct

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -98,6 +98,8 @@ struct JTPrimaryButton: View {
 
 @MainActor
 private struct JTPrimaryButtonStyle: ButtonStyle {
+    static var jtPrimary: Self { .init() }
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(JTColors.onAccent)
@@ -113,17 +115,12 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension ButtonStyle where Self == JTPrimaryButtonStyle {
-    static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle() }
-}
-
-@MainActor
 private struct JTPrimaryPrimitiveButtonStyle: PrimitiveButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         Button(role: configuration.role, action: configuration.trigger) {
             configuration.label
         }
-        .buttonStyle(JTPrimaryButtonStyle())
+        .buttonStyle(JTPrimaryButtonStyle.jtPrimary)
     }
 }
 


### PR DESCRIPTION
## Summary
- move the jtPrimary factory onto JTPrimaryButtonStyle so it lives on the type itself
- update JTPrimaryPrimitiveButtonStyle to reference the relocated factory and drop the old ButtonStyle convenience

## Testing
- swift build (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68d04f3f7014832d830b9e9b93be68e8