### PR TITLE
Expose primary button styles for reuse

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -97,7 +97,7 @@ struct JTPrimaryButton: View {
 }
 
 @MainActor
-private struct JTPrimaryButtonStyle: ButtonStyle {
+struct JTPrimaryButtonStyle: ButtonStyle {
     static var jtPrimary: Self { .init() }
 
     func makeBody(configuration: Configuration) -> some View {
@@ -120,7 +120,7 @@ extension ButtonStyle where Self == JTPrimaryButtonStyle {
 }
 
 @MainActor
-private struct JTPrimaryPrimitiveButtonStyle: PrimitiveButtonStyle {
+struct JTPrimaryPrimitiveButtonStyle: PrimitiveButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         Button(role: configuration.role, action: configuration.trigger) {
             configuration.label


### PR DESCRIPTION
## Summary
- update the JT primary button style types to be module-visible so the `.jtPrimary` helpers can be resolved from other files

## Testing
- xcodebuild -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -destination "generic/platform=iOS" build (fails: `xcodebuild` is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d0539550d0832dbc0e5a85038527cc