### PR TITLE
Geocode crew job imports before creating dashboard job

### DIFF
--- a/Job TrackerTests/RecentCrewJobDetailSheetTests.swift
+++ b/Job TrackerTests/RecentCrewJobDetailSheetTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CoreLocation
 @testable import Job_Tracker
 
 final class RecentCrewJobDetailSheetTests: XCTestCase {
@@ -64,5 +65,19 @@ final class RecentCrewJobDetailSheetTests: XCTestCase {
             items.first(where: { $0.title == "Assigned To" })?.value,
             "unknown-user"
         )
+    }
+
+    func testDashboardJobIncludesResolvedCoordinates() {
+        let coordinate = CLLocationCoordinate2D(latitude: 37.3349, longitude: -122.0090)
+        let crewJob = makeJob()
+
+        let job = RecentCrewJobDetailSheet.makeDashboardJob(
+            from: crewJob,
+            userID: "user-1",
+            coordinate: coordinate
+        )
+
+        XCTAssertEqual(job.latitude, coordinate.latitude, accuracy: 0.0001)
+        XCTAssertEqual(job.longitude, coordinate.longitude, accuracy: 0.0001)
     }
 }


### PR DESCRIPTION
## Summary
- geocode crew job addresses before adding them to the dashboard so latitude/longitude are stored when available
- extract a helper that builds the dashboard job payload including optional coordinates
- add a unit test that verifies the helper carries through resolved coordinates

## Testing
- Not run (Xcode is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d2dd6f4164832db779cc8c4010aab5