### PR TITLE
Add recent crew jobs case to AppShellDetailView

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppShellView.swift
+++ b/Job Tracker/Features/Shared/Shell/AppShellView.swift
@@ -87,6 +87,8 @@ private struct AppShellDetailView: View {
             WeeklyTimesheetView()
         case .yellowSheet:
             YellowSheetView()
+        case .recentCrewJobs:
+            RecentCrewJobsView()
         case .search:
             JobSearchView(viewModel: JobSearchViewModel(jobsViewModel: jobsViewModel, usersViewModel: usersViewModel))
         case .maps:


### PR DESCRIPTION
## Summary
- add the recent crew jobs destination to the AppShellDetailView switch so it presents RecentCrewJobsView

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1e275a06c832db231c7eb3cda01a9