### PR TITLE
Restore JT primary button style helper

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -115,6 +115,11 @@ private struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
+extension ButtonStyle where Self == JTPrimaryButtonStyle {
+    static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle.jtPrimary }
+}
+
+@MainActor
 private struct JTPrimaryPrimitiveButtonStyle: PrimitiveButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         Button(role: configuration.role, action: configuration.trigger) {


### PR DESCRIPTION
## Summary
- restore the ButtonStyle helper for JTPrimaryButtonStyle so `.buttonStyle(.jtPrimary)` compiles again

## Testing
- xcodebuild -list -project 'Job Tracker.xcodeproj' *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d05110cc44832dab218ee3a0271b29