### PR TITLE
Add Recent Crew Jobs screen to More menu

### DIFF
--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -1,0 +1,511 @@
+import SwiftUI
+
+struct RecentCrewJobsView: View {
+    @StateObject private var viewModel = RecentCrewJobsViewModel()
+    @State private var selectedFilter: RecentCrewJobsViewModel.CrewRoleFilter = .all
+    @State private var selectedJob: RecentCrewJob?
+
+    var body: some View {
+        ZStack {
+            JTGradients.background(stops: 4).ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                filterChips
+                content
+            }
+        }
+        .navigationTitle("Recent Crew Jobs")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.startListening() }
+        .onDisappear { viewModel.stopListening() }
+        .sheet(item: $selectedJob, onDismiss: { selectedJob = nil }) { job in
+            RecentCrewJobDetailSheet(job: job)
+        }
+    }
+
+    private var content: some View {
+        let groups = viewModel.groups(for: selectedFilter)
+
+        return Group {
+            if viewModel.isLoading && viewModel.jobs.isEmpty {
+                loadingState
+            } else if let error = viewModel.errorMessage {
+                stateView(
+                    title: "Unable to load jobs",
+                    systemImage: "exclamationmark.triangle",
+                    message: error
+                )
+            } else if groups.isEmpty {
+                stateView(
+                    title: "No recent jobs",
+                    systemImage: "tray",
+                    message: "Crew submissions from the last 14 days will appear here once they’re completed."
+                )
+            } else {
+                List {
+                    ForEach(groups) { group in
+                        NavigationLink {
+                            RecentCrewJobGroupDetailView(group: group) { job in
+                                selectedJob = job
+                            }
+                        } label: {
+                            RecentCrewJobGroupRow(group: group)
+                        }
+                        .listRowBackground(Color.clear)
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+            }
+        }
+    }
+
+    private var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: JTSpacing.sm) {
+                ForEach(RecentCrewJobsViewModel.CrewRoleFilter.allCases) { filter in
+                    Button {
+                        selectedFilter = filter
+                    } label: {
+                        Text(filter.rawValue)
+                            .font(JTTypography.subheadline)
+                            .fontWeight(filter == selectedFilter ? .semibold : .regular)
+                            .padding(.vertical, JTSpacing.xs)
+                            .padding(.horizontal, JTSpacing.md)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(filter == selectedFilter ? JTColors.accent.opacity(0.9) : JTColors.glassHighlight)
+                            )
+                            .overlay(
+                                Capsule(style: .continuous)
+                                    .stroke(filter == selectedFilter ? JTColors.accent : JTColors.glassSoftStroke, lineWidth: 1)
+                            )
+                            .foregroundStyle(JTColors.textPrimary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, JTSpacing.md)
+            .padding(.vertical, JTSpacing.sm)
+        }
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: JTSpacing.md) {
+            ProgressView("Loading recent jobs…")
+                .tint(JTColors.accent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, JTSpacing.xl)
+    }
+
+    private func stateView(title: String, systemImage: String, message: String) -> some View {
+        VStack(spacing: JTSpacing.md) {
+            Image(systemName: systemImage)
+                .font(.system(size: 40, weight: .regular))
+                .foregroundStyle(JTColors.textMuted)
+
+            Text(title)
+                .font(JTTypography.headline)
+                .foregroundStyle(JTColors.textPrimary)
+
+            Text(message)
+                .font(JTTypography.caption)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(JTColors.textSecondary)
+                .padding(.horizontal, JTSpacing.lg)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, JTSpacing.xl)
+    }
+}
+
+private struct RecentCrewJobGroupRow: View {
+    let group: RecentCrewJobGroup
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(group.title)
+                    .font(JTTypography.subheadline.weight(.semibold))
+                    .foregroundStyle(JTColors.textPrimary)
+                Spacer()
+                if let date = group.latestFormattedDate {
+                    Text(date)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+            }
+
+            Text(group.subtitle)
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+                .lineLimit(1)
+
+            HStack(spacing: JTSpacing.xs) {
+                if let role = group.primaryRole {
+                    CrewJobChip(text: role, tint: JTColors.accent)
+                }
+                CrewJobChip(text: group.latestStatus, tint: statusTint(for: group.latestStatus))
+                if group.isMultiEntry {
+                    CrewJobChip(text: "Multiple entries", tint: JTColors.info)
+                }
+            }
+        }
+        .padding(.vertical, JTSpacing.sm)
+    }
+}
+
+private struct RecentCrewJobGroupDetailView: View {
+    let group: RecentCrewJobGroup
+    let onSelectJob: (RecentCrewJob) -> Void
+
+    var body: some View {
+        List {
+            Section {
+                RecentCrewJobGroupSummary(group: group)
+                    .listRowInsets(EdgeInsets(top: JTSpacing.sm, leading: JTSpacing.md, bottom: JTSpacing.sm, trailing: JTSpacing.md))
+                    .listRowBackground(Color.clear)
+            }
+
+            Section(group.entryCount == 1 ? "Submission" : "Submissions") {
+                ForEach(group.jobs) { job in
+                    Button {
+                        onSelectJob(job)
+                    } label: {
+                        RecentCrewJobRow(job: job)
+                    }
+                    .buttonStyle(.plain)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(JTGradients.background(stops: 4).ignoresSafeArea())
+        .navigationTitle(group.title)
+    }
+}
+
+private struct RecentCrewJobGroupSummary: View {
+    let group: RecentCrewJobGroup
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Text(group.title)
+                    .font(JTTypography.title3)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Text(group.subtitle)
+                    .font(JTTypography.subheadline)
+                    .foregroundStyle(JTColors.textSecondary)
+
+                HStack(spacing: JTSpacing.xs) {
+                    if let role = group.primaryRole {
+                        CrewJobChip(text: role, tint: JTColors.accent)
+                    }
+                    CrewJobChip(text: group.latestStatus, tint: statusTint(for: group.latestStatus))
+                    if let date = group.latestFormattedDate {
+                        CrewJobChip(text: date, tint: JTColors.info)
+                    }
+                    Spacer(minLength: JTSpacing.md)
+                    if group.isMultiEntry {
+                        CrewJobChip(text: "\(group.entryCount) entries", tint: JTColors.info)
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+        .listRowSeparator(.hidden)
+    }
+}
+
+private struct RecentCrewJobRow: View {
+    let job: RecentCrewJob
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(job.status)
+                    .font(JTTypography.subheadline.weight(.semibold))
+                    .foregroundStyle(JTColors.textPrimary)
+                Spacer()
+                Text(job.formattedDate)
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+
+            if let number = job.trimmedJobNumber {
+                Text("Job #\(number)")
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+
+            Text(job.address)
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textPrimary)
+                .multilineTextAlignment(.leading)
+
+            if let role = job.displayCrewRole {
+                CrewJobChip(text: role, tint: JTColors.accent)
+            }
+
+            if let notes = job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
+                Text(notes)
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, JTSpacing.sm)
+    }
+}
+
+private struct CrewJobChip: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        Text(text)
+            .font(JTTypography.caption)
+            .foregroundStyle(tint)
+            .padding(.horizontal, JTSpacing.sm + 2)
+            .padding(.vertical, JTSpacing.xs)
+            .background(tint.opacity(0.18), in: Capsule(style: .continuous))
+    }
+}
+
+private func statusTint(for status: String) -> Color {
+    let lower = status.lowercased()
+    if lower.contains("done") || lower.contains("complete") {
+        return JTColors.success
+    }
+    if lower.contains("need") || lower.contains("pending") {
+        return JTColors.info
+    }
+    if lower.contains("talk") || lower.contains("hold") {
+        return JTColors.warning
+    }
+    return JTColors.accent
+}
+
+private struct RecentCrewJobDetailSheet: View {
+    let job: RecentCrewJob
+
+    @EnvironmentObject private var jobsViewModel: JobsViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var isAdding = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                    summaryCard
+                    metadataCard
+                    if let notesCard = notesCard {
+                        notesCard
+                    }
+                }
+                .padding(.horizontal, JTSpacing.lg)
+                .padding(.top, JTSpacing.lg)
+                .padding(.bottom, JTSpacing.xxl * 2)
+            }
+            .background(JTGradients.background(stops: 4).ignoresSafeArea())
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                VStack(spacing: JTSpacing.sm) {
+                    JTPrimaryButton(isAdding ? "Adding…" : "Add to Dashboard", systemImage: "plus.circle") {
+                        addToDashboard()
+                    }
+                    .disabled(isAdding)
+                }
+                .padding(.horizontal, JTSpacing.lg)
+                .padding(.top, JTSpacing.md)
+                .padding(.bottom, JTSpacing.lg)
+                .background(.ultraThinMaterial)
+            }
+            .alert("Unable to add job", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "Unknown error")
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Text(job.displayTitle)
+                    .font(JTTypography.title3)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Text(job.address)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .multilineTextAlignment(.leading)
+
+                HStack(spacing: JTSpacing.xs) {
+                    CrewJobChip(text: job.status, tint: statusTint(for: job.status))
+                    CrewJobChip(text: job.formattedDate, tint: JTColors.info)
+                    if let role = job.displayCrewRole {
+                        CrewJobChip(text: role, tint: JTColors.accent)
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var metadataCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                ForEach(detailItems) { item in
+                    HStack(alignment: .top, spacing: JTSpacing.md) {
+                        Image(systemName: item.icon)
+                            .font(.subheadline)
+                            .foregroundStyle(JTColors.textSecondary)
+                            .frame(width: 20)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.title)
+                                .font(JTTypography.caption)
+                                .foregroundStyle(JTColors.textSecondary)
+                            Text(item.value)
+                                .font(JTTypography.subheadline)
+                                .foregroundStyle(JTColors.textPrimary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var notesCard: some View? {
+        guard let notes = job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty else {
+            return nil
+        }
+
+        return GlassCard {
+            VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                Text("Notes")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                Text(notes)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var detailItems: [DetailItem] {
+        var items: [DetailItem] = []
+
+        if let jobNumber = job.trimmedJobNumber {
+            items.append(DetailItem(icon: "number", title: "Job Number", value: jobNumber))
+        }
+
+        if let role = job.displayCrewRole {
+            items.append(DetailItem(icon: "person.3", title: "Crew Role", value: role))
+        }
+
+        items.append(DetailItem(icon: "calendar", title: "Date", value: job.formattedDate))
+        items.append(DetailItem(icon: "flag.fill", title: "Status", value: job.status))
+
+        if let crewName = normalizedNonEmpty(job.crewName) {
+            items.append(DetailItem(icon: "person.2", title: "Crew Name", value: crewName))
+        }
+
+        if let crewLead = normalizedNonEmpty(job.crewLead) {
+            items.append(DetailItem(icon: "person.crop.circle.badge.checkmark", title: "Crew Lead", value: crewLead))
+        }
+
+        if let hours = job.hours, hours > 0 {
+            items.append(DetailItem(icon: "clock", title: "Hours", value: String(format: "%.1f", hours)))
+        }
+
+        if let materials = normalizedNonEmpty(job.materialsUsed) {
+            items.append(DetailItem(icon: "shippingbox", title: "Materials Used", value: materials))
+        }
+
+        if let canFootage = normalizedNonEmpty(job.canFootage) {
+            items.append(DetailItem(icon: "ruler", title: "CAN Footage", value: canFootage))
+        }
+
+        if let nidFootage = normalizedNonEmpty(job.nidFootage) {
+            items.append(DetailItem(icon: "ruler", title: "NID Footage", value: nidFootage))
+        }
+
+        if let createdBy = normalizedNonEmpty(job.createdBy) {
+            items.append(DetailItem(icon: "person.badge.key", title: "Created By", value: createdBy))
+        }
+
+        if let assignedTo = normalizedNonEmpty(job.assignedTo) {
+            items.append(DetailItem(icon: "person.crop.circle.badge.exclam", title: "Assigned To", value: assignedTo))
+        }
+
+        return items
+    }
+
+    private func addToDashboard() {
+        guard !isAdding else { return }
+
+        isAdding = true
+        errorMessage = nil
+
+        let userID = authViewModel.currentUser?.id
+        let newJob = Job(
+            address: job.address,
+            date: Date(),
+            status: "Pending",
+            assignedTo: nil,
+            createdBy: userID,
+            notes: "",
+            jobNumber: job.trimmedJobNumber,
+            assignments: nil,
+            materialsUsed: nil,
+            photos: [],
+            participants: nil,
+            hours: 0.0,
+            nidFootage: nil,
+            canFootage: nil
+        )
+
+        jobsViewModel.createJob(newJob) { success in
+            isAdding = false
+            if success {
+                dismiss()
+            } else {
+                errorMessage = "We couldn’t add the job to your dashboard. Please try again."
+            }
+        }
+    }
+
+    private func normalizedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private struct DetailItem: Identifiable {
+        let id = UUID()
+        let icon: String
+        let title: String
+        let value: String
+    }
+}

--- a/Job Tracker/Features/Shared/More/RecentCrewJobsViewModel.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsViewModel.swift
@@ -1,0 +1,386 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+final class RecentCrewJobsViewModel: ObservableObject {
+    enum CrewRoleFilter: String, CaseIterable, Identifiable {
+        case all = "All"
+        case underground = "Underground"
+        case aerial = "Aerial"
+        case can = "CAN"
+        case nid = "NID"
+
+        var id: String { rawValue }
+    }
+
+    @Published private(set) var jobs: [RecentCrewJob] = []
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var errorMessage: String?
+
+    private var listener: ListenerRegistration?
+    private let db = Firestore.firestore()
+
+    deinit {
+        listener?.remove()
+    }
+
+    func startListening() {
+        guard listener == nil else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        let calendar = Calendar.current
+        let fourteenDaysAgo = calendar.date(byAdding: .day, value: -14, to: Date()) ?? Date()
+
+        let query = db.collection("jobs")
+            .whereField("date", isGreaterThanOrEqualTo: fourteenDaysAgo)
+            .order(by: "date", descending: true)
+
+        listener = query.addSnapshotListener { [weak self] snapshot, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                DispatchQueue.main.async {
+                    self.errorMessage = error.localizedDescription
+                    self.isLoading = false
+                }
+                return
+            }
+
+            guard let documents = snapshot?.documents else {
+                DispatchQueue.main.async {
+                    self.jobs = []
+                    self.isLoading = false
+                }
+                return
+            }
+
+            let decoded: [RecentCrewJob] = documents.compactMap { doc in
+                do {
+                    var job = try doc.data(as: RecentCrewJob.self)
+                    job.id = doc.documentID
+                    return job
+                } catch {
+                    #if DEBUG
+                    print("[RecentCrewJobs] Failed to decode job: \(error)")
+                    #endif
+                    return nil
+                }
+            }
+            .filter { $0.status.lowercased() != "pending" }
+
+            DispatchQueue.main.async {
+                self.jobs = decoded.sorted { $0.date > $1.date }
+                self.isLoading = false
+            }
+        }
+    }
+
+    func stopListening() {
+        listener?.remove()
+        listener = nil
+    }
+
+    func groups(for filter: CrewRoleFilter) -> [RecentCrewJobGroup] {
+        let filtered: [RecentCrewJob]
+        switch filter {
+        case .all:
+            filtered = jobs
+        case .underground, .aerial, .can, .nid:
+            filtered = jobs.filter { $0.matches(filter) }
+        }
+
+        guard !filtered.isEmpty else { return [] }
+
+        let grouped = Dictionary(grouping: filtered) { $0.groupingKey }
+
+        let mapped: [RecentCrewJobGroup] = grouped.compactMap { key, value in
+            let sortedEntries = value.sorted { $0.date > $1.date }
+            guard let representative = sortedEntries.first else { return nil }
+            return RecentCrewJobGroup(
+                id: key,
+                title: representative.displayTitle,
+                subtitle: representative.subtitleText,
+                jobs: sortedEntries
+            )
+        }
+
+        return mapped.sorted { $0.latestDate > $1.latestDate }
+    }
+}
+
+struct RecentCrewJobGroup: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let jobs: [RecentCrewJob]
+
+    var latestDate: Date {
+        jobs.map(\.date).max() ?? .distantPast
+    }
+
+    var primaryRole: String? {
+        jobs.first?.displayCrewRole
+    }
+
+    var latestStatus: String {
+        jobs.first?.status ?? ""
+    }
+
+    var latestFormattedDate: String? {
+        jobs.first?.formattedDate
+    }
+
+    var isMultiEntry: Bool { jobs.count > 1 }
+
+    var entryCount: Int { jobs.count }
+}
+
+struct RecentCrewJob: Identifiable, Codable, Hashable {
+    var id: String = UUID().uuidString
+    let jobNumber: String?
+    let address: String
+    let status: String
+    let date: Date
+    let notes: String?
+    let createdBy: String?
+    let assignedTo: String?
+    let hours: Double?
+    let materialsUsed: String?
+    let canFootage: String?
+    let nidFootage: String?
+    let photos: [String]?
+    let participants: [String]?
+    let crewLead: String?
+    let crewName: String?
+
+    private let crewRoleRaw: String?
+    private let crewRaw: String?
+    private let roleRaw: String?
+    private let extraRoleValues: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case jobNumber
+        case address
+        case status
+        case date
+        case notes
+        case createdBy
+        case assignedTo
+        case hours
+        case materialsUsed
+        case canFootage
+        case nidFootage
+        case photos
+        case participants
+        case crewLead
+        case crewName
+        case crewRole
+        case crew
+        case role
+        case crewRoleNormalized
+        case primaryRole
+        case position
+        case crewType
+        case teamRole
+    }
+
+    init(
+        id: String = UUID().uuidString,
+        jobNumber: String?,
+        address: String,
+        status: String,
+        date: Date,
+        notes: String?,
+        createdBy: String?,
+        assignedTo: String?,
+        hours: Double?,
+        materialsUsed: String?,
+        canFootage: String?,
+        nidFootage: String?,
+        photos: [String]?,
+        participants: [String]?,
+        crewLead: String?,
+        crewName: String?,
+        crewRoleRaw: String?,
+        crewRaw: String?,
+        roleRaw: String?,
+        extraRoleValues: [String]
+    ) {
+        self.id = id
+        self.jobNumber = jobNumber
+        self.address = address
+        self.status = status
+        self.date = date
+        self.notes = notes
+        self.createdBy = createdBy
+        self.assignedTo = assignedTo
+        self.hours = hours
+        self.materialsUsed = materialsUsed
+        self.canFootage = canFootage
+        self.nidFootage = nidFootage
+        self.photos = photos
+        self.participants = participants
+        self.crewLead = crewLead
+        self.crewName = crewName
+        self.crewRoleRaw = crewRoleRaw
+        self.crewRaw = crewRaw
+        self.roleRaw = roleRaw
+        self.extraRoleValues = extraRoleValues
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        self.jobNumber = try container.decodeIfPresent(String.self, forKey: .jobNumber)
+        self.address = try container.decodeIfPresent(String.self, forKey: .address) ?? ""
+        self.status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        self.date = try container.decodeIfPresent(Date.self, forKey: .date) ?? Date()
+        self.notes = try container.decodeIfPresent(String.self, forKey: .notes)
+        self.createdBy = try container.decodeIfPresent(String.self, forKey: .createdBy)
+        self.assignedTo = try container.decodeIfPresent(String.self, forKey: .assignedTo)
+        self.hours = try container.decodeIfPresent(Double.self, forKey: .hours)
+        self.materialsUsed = try container.decodeIfPresent(String.self, forKey: .materialsUsed)
+        self.canFootage = try container.decodeIfPresent(String.self, forKey: .canFootage)
+        self.nidFootage = try container.decodeIfPresent(String.self, forKey: .nidFootage)
+        self.photos = try container.decodeIfPresent([String].self, forKey: .photos)
+        self.participants = try container.decodeIfPresent([String].self, forKey: .participants)
+        self.crewLead = try container.decodeIfPresent(String.self, forKey: .crewLead)
+        self.crewName = try container.decodeIfPresent(String.self, forKey: .crewName)
+
+        self.crewRoleRaw = try container.decodeIfPresent(String.self, forKey: .crewRole)
+        self.crewRaw = try container.decodeIfPresent(String.self, forKey: .crew)
+        self.roleRaw = try container.decodeIfPresent(String.self, forKey: .role)
+
+        let normalized = try container.decodeIfPresent(String.self, forKey: .crewRoleNormalized)
+        let primaryRole = try container.decodeIfPresent(String.self, forKey: .primaryRole)
+        let position = try container.decodeIfPresent(String.self, forKey: .position)
+        let crewType = try container.decodeIfPresent(String.self, forKey: .crewType)
+        let teamRole = try container.decodeIfPresent(String.self, forKey: .teamRole)
+        self.extraRoleValues = [normalized, primaryRole, position, crewType, teamRole].compactMap { value in
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }
+            return trimmed
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: RecentCrewJob, rhs: RecentCrewJob) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+extension RecentCrewJob {
+    private var rawRoleCandidates: [String] {
+        var values: [String] = []
+        for candidate in [crewRoleRaw, crewRaw, roleRaw] {
+            if let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+                values.append(trimmed)
+            }
+        }
+        values.append(contentsOf: extraRoleValues)
+        return values
+    }
+
+    var normalizedCrewRole: String? {
+        for candidate in rawRoleCandidates {
+            if let normalized = RecentCrewJob.normalizeRole(candidate) {
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    var displayCrewRole: String? {
+        normalizedCrewRole ?? rawRoleCandidates.first
+    }
+
+    private static func normalizeRole(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lower = trimmed.lowercased()
+        if lower.contains("underground") || lower == "ug" || lower.contains("ug crew") || lower.contains("u/g") {
+            return CrewRoleFilter.underground.rawValue
+        }
+        if lower.contains("aerial") || lower.contains("ariel") {
+            return CrewRoleFilter.aerial.rawValue
+        }
+        if lower.contains("can") {
+            return CrewRoleFilter.can.rawValue
+        }
+        if lower.contains("nid") {
+            return CrewRoleFilter.nid.rawValue
+        }
+        return nil
+    }
+
+    func matches(_ filter: RecentCrewJobsViewModel.CrewRoleFilter) -> Bool {
+        guard filter != .all else { return true }
+        guard let normalized = normalizedCrewRole else { return false }
+        return normalized.caseInsensitiveCompare(filter.rawValue) == .orderedSame
+    }
+
+    var trimmedJobNumber: String? {
+        guard let jobNumber = jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !jobNumber.isEmpty else { return nil }
+        return jobNumber
+    }
+
+    var shortAddress: String {
+        if let line = address.split(whereSeparator: { $0 == "\n" || $0 == "," }).first {
+            return line.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return address
+    }
+
+    var displayTitle: String {
+        trimmedJobNumber ?? shortAddress
+    }
+
+    var subtitleText: String {
+        if trimmedJobNumber != nil {
+            return shortAddress
+        }
+        return CrewJobDateFormatter.shared.string(from: date)
+    }
+
+    private var normalizedAddressKey: String {
+        address.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+    }
+
+    var groupingKey: String {
+        if let number = trimmedJobNumber?.uppercased() {
+            return "job-number::\(number)"
+        }
+        return "address::\(normalizedAddressKey)"
+    }
+
+    var formattedDate: String {
+        CrewJobDateFormatter.shared.string(from: date)
+    }
+}
+
+private final class CrewJobDateFormatter {
+    static let shared = CrewJobDateFormatter()
+    private let formatter: DateFormatter
+
+    private init() {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.locale = .current
+        self.formatter = formatter
+    }
+
+    func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+}

--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -7,6 +7,7 @@ final class AppNavigationViewModel: ObservableObject {
         case timesheets
         case yellowSheet
         case maps
+        case recentCrewJobs
         case search
         case more
         case profile
@@ -24,6 +25,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return "Timesheets"
             case .yellowSheet: return "Yellow Sheet"
             case .maps:        return "Route Mapper"
+            case .recentCrewJobs: return "Recent Crew Jobs"
             case .search:      return "Job Search"
             case .more:        return "More"
             case .profile:     return "Profile"
@@ -41,6 +43,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return "clock"
             case .yellowSheet: return "doc.text"
             case .maps:        return "map"
+            case .recentCrewJobs: return "clock.arrow.circlepath"
             case .search:      return "magnifyingglass"
             case .more:        return "ellipsis.circle"
             case .profile:     return "person.crop.circle"
@@ -58,6 +61,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .timesheets:  return .timesheets
             case .yellowSheet: return .yellowSheet
             case .maps:        return .more
+            case .recentCrewJobs: return .more
             case .search:      return .search
             case .more,
                  .profile,
@@ -72,7 +76,7 @@ final class AppNavigationViewModel: ObservableObject {
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps:
+            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs:
                 return true
             default:
                 return false

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -155,6 +155,13 @@ private struct MoreMenuList: View {
                 }
             }
 
+            Section("Jobs") {
+                NavigationLink(value: AppNavigationViewModel.Destination.recentCrewJobs) {
+                    Label(AppNavigationViewModel.Destination.recentCrewJobs.title,
+                          systemImage: AppNavigationViewModel.Destination.recentCrewJobs.systemImage)
+                }
+            }
+
             Section("Resources") {
                 NavigationLink(value: AppNavigationViewModel.Destination.maps) {
                     Label(AppNavigationViewModel.Destination.maps.title,
@@ -218,6 +225,8 @@ private struct MoreDestinationView: View {
             SettingsView()
         case .helpCenter:
             HelpCenterView()
+        case .recentCrewJobs:
+            RecentCrewJobsView()
         case .more:
             MoreMenuList()
         default:


### PR DESCRIPTION
## Summary
- add a Recent Crew Jobs destination in the navigation model and surface it from the More tab
- implement a RecentCrewJobsView + view model that listens for non-pending jobs from the last 14 days, supports crew-role filters, and groups submissions by job number or address
- provide detail drill-ins with original job metadata and an Add to Dashboard action that seeds a new pending job for the current user

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d17df2bdd8832d9d00eecd9817c0a4