### PR TITLE
Ensure ShellActionButtons align when menu hidden

### DIFF
--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -238,15 +238,17 @@ private struct MoreDestinationView: View {
 // MARK: - Action buttons & menu
 
 struct ShellActionButtons: View {
-    var onShowMenu: () -> Void
+    var onShowMenu: (() -> Void)? = nil
     var onOpenHelp: () -> Void
     var horizontalPadding: CGFloat = 16
     var topPadding: CGFloat = 12
 
     var body: some View {
         HStack(spacing: 12) {
-            RoundedActionButton(icon: "line.3.horizontal", label: "Menu", action: onShowMenu)
-            Spacer()
+            if let onShowMenu {
+                RoundedActionButton(icon: "line.3.horizontal", label: "Menu", action: onShowMenu)
+            }
+            Spacer(minLength: 0)
             RoundedActionButton(icon: "questionmark.circle", label: "Help", action: onOpenHelp)
         }
         .padding(.horizontal, horizontalPadding)

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -31,6 +31,7 @@ struct WeeklyTimesheetView: View {
     // Top padding to provide breathing room above the week picker and action buttons.
     private let topContentPadding: CGFloat = 20
     @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @EnvironmentObject private var navigation: AppNavigationViewModel
     // Use an independent view model for timesheet jobs.
     @StateObject private var timesheetJobsVM = TimesheetJobsViewModel()
@@ -170,7 +171,7 @@ struct WeeklyTimesheetView: View {
 
                         // Global quick actions placed below the week picker to avoid overlaps.
                         ShellActionButtons(
-                            onShowMenu: { navigation.isPrimaryMenuPresented = true },
+                            onShowMenu: horizontalSizeClass == .compact ? nil : { navigation.isPrimaryMenuPresented = true },
                             onOpenHelp: { navigation.navigate(to: .helpCenter) },
                             horizontalPadding: 0,
                             topPadding: 0


### PR DESCRIPTION
## Summary
- allow ShellActionButtons to hide the menu action while keeping the help button aligned to the trailing edge
- hide the menu button in WeeklyTimesheetView when running in a compact horizontal size class so the help pill anchors to the trailing edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1838e01c0832db2536a9966f61607