### PR TITLE
Add sender name to shared job payload and preview

### DIFF
--- a/Job Tracker/Features/Jobs/Sharing/JobImportPreviewView.swift
+++ b/Job Tracker/Features/Jobs/Sharing/JobImportPreviewView.swift
@@ -18,6 +18,10 @@ struct JobImportPreviewView: View {
         return jobNumber
     }
 
+    private var sharedByText: String? {
+        payload.senderDisplayName
+    }
+
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .full
@@ -41,6 +45,10 @@ struct JobImportPreviewView: View {
 
                             GlassCard {
                                 VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                                    if let sharedByText {
+                                        detailRow(title: "Shared by", value: sharedByText)
+                                        Divider().overlay(JTColors.glassStroke)
+                                    }
                                     detailRow(title: "Address", value: payload.address)
                                     Divider().overlay(JTColors.glassStroke)
                                     detailRow(title: "Scheduled date", value: scheduledDateText)


### PR DESCRIPTION
## Summary
- extend `SharedJobPayload` to carry an optional sender display name and provide a derived `senderDisplayName` helper
- reuse the fetched user profile while publishing share links to populate the sender name with Auth display name fallbacks
- show a new "Shared by" row in the job import preview and cover the name round-trip with unit tests

## Testing
- Not run (Xcode is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3093899e0832da177e7df00c6f97d