### PR TITLE
Annotate statusTint helper with MainActor

### DIFF
--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -276,7 +276,7 @@ private struct CrewJobChip: View {
     }
 }
 
-private func statusTint(for status: String) -> Color {
+@MainActor private func statusTint(for status: String) -> Color {
     let lower = status.lowercased()
     if lower.contains("done") || lower.contains("complete") {
         return JTColors.success


### PR DESCRIPTION
## Summary
- add the @MainActor attribute to statusTint(for:) so JTColors lookups occur on the main actor

## Testing
- swiftc 'Job Tracker/Features/Shared/More/RecentCrewJobsView.swift' *(fails: SwiftUI module unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1dc53a7cc832db0a54bb8d8dfc43a