### PR TITLE
Fix deep link route parsing and add coverage

### DIFF
--- a/Job TrackerTests/DeepLinkRouterTests.swift
+++ b/Job TrackerTests/DeepLinkRouterTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import Job_Tracker
+
+final class DeepLinkRouterTests: XCTestCase {
+    func testHandlesStandardImportURL() throws {
+        let url = try XCTUnwrap(URL(string: "jobtracker://importJob?token=ABC123"))
+        XCTAssertEqual(DeepLinkRouter.handle(url), .importJob(token: "ABC123"))
+    }
+
+    func testHandlesSingleSlashImportURL() throws {
+        let url = try XCTUnwrap(URL(string: "jobtracker:/importJob?token=XYZ789"))
+        XCTAssertEqual(DeepLinkRouter.handle(url), .importJob(token: "XYZ789"))
+    }
+
+    func testHandlesSchemeWithoutSlashes() throws {
+        let url = try XCTUnwrap(URL(string: "jobtracker:importJob?token=SINGLE"))
+        XCTAssertEqual(DeepLinkRouter.handle(url), .importJob(token: "SINGLE"))
+    }
+
+    func testRejectsUnknownRoute() throws {
+        let url = try XCTUnwrap(URL(string: "jobtracker://help?token=ABC123"))
+        XCTAssertNil(DeepLinkRouter.handle(url))
+    }
+
+    func testRejectsMissingToken() throws {
+        let url = try XCTUnwrap(URL(string: "jobtracker://importJob"))
+        XCTAssertNil(DeepLinkRouter.handle(url))
+    }
+}


### PR DESCRIPTION
## Summary
- normalize deep-link route parsing to accept colon-only jobtracker URLs in addition to the existing variants
- add unit tests covering accepted and rejected deep-link permutations

## Testing
- Not run (requires Xcode simulator environment)

------
https://chatgpt.com/codex/tasks/task_e_68d486449180832d8adff66bfb5e798b