### PR TITLE
Add crew role fallback for recent jobs

### DIFF
--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -1,9 +1,21 @@
 import SwiftUI
 
 struct RecentCrewJobsView: View {
-    @StateObject private var viewModel = RecentCrewJobsViewModel()
+    @EnvironmentObject private var usersViewModel: UsersViewModel
+
+    var body: some View {
+        RecentCrewJobsContent(userLookup: { usersViewModel.usersDict })
+    }
+}
+
+private struct RecentCrewJobsContent: View {
+    @StateObject private var viewModel: RecentCrewJobsViewModel
     @State private var selectedFilter: RecentCrewJobsViewModel.CrewRoleFilter = .all
     @State private var selectedJob: RecentCrewJob?
+
+    init(userLookup: @escaping () -> [String: AppUser]) {
+        _viewModel = StateObject(wrappedValue: RecentCrewJobsViewModel(userLookup: userLookup))
+    }
 
     var body: some View {
         ZStack {

--- a/Job TrackerTests/RecentCrewJobsViewModelTests.swift
+++ b/Job TrackerTests/RecentCrewJobsViewModelTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Job_Tracker
+
+final class RecentCrewJobsViewModelTests: XCTestCase {
+    func testCrewRoleFiltersFallbackToSubmitterPosition() {
+        let users: [String: AppUser] = [
+            "ug-user": AppUser(id: "ug-user", firstName: "Una", lastName: "Ground", email: "ug@example.com", position: "Underground"),
+            "aerial-user": AppUser(id: "aerial-user", firstName: "Al", lastName: "Aerial", email: "aerial@example.com", position: "Ariel"),
+            "can-user": AppUser(id: "can-user", firstName: "Cam", lastName: "North", email: "can@example.com", position: "CAN"),
+            "nid-user": AppUser(id: "nid-user", firstName: "Nia", lastName: "Down", email: "nid@example.com", position: "nid")
+        ]
+
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let jobs: [RecentCrewJob] = [
+            RecentCrewJob(
+                id: "job-underground",
+                jobNumber: "UG-1",
+                address: "101 Underground Way",
+                status: "Completed",
+                date: baseDate,
+                notes: nil,
+                createdBy: "ug-user",
+                assignedTo: nil,
+                hours: nil,
+                materialsUsed: nil,
+                canFootage: nil,
+                nidFootage: nil,
+                photos: nil,
+                participants: nil,
+                crewLead: nil,
+                crewName: nil,
+                crewRoleRaw: nil,
+                crewRaw: nil,
+                roleRaw: nil,
+                extraRoleValues: []
+            ),
+            RecentCrewJob(
+                id: "job-aerial",
+                jobNumber: "AR-1",
+                address: "202 Aerial Ave",
+                status: "Completed",
+                date: baseDate.addingTimeInterval(60),
+                notes: nil,
+                createdBy: "aerial-user",
+                assignedTo: nil,
+                hours: nil,
+                materialsUsed: nil,
+                canFootage: nil,
+                nidFootage: nil,
+                photos: nil,
+                participants: nil,
+                crewLead: nil,
+                crewName: nil,
+                crewRoleRaw: nil,
+                crewRaw: nil,
+                roleRaw: nil,
+                extraRoleValues: []
+            ),
+            RecentCrewJob(
+                id: "job-can",
+                jobNumber: "CA-1",
+                address: "303 Can Rd",
+                status: "Completed",
+                date: baseDate.addingTimeInterval(120),
+                notes: nil,
+                createdBy: "can-user",
+                assignedTo: nil,
+                hours: nil,
+                materialsUsed: nil,
+                canFootage: nil,
+                nidFootage: nil,
+                photos: nil,
+                participants: nil,
+                crewLead: nil,
+                crewName: nil,
+                crewRoleRaw: nil,
+                crewRaw: nil,
+                roleRaw: nil,
+                extraRoleValues: []
+            ),
+            RecentCrewJob(
+                id: "job-nid",
+                jobNumber: "NI-1",
+                address: "404 Nid Blvd",
+                status: "Completed",
+                date: baseDate.addingTimeInterval(180),
+                notes: nil,
+                createdBy: "nid-user",
+                assignedTo: nil,
+                hours: nil,
+                materialsUsed: nil,
+                canFootage: nil,
+                nidFootage: nil,
+                photos: nil,
+                participants: nil,
+                crewLead: nil,
+                crewName: nil,
+                crewRoleRaw: nil,
+                crewRaw: nil,
+                roleRaw: nil,
+                extraRoleValues: []
+            )
+        ]
+
+        let viewModel = RecentCrewJobsViewModel(userLookup: { users }, initialJobs: jobs)
+
+        XCTAssertEqual(viewModel.groups(for: .all).flatMap { $0.jobs }.map(\.id).sorted(), ["job-aerial", "job-can", "job-nid", "job-underground"].sorted())
+
+        XCTAssertEqual(viewModel.groups(for: .underground).flatMap { $0.jobs }.map(\.id), ["job-underground"])
+        XCTAssertEqual(viewModel.groups(for: .aerial).flatMap { $0.jobs }.map(\.id), ["job-aerial"])
+        XCTAssertEqual(viewModel.groups(for: .can).flatMap { $0.jobs }.map(\.id), ["job-can"])
+        XCTAssertEqual(viewModel.groups(for: .nid).flatMap { $0.jobs }.map(\.id), ["job-nid"])
+    }
+}


### PR DESCRIPTION
## Summary
- provide RecentCrewJobsViewModel with a user lookup via UsersViewModel and restructure the view wrapper
- add submitter-role enrichment and fallback crew-role matching in RecentCrewJobsViewModel/RecentCrewJob
- cover legacy documents with a unit test that ensures crew filters match when crewRole fields are missing

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1e987c8a0832d932f27d5e245afc9