### PR TITLE
Add dashboard add flow to job search detail

### DIFF
--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct JobSearchView: View {
     @EnvironmentObject private var jobsViewModel: JobsViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var navigation: AppNavigationViewModel
     @Environment(\.shellChromeHeight) private var shellChromeHeight
 
@@ -42,7 +43,9 @@ struct JobSearchView: View {
             .navigationDestination(for: JobSearchViewModel.Result.self) { result in
                 if let job = viewModel.job(for: result.id) {
                     JobSearchDetailView(job: job, metadata: result)
+                        .environmentObject(jobsViewModel)
                         .environmentObject(usersViewModel)
+                        .environmentObject(authViewModel)
                 } else {
                     MissingSearchResultView()
                 }


### PR DESCRIPTION
## Summary
- inject the jobs and auth environment dependencies into `JobSearchDetailView`
- add dashboard add state, safe-area action button, and dashboard creation flow with unified alert handling
- forward the necessary environment objects from `JobSearchView`

## Testing
- Not run (Xcode unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2bcb9c144832d87716c6238ed64fa