### PR TITLE
Apply consistent dark navigation bar styling

### DIFF
--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -17,6 +17,26 @@ private struct JTGlassBackgroundModifier<S: Shape>: ViewModifier {
     }
 }
 
+@MainActor
+private struct JTNavigationBarModifier: ViewModifier {
+    @EnvironmentObject private var themeManager: JTThemeManager
+
+    private var backgroundStyle: LinearGradient {
+        LinearGradient(
+            colors: themeManager.theme.backgroundGradientStops(count: 3),
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarBackground(backgroundStyle, for: .navigationBar)
+            .toolbarColorScheme(themeManager.theme.colorScheme, for: .navigationBar)
+    }
+}
+
 @MainActor public extension View {
     func jtGlassBackground(cornerRadius: CGFloat = JTShapes.cardCornerRadius,
                            strokeColor: Color? = nil,
@@ -38,6 +58,10 @@ private struct JTGlassBackgroundModifier<S: Shape>: ViewModifier {
                 strokeWidth: strokeWidth
             )
         )
+    }
+
+    func jtNavigationBarStyle() -> some View {
+        modifier(JTNavigationBarModifier())
     }
 }
 

--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -257,6 +257,7 @@ struct JobCard: View {
                             }
                         }
                     }
+                    .jtNavigationBarStyle()
                 }
                 .presentationDetents([.medium])
             }

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -142,6 +142,7 @@ struct DashboardView: View {
                 .padding(.top, JTSpacing.md)
             }
             .toolbar(navigationBarVisibility, for: .navigationBar)
+            .jtNavigationBarStyle()
             .safeAreaInset(edge: .top) {
                 Color.clear.frame(height: shellChromeHeight)
             }

--- a/Job Tracker/Features/Help/HelpCenterView.swift
+++ b/Job Tracker/Features/Help/HelpCenterView.swift
@@ -278,12 +278,14 @@ struct HelpCenterView: View {
         }
         .sheet(isPresented: $showingCreateJob) {
             NavigationStack { CreateJobView() }
+            .jtNavigationBarStyle()
         }
         .sheet(item: $selectedTopic) { topic in
             TopicDetailSheet(topic: topic)
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(navigationBarVisibility, for: .navigationBar)
+        .jtNavigationBarStyle()
     }
 
     // Topic detail sheet
@@ -327,6 +329,7 @@ struct HelpCenterView: View {
                     }
                 }
             }
+            .jtNavigationBarStyle()
         }
     }
 }

--- a/Job Tracker/Features/Help/InteractiveTutorialView.swift
+++ b/Job Tracker/Features/Help/InteractiveTutorialView.swift
@@ -378,6 +378,7 @@ struct InteractiveTutorialView: View {
             }
             .navigationTitle("Interactive Tutorial")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     if onComplete != nil {

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -419,6 +419,7 @@ struct CreateJobView: View {
             }
             .navigationTitle("Create Job")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Close") { dismiss() }

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -261,9 +261,8 @@ private let fiberChoices = ["Flat", "Round", "Mainline"]
                 .scrollContentBackground(.hidden)   // keep gradient visible
                 .navigationTitle("Job Detail")
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+                .jtNavigationBarStyle()
                 .navBarBackgroundVisibilityIfAvailable(.visible)
-                .toolbarColorScheme(.dark, for: .navigationBar)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button("Cancel") { dismiss() }

--- a/Job Tracker/Features/Jobs/Editor/SupervisorJobImportView.swift
+++ b/Job Tracker/Features/Jobs/Editor/SupervisorJobImportView.swift
@@ -208,6 +208,7 @@ struct SupervisorJobImportView: View {
                     Button("Done") { dismiss() }
                 }
             }
+            .jtNavigationBarStyle()
         }
         .sheet(isPresented: $showImagePicker) {
             ImagePicker(image: $pickedImage)

--- a/Job Tracker/Features/Jobs/ExtraWorkView.swift
+++ b/Job Tracker/Features/Jobs/ExtraWorkView.swift
@@ -56,6 +56,7 @@ struct ExtraWorkView: View {
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Extra Work")
+            .jtNavigationBarStyle()
             .sheet(item: $selectedJob) { job in
                 if let index = jobsViewModel.jobs.firstIndex(where: { $0.id == job.id }) {
                     JobDetailView(job: $jobsViewModel.jobs[index])

--- a/Job Tracker/Features/Jobs/Sharing/JobImportPreviewView.swift
+++ b/Job Tracker/Features/Jobs/Sharing/JobImportPreviewView.swift
@@ -92,6 +92,7 @@ struct JobImportPreviewView: View {
                 }
                 .navigationTitle("Import Job")
                 .navigationBarTitleDisplayMode(.inline)
+                .jtNavigationBarStyle()
                 .interactiveDismissDisabled(isImporting)
 
                 if isImporting {

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -765,6 +765,7 @@ struct SupervisorCreateJobView: View {
             }
             .navigationTitle("New Job")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Close") { dismiss() }
@@ -889,6 +890,7 @@ private struct UserSelectSheet: View {
                     Button("Close") { dismiss() }
                 }
             }
+            .jtNavigationBarStyle()
         }
     }
 

--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -48,6 +48,7 @@ struct JobSearchView: View {
                 }
             }
         }
