### PR TITLE
Sort weekly timesheet jobs by job number

### DIFF
--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetPDFGenerator.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetPDFGenerator.swift
@@ -334,15 +334,17 @@ extension WeeklyTimesheetPDFGenerator {
             return ids
         }()
 
-        return jobs.filter { job in
-            guard job.status.lowercased() != "pending" else { return false }
+        return jobs
+            .filter { job in
+                guard job.status.lowercased() != "pending" else { return false }
 
-            let createdByAllowed = job.createdBy.flatMap { allowedUserIDs.contains($0) } ?? false
-            let assignedToAllowed = job.assignedTo.flatMap { allowedUserIDs.contains($0) } ?? false
-            guard createdByAllowed || assignedToAllowed else { return false }
+                let createdByAllowed = job.createdBy.flatMap { allowedUserIDs.contains($0) } ?? false
+                let assignedToAllowed = job.assignedTo.flatMap { allowedUserIDs.contains($0) } ?? false
+                guard createdByAllowed || assignedToAllowed else { return false }
 
-            return Calendar.current.isDate(job.date, inSameDayAs: date)
-        }
+                return Calendar.current.isDate(job.date, inSameDayAs: date)
+            }
+            .sortedForTimesheet()
     }
 
     // Basic text drawing helpers.

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -488,12 +488,14 @@ extension WeeklyTimesheetView {
     private func jobsForTimesheet() -> [Job] {
         guard let me = authViewModel.currentUser?.id else { return [] }
         let other = partnerUid
-        return timesheetJobsVM.jobs.filter { job in
-            let mine = (job.createdBy == me || job.assignedTo == me)
-            let partners = (other != nil) && (job.createdBy == other || job.assignedTo == other)
-            return (mine || partners)
-                && job.status.lowercased() != "pending"
-        }
+        return timesheetJobsVM.jobs
+            .filter { job in
+                let mine = (job.createdBy == me || job.assignedTo == me)
+                let partners = (other != nil) && (job.createdBy == other || job.assignedTo == other)
+                return (mine || partners)
+                    && job.status.lowercased() != "pending"
+            }
+            .sortedForTimesheet()
     }
     
     private func bindingFor(day: Date) -> Binding<String> {


### PR DESCRIPTION
## Summary
- add a shared timesheet job sorter that prefers numeric job numbers and falls back to normalized strings/date/address
- apply the sorter to the weekly timesheet view and PDF generator so both surfaces group jobs identically

## Testing
- Not run (iOS build/test tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d07a6dca54832d882153cf6ea94129