### PR TITLE
Resolve crew job detail names via UsersViewModel

### DIFF
--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -295,6 +295,7 @@ private struct RecentCrewJobDetailSheet: View {
     let job: RecentCrewJob
 
     @EnvironmentObject private var jobsViewModel: JobsViewModel
+    @EnvironmentObject private var usersViewModel: UsersViewModel
     @EnvironmentObject private var authViewModel: AuthViewModel
     @Environment(\.dismiss) private var dismiss
 
@@ -393,7 +394,7 @@ private struct RecentCrewJobDetailSheet: View {
     }
 
     @ViewBuilder private var notesCard: some View {
-        if let notes = normalizedNonEmpty(job.notes) {
+        if let notes = Self.normalizedNonEmpty(job.notes) {
             GlassCard {
                 VStack(alignment: .leading, spacing: JTSpacing.sm) {
                     Text("Notes")
@@ -412,6 +413,10 @@ private struct RecentCrewJobDetailSheet: View {
     }
 
     private var detailItems: [DetailItem] {
+        Self.makeDetailItems(for: job, usersViewModel: usersViewModel)
+    }
+
+    static func makeDetailItems(for job: RecentCrewJob, usersViewModel: UsersViewModel) -> [DetailItem] {
         var items: [DetailItem] = []
 
         if let jobNumber = job.trimmedJobNumber {
@@ -425,11 +430,11 @@ private struct RecentCrewJobDetailSheet: View {
         items.append(DetailItem(icon: "calendar", title: "Date", value: job.formattedDate))
         items.append(DetailItem(icon: "flag.fill", title: "Status", value: job.status))
 
-        if let crewName = normalizedNonEmpty(job.crewName) {
+        if let crewName = Self.displayName(for: job.crewName, usersViewModel: usersViewModel) {
             items.append(DetailItem(icon: "person.2", title: "Crew Name", value: crewName))
         }
 
-        if let crewLead = normalizedNonEmpty(job.crewLead) {
+        if let crewLead = Self.displayName(for: job.crewLead, usersViewModel: usersViewModel) {
             items.append(DetailItem(icon: "person.crop.circle.badge.checkmark", title: "Crew Lead", value: crewLead))
         }
 
@@ -437,27 +442,55 @@ private struct RecentCrewJobDetailSheet: View {
             items.append(DetailItem(icon: "clock", title: "Hours", value: String(format: "%.1f", hours)))
         }
 
-        if let materials = normalizedNonEmpty(job.materialsUsed) {
+        if let materials = Self.normalizedNonEmpty(job.materialsUsed) {
             items.append(DetailItem(icon: "shippingbox", title: "Materials Used", value: materials))
         }
 
-        if let canFootage = normalizedNonEmpty(job.canFootage) {
+        if let canFootage = Self.normalizedNonEmpty(job.canFootage) {
             items.append(DetailItem(icon: "ruler", title: "CAN Footage", value: canFootage))
         }
 
-        if let nidFootage = normalizedNonEmpty(job.nidFootage) {
+        if let nidFootage = Self.normalizedNonEmpty(job.nidFootage) {
             items.append(DetailItem(icon: "ruler", title: "NID Footage", value: nidFootage))
         }
 
-        if let createdBy = normalizedNonEmpty(job.createdBy) {
+        if let createdBy = Self.displayName(for: job.createdBy, usersViewModel: usersViewModel) {
             items.append(DetailItem(icon: "person.badge.key", title: "Created By", value: createdBy))
         }
 
-        if let assignedTo = normalizedNonEmpty(job.assignedTo) {
+        if let assignedTo = Self.displayName(for: job.assignedTo, usersViewModel: usersViewModel) {
             items.append(DetailItem(icon: "person.crop.circle.badge.exclam", title: "Assigned To", value: assignedTo))
         }
 
         return items
+    }
+
+    static func displayName(for rawValue: String?, usersViewModel: UsersViewModel) -> String? {
+        guard let trimmed = Self.normalizedNonEmpty(rawValue) else { return nil }
+        if let user = usersViewModel.user(id: trimmed) {
+            let components = [Self.normalizedNonEmpty(user.firstName), Self.normalizedNonEmpty(user.lastName)].compactMap { $0 }
+            if !components.isEmpty {
+                return components.joined(separator: " ")
+            }
+            if let email = Self.normalizedNonEmpty(user.email) {
+                return email
+            }
+        }
+        return trimmed
+    }
+
+    static func normalizedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    struct DetailItem: Identifiable {
+        let id = UUID()
+        let icon: String
+        let title: String
+        let value: String
     }
 
     private func addToDashboard() {
@@ -494,17 +527,4 @@ private struct RecentCrewJobDetailSheet: View {
         }
     }
 
-    private func normalizedNonEmpty(_ value: String?) -> String? {
-        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
-            return nil
-        }
-        return trimmed
-    }
-
-    private struct DetailItem: Identifiable {
-        let id = UUID()
-        let icon: String
-        let title: String
-        let value: String
-    }
 }

--- a/Job Tracker/Features/Shared/Team/UsersViewModel.swift
+++ b/Job Tracker/Features/Shared/Team/UsersViewModel.swift
@@ -21,8 +21,11 @@ class UsersViewModel: ObservableObject {
     
     private var listenerRegistration: ListenerRegistration?
     
-    init() {
-        listenToAllUsers()
+    init(shouldListen: Bool = true, seedUsers: [String: AppUser] = [:]) {
+        self.usersDict = seedUsers
+        if shouldListen {
+            listenToAllUsers()
+        }
     }
     
     deinit {

--- a/Job TrackerTests/RecentCrewJobDetailSheetTests.swift
+++ b/Job TrackerTests/RecentCrewJobDetailSheetTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Job_Tracker
+
+final class RecentCrewJobDetailSheetTests: XCTestCase {
+    private func makeJob(
+        createdBy: String? = nil,
+        assignedTo: String? = nil,
+        crewLead: String? = nil
+    ) -> RecentCrewJob {
+        RecentCrewJob(
+            id: "job-1",
+            jobNumber: "JT-1001",
+            address: "123 Main Street",
+            status: "Pending",
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            notes: nil,
+            createdBy: createdBy,
+            assignedTo: assignedTo,
+            hours: nil,
+            materialsUsed: nil,
+            canFootage: nil,
+            nidFootage: nil,
+            photos: nil,
+            participants: nil,
+            crewLead: crewLead,
+            crewName: nil,
+            crewRoleRaw: "Aerial",
+            crewRaw: nil,
+            roleRaw: nil,
+            extraRoleValues: []
+        )
+    }
+
+    func testDetailItemsUseDisplayNameWhenProfileFound() {
+        let user = AppUser(
+            id: "user-123",
+            firstName: "Jordan",
+            lastName: "Taylor",
+            email: "jordan@example.com",
+            position: "Technician"
+        )
+        let usersViewModel = UsersViewModel(shouldListen: false, seedUsers: [user.id: user])
+        let job = makeJob(createdBy: user.id, crewLead: user.id)
+
+        let items = RecentCrewJobDetailSheet.makeDetailItems(for: job, usersViewModel: usersViewModel)
+
+        XCTAssertEqual(
+            items.first(where: { $0.title == "Created By" })?.value,
+            "Jordan Taylor"
+        )
+        XCTAssertEqual(
+            items.first(where: { $0.title == "Crew Lead" })?.value,
+            "Jordan Taylor"
+        )
+    }
+
+    func testDetailItemsFallbackToUIDWhenProfileMissing() {
+        let usersViewModel = UsersViewModel(shouldListen: false)
+        let job = makeJob(assignedTo: "unknown-user")
+
+        let items = RecentCrewJobDetailSheet.makeDetailItems(for: job, usersViewModel: usersViewModel)
+
+        XCTAssertEqual(
+            items.first(where: { $0.title == "Assigned To" })?.value,
+            "unknown-user"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- inject UsersViewModel into RecentCrewJobDetailSheet and add helpers to resolve UIDs to display names
- update detail item generation to show friendly names for crew lead, creator, assignee, and other UID-backed fields
- add flexible UsersViewModel initializer plus unit tests covering the new name resolution logic

## Testing
- not run (xcodebuild is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d1e9831bb8832d986e9146bbc9eb04