### PR TITLE
Refine notes card builder

### DIFF
--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -392,7 +392,7 @@ private struct RecentCrewJobDetailSheet: View {
     }
 
     @ViewBuilder private var notesCard: some View {
-        if let notes = job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
+        if let notes = normalizedNonEmpty(job.notes) {
             GlassCard {
                 VStack(alignment: .leading, spacing: JTSpacing.sm) {
                     Text("Notes")


### PR DESCRIPTION
## Summary
- reuse the existing normalized helper for the notes card and keep it inside the view builder

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1e27b0434832d99662dae5c1267c0