+        .jtNavigationBarStyle()
         .safeAreaInset(edge: .top) {
             Color.clear.frame(height: shellChromeHeight)
         }

--- a/Job Tracker/Features/Settings/ProfileView.swift
+++ b/Job Tracker/Features/Settings/ProfileView.swift
@@ -34,6 +34,7 @@ struct ProfileView: View {
             }
             .navigationTitle("Profile")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
         }
         .onAppear {
             if let user = authViewModel.currentUser {

--- a/Job Tracker/Features/Settings/SettingsView.swift
+++ b/Job Tracker/Features/Settings/SettingsView.swift
@@ -465,6 +465,7 @@ private struct ThemeEditorSheet: View {
             }
             .navigationTitle("Custom Theme")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { isPresented = false }

--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -1025,6 +1025,7 @@ struct MapsView: View {
                         }
                     }
                 }
+                .jtNavigationBarStyle()
             }
             .sheet(isPresented: $showInviteShare) {
                 if let code = sessionID {
@@ -1701,6 +1702,7 @@ struct MapsView: View {
                     }
                 }
             }
+            .jtNavigationBarStyle()
         }
     }
 
@@ -1926,6 +1928,7 @@ struct MapsView: View {
                     }
                 }
             }
+            .jtNavigationBarStyle()
         }
 
         // tiny wrapper for fullScreenCover

--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -353,6 +353,7 @@ private struct RecentCrewJobDetailSheet: View {
                 Text(errorMessage ?? "Unknown error")
             }
         }
+        .jtNavigationBarStyle()
     }
 
     private var summaryCard: some View {

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -82,6 +82,7 @@ struct MoreTabView: View {
                     MoreDestinationView(destination: destination)
                 }
         }
+        .jtNavigationBarStyle()
         .background(JTGradients.background(stops: 4).ignoresSafeArea())
         .onAppear {
             if !navigation.activeDestination.isMoreStackDestination {

--- a/Job Tracker/Features/Timesheets/JobEditView.swift
+++ b/Job Tracker/Features/Timesheets/JobEditView.swift
@@ -27,6 +27,7 @@ struct JobEditView: View {
                 }
             }
             .navigationTitle("Edit Job")
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {

--- a/Job Tracker/Features/Timesheets/PastTimesheetsView.swift
+++ b/Job Tracker/Features/Timesheets/PastTimesheetsView.swift
@@ -40,6 +40,7 @@ struct PastTimesheetsView: View {
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Past Timesheets")
+            .jtNavigationBarStyle()
             .onAppear {
                 if let user = authViewModel.currentUser {
                     timesheetListVM.fetchTimesheets(for: user.id)

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -232,8 +232,7 @@ struct WeeklyTimesheetView: View {
             }
             .navigationTitle("Timesheet")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
                     Button {
@@ -364,6 +363,7 @@ struct WeeklyTimesheetView: View {
                     })
                     .padding()
             }
+            .jtNavigationBarStyle()
         }
     }
 }
@@ -750,6 +750,7 @@ struct PDFPreviewSheet: View {
                     }
                 }
         }
+        .jtNavigationBarStyle()
     }
 }
 

--- a/Job Tracker/Features/YellowSheet/PastYellowSheetsView.swift
+++ b/Job Tracker/Features/YellowSheet/PastYellowSheetsView.swift
@@ -39,6 +39,7 @@ struct PastYellowSheetsView: View {
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Past Yellow Sheets")
+            .jtNavigationBarStyle()
             .onAppear {
                 if let user = authViewModel.currentUser {
                     yellowSheetsVM.fetchYellowSheets(for: user.id)

--- a/Job Tracker/Features/YellowSheet/YellowSheetView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetView.swift
@@ -63,6 +63,7 @@ struct YellowSheetView: View {
                 .padding(.top, topContentPadding)
             }
             .navigationTitle("     ")
+            .jtNavigationBarStyle()
             .onAppear {
                 if let me = authViewModel.currentUser?.id {
                     FirebaseService.shared.fetchPartnerId(for: me) { pid in
@@ -101,6 +102,7 @@ struct YellowSheetView: View {
                     })
                     .padding()
             }
+            .jtNavigationBarStyle()
         }
     }
     


### PR DESCRIPTION
## Summary
- add a `jtNavigationBarStyle()` modifier in the design system that reads the active JTTheme and applies a dark gradient to navigation bars
- replace ad-hoc toolbar background calls in Job Detail, Weekly Timesheet, and other navigation stacks with the new modifier
- apply the modifier to every primary NavigationStack/NavigationView used by tabs and modal flows so navigation chrome is consistently opaque

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1fb41be14832d8ca068565d48ecbf