### PR TITLE
Clear materials when importing job from search

### DIFF
--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -288,26 +288,15 @@ struct JobSearchDetailView: View {
 
         let normalizedJobNumber = displayValue(metadata.jobNumber) ?? displayValue(job.jobNumber)
 
-        var newJob = Job(
+        let newJob = Job(
             address: combinedAddress,
             date: Date(),
             status: "Pending",
-            assignedTo: nil,
             createdBy: authViewModel.currentUser?.id,
-            notes: job.notes ?? "",
             jobNumber: normalizedJobNumber,
-            assignments: job.assignments,
-            materialsUsed: job.materialsUsed,
-            photos: job.photos,
-            participants: nil,
-            hours: 0.0,
-            nidFootage: job.nidFootage,
-            canFootage: job.canFootage,
             latitude: job.latitude,
             longitude: job.longitude
         )
-
-        newJob.notes = job.notes
 
         jobsViewModel.createJob(newJob) { success in
             isAdding = false


### PR DESCRIPTION
## Summary
- stop copying search result materials and other extras when creating a new job from search
- limit the imported job to address details, coordinates, and job number so crews add their own materials

## Testing
- xcodebuild -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -destination 'generic/platform=iOS' build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fa9bf1b4832d833558b3510ae3ff