### PR TITLE
Resolve jtPrimary button style ambiguity

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -115,17 +115,12 @@ struct JTPrimaryButtonStyle: ButtonStyle {
 }
 
 @MainActor
-extension ButtonStyle where Self == JTPrimaryButtonStyle {
-    static var jtPrimary: JTPrimaryButtonStyle { JTPrimaryButtonStyle.jtPrimary }
-}
-
-@MainActor
 struct JTPrimaryPrimitiveButtonStyle: PrimitiveButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         Button(role: configuration.role, action: configuration.trigger) {
             configuration.label
         }
-        .buttonStyle(JTPrimaryButtonStyle.jtPrimary)
+        .buttonStyle(JTPrimaryButtonStyle())
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the `ButtonStyle` helper for `jtPrimary` so the primitive style is the sole exported entry point
- update `JTPrimaryPrimitiveButtonStyle` to initialize `JTPrimaryButtonStyle` directly

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d055e56e94832da1ff23296e9d8da3