### PR TITLE
Add Splice Assist feature to More tab

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -16,6 +16,7 @@ final class AppNavigationViewModel: ObservableObject {
         case admin
         case settings
         case helpCenter
+        case spliceAssist
 
         var id: String { title }
 
@@ -34,7 +35,8 @@ final class AppNavigationViewModel: ObservableObject {
             case .admin:       return "Admin"
             case .settings:    return "Settings"
             case .helpCenter:  return "Help Center"
-            }
+            case .spliceAssist: return "Splice Assist"
+        }
         }
 
         var systemImage: String {
@@ -52,7 +54,8 @@ final class AppNavigationViewModel: ObservableObject {
             case .admin:       return "gearshape.2"
             case .settings:    return "gearshape"
             case .helpCenter:  return "questionmark.circle"
-            }
+            case .spliceAssist: return "wand.and.stars"
+        }
         }
 
         var primaryDestination: PrimaryDestination {
@@ -69,14 +72,15 @@ final class AppNavigationViewModel: ObservableObject {
                  .supervisor,
                  .admin,
                  .settings,
-                 .helpCenter:
+                 .helpCenter,
+                 .spliceAssist:
                 return .more
-            }
+        }
         }
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs:
+            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs, .spliceAssist:
                 return true
             default:
                 return false

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -128,6 +128,13 @@ private struct MoreMenuList: View {
                 }
             }
 
+            Section("Splice Assist") {
+                NavigationLink(value: AppNavigationViewModel.Destination.spliceAssist) {
+                    Label(AppNavigationViewModel.Destination.spliceAssist.title,
+                          systemImage: AppNavigationViewModel.Destination.spliceAssist.systemImage)
+                }
+            }
+
             if authViewModel.isSupervisorFlag {
                 Section("Supervisor") {
                     NavigationLink(value: AppNavigationViewModel.Destination.supervisor) {
@@ -186,6 +193,8 @@ private struct MoreDestinationView: View {
             HelpCenterView()
         case .recentCrewJobs:
             RecentCrewJobsView()
+        case .spliceAssist:
+            SpliceAssistView()
         case .more:
             MoreMenuList()
         default:

--- a/Job Tracker/Features/SpliceAssist/GeminiService.swift
+++ b/Job Tracker/Features/SpliceAssist/GeminiService.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+struct GeminiService {
+    enum ServiceError: LocalizedError {
+        case missingAPIKey
+        case invalidResponse
+        case serverError(String)
+        case emptyContent
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAPIKey:
+                return "Add a Gemini API key to the app configuration before using Splice Assist."
+            case .invalidResponse:
+                return "The Gemini service returned an unexpected response."
+            case .serverError(let message):
+                return message
+            case .emptyContent:
+                return "No content was returned by the Gemini service."
+            }
+        }
+    }
+
+    private let apiKey: String?
+    private let urlSession: URLSession
+
+    init(apiKey: String? = Bundle.main.infoDictionary?["GEMINI_API_KEY"] as? String,
+         urlSession: URLSession = .shared) {
+        self.apiKey = apiKey
+        self.urlSession = urlSession
+    }
+
+    func generateContent(prompt: String, systemPrompt: String, base64Image: String) async throws -> String {
+        guard let apiKey, !apiKey.isEmpty else {
+            throw ServiceError.missingAPIKey
+        }
+
+        let endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=\(apiKey)"
+        guard let url = URL(string: endpoint) else {
+            throw ServiceError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(
+            GeminiRequest(
+                contents: [
+                    .init(parts: [
+                        .init(text: prompt),
+                        .init(inlineData: .init(mimeType: "image/jpeg", data: base64Image))
+                    ])
+                ],
+                systemInstruction: .init(parts: [.init(text: systemPrompt)])
+            )
+        )
+
+        let (data, response) = try await urlSession.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ServiceError.invalidResponse
+        }
+
+        if httpResponse.statusCode != 200 {
+            if let serverError = try? JSONDecoder().decode(GeminiErrorResponse.self, from: data) {
+                throw ServiceError.serverError(serverError.error.message)
+            } else {
+                throw ServiceError.serverError("Gemini returned status code \(httpResponse.statusCode).")
+            }
+        }
+
+        let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
+        guard
+            let text = decoded.candidates?.first?.content.parts.first(where: { $0.text != nil })?.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !text.isEmpty
+        else {
+            throw ServiceError.emptyContent
+        }
+
+        return text
+    }
+}
+
+private struct GeminiRequest: Encodable {
+    struct Content: Encodable {
+        var parts: [Part]
+    }
+
+    struct Part: Encodable {
+        var text: String?
+        var inlineData: InlineData?
+    }
+
+    struct InlineData: Encodable {
+        var mimeType: String
+        var data: String
+    }
+
+    struct SystemInstruction: Encodable {
+        var parts: [Part]
+    }
+
+    var contents: [Content]
+    var systemInstruction: SystemInstruction
+}
+
+private struct GeminiResponse: Decodable {
+    struct Candidate: Decodable {
+        struct Content: Decodable {
+            var parts: [Part]
+        }
+
+        var content: Content
+    }
+
+    struct Part: Decodable {
+        var text: String?
+    }
+
+    var candidates: [Candidate]?
+}
+
+private struct GeminiErrorResponse: Decodable {
+    struct GeminiError: Decodable {
+        var message: String
+    }
+
+    var error: GeminiError
+}

--- a/Job Tracker/Features/SpliceAssist/SpliceAssistImagePicker.swift
+++ b/Job Tracker/Features/SpliceAssist/SpliceAssistImagePicker.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import UIKit
+
+struct SpliceAssistImagePicker: UIViewControllerRepresentable {
+    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        private let parent: SpliceAssistImagePicker
+
+        init(parent: SpliceAssistImagePicker) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController,
+                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            let editedImage = info[.editedImage] as? UIImage
+            let originalImage = info[.originalImage] as? UIImage
+            parent.onImagePicked(editedImage ?? originalImage)
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.onImagePicked(nil)
+            picker.dismiss(animated: true)
+        }
+    }
+
+    var onImagePicked: (UIImage?) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = .photoLibrary
+        picker.allowsEditing = true
+        picker.modalPresentationStyle = .formSheet
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+}

--- a/Job Tracker/Features/SpliceAssist/SpliceAssistView.swift
+++ b/Job Tracker/Features/SpliceAssist/SpliceAssistView.swift
@@ -1,0 +1,344 @@
+import SwiftUI
+
+struct SpliceAssistView: View {
+    @StateObject private var viewModel = SpliceAssistViewModel()
+
+    @State private var isImagePickerPresented = false
+    @State private var isTroubleshootSheetPresented = false
+    @State private var isT2TooltipPresented = false
+
+    @State private var troubleshootIdentifier: String = ""
+    @State private var troubleshootColor: String = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: JTSpacing.xl) {
+                header
+                stepOneCard
+                stepTwoCard
+                stepThreeCard
+
+                if let message = viewModel.message {
+                    messageCard(message)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                        .onTapGesture { viewModel.clearMessage() }
+                }
+
+                if viewModel.isProcessing || viewModel.result != nil {
+                    resultsCard
+                }
+            }
+            .padding(.horizontal, JTSpacing.xl)
+            .padding(.vertical, JTSpacing.xxl)
+        }
+        .background(JTGradients.background(stops: 4).ignoresSafeArea())
+        .navigationTitle("Splice Assist")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isImagePickerPresented) {
+            SpliceAssistImagePicker { image in
+                viewModel.setMapImage(image)
+            }
+        }
+        .sheet(isPresented: $isTroubleshootSheetPresented) {
+            troubleshootSheet
+        }
+        .alert("T2 Splitter", isPresented: $isT2TooltipPresented, actions: {
+            Button("Got it", role: .cancel) { }
+        }, message: {
+            Text("Enable this if the can contains a T2 splitter. The AI will use T2 fiber colors (5–8) for the mainline assignment instead of standard drop colors (1–4).")
+        })
+    }
+
+    // MARK: - Header
+    private var header: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            Text("AI Fiber Splicer Helper")
+                .font(JTTypography.title)
+                .foregroundStyle(JTColors.textPrimary)
+
+            Text("Your field assistant for accurate splicing and rapid troubleshooting.")
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+    }
+
+    // MARK: - Step cards
+    private var stepOneCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+            VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                stepHeader(number: 1, title: "Provide Map & Context")
+
+                VStack(alignment: .leading, spacing: JTSpacing.md) {
+                    Text("Upload Assignment / Map")
+                        .font(JTTypography.headline)
+                        .foregroundStyle(JTColors.textPrimary)
+
+                    mapPreview
+
+                    Button(action: { isImagePickerPresented = true }) {
+                        Label(viewModel.hasMapImage ? "Change Map" : "Choose Map", systemImage: "photo")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(JTColors.accent)
+                }
+
+                Toggle(isOn: $viewModel.isT2SplitterPresent) {
+                    HStack(spacing: JTSpacing.sm) {
+                        Text("T2 Splitter Present?")
+                            .font(JTTypography.headline)
+                            .foregroundStyle(JTColors.textPrimary)
+
+                        Button {
+                            isT2TooltipPresented = true
+                        } label: {
+                            Image(systemName: "questionmark.circle")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(JTColors.textSecondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("About T2 splitters")
+                    }
+                }
+                .toggleStyle(.switch)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var stepTwoCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+            VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                stepHeader(number: 2, title: "Identify Your Target")
+
+                JTTextField("Splice Can Identifier",
+                             text: $viewModel.canIdentifier,
+                             icon: "number")
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled()
+
+                Text("If you don't have an assignment, use the Find Assignment button below.")
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var stepThreeCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+            VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                stepHeader(number: 3, title: "Action Center")
+
+                Text("Choose an action based on your current task.")
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+
+                VStack(spacing: JTSpacing.md) {
+                    HStack(spacing: JTSpacing.md) {
+                        SpliceAssistActionButton(title: "Troubleshoot",
+                                                  symbol: "exclamationmark.triangle.fill",
+                                                  tint: .red,
+                                                  isDisabled: !viewModel.hasMapImage) {
+                            troubleshootIdentifier = viewModel.canIdentifier
+                            troubleshootColor = ""
+                            isTroubleshootSheetPresented = true
+                        }
+                    }
+
+                    HStack(spacing: JTSpacing.md) {
+                        SpliceAssistActionButton(title: "Find Assignment",
+                                                  symbol: "magnifyingglass",
+                                                  tint: .green,
+                                                  isDisabled: !viewModel.hasMapImage) {
+                            Task { await viewModel.performAssignmentSearch() }
+                        }
+
+                        SpliceAssistActionButton(title: "Analyze Splice",
+                                                  symbol: "bolt.fill",
+                                                  tint: .blue,
+                                                  isDisabled: !viewModel.canRunAnalysis) {
+                            Task { await viewModel.performAnalysis() }
+                        }
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    // MARK: - Message & Results
+    private func messageCard(_ message: SpliceAssistViewModel.Message) -> some View {
+        HStack(alignment: .top, spacing: JTSpacing.md) {
+            Image(systemName: message.kind == .success ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(message.kind == .success ? JTColors.success : JTColors.error)
+                .font(.system(size: 24))
+
+            Text(message.text)
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textPrimary)
+        }
+        .padding(JTSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: JTShapes.cardCornerRadius)
+                .fill(Color.black.opacity(0.25))
+                .overlay(
+                    RoundedRectangle(cornerRadius: JTShapes.cardCornerRadius)
+                        .stroke(message.kind == .success ? JTColors.success.opacity(0.6) : JTColors.error.opacity(0.6), lineWidth: 1.5)
+                )
+        )
+    }
+
+    private var resultsCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius) {
+            VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                HStack(spacing: JTSpacing.sm) {
+                    Image(systemName: viewModel.result?.action.symbolName ?? "hourglass")
+                    Text(viewModel.result?.action.title ?? "Working…")
+                        .font(JTTypography.headline)
+                }
+                .foregroundStyle(JTColors.textPrimary)
+
+                if viewModel.isProcessing {
+                    HStack(spacing: JTSpacing.md) {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                        Text("AI is analyzing…")
+                            .font(JTTypography.body)
+                            .foregroundStyle(JTColors.textSecondary)
+                    }
+                } else if let result = viewModel.result {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: JTSpacing.md) {
+                            if let attributed = try? AttributedString(
+                                markdown: result.content,
+                                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                            ) {
+                                Text(attributed)
+                                    .font(JTTypography.body)
+                                    .foregroundStyle(JTColors.textPrimary)
+                            } else {
+                                Text(result.content)
+                                    .font(JTTypography.body)
+                                    .foregroundStyle(JTColors.textPrimary)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 280)
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    // MARK: - Subviews
+    private func stepHeader(number: Int, title: String) -> some View {
+        HStack(alignment: .center, spacing: JTSpacing.md) {
+            Text("\(number)")
+                .font(.system(size: 20, weight: .bold))
+                .frame(width: 42, height: 42)
+                .background(JTColors.accent, in: Circle())
+                .foregroundStyle(JTColors.onAccent)
+
+            Text(title)
+                .font(JTTypography.headline)
+                .foregroundStyle(JTColors.textPrimary)
+        }
+    }
+
+    private var mapPreview: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: JTShapes.cardCornerRadius)
+                .stroke(style: StrokeStyle(lineWidth: 1.5, dash: [6]))
+                .foregroundStyle(JTColors.glassStroke)
+                .frame(maxWidth: .infinity)
+                .frame(height: 220)
+
+            if let image = viewModel.mapImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 220)
+                    .clipShape(RoundedRectangle(cornerRadius: JTShapes.cardCornerRadius))
+            } else {
+                Text("Upload map to begin…")
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+        }
+    }
+
+    private var troubleshootSheet: some View {
+        NavigationStack {
+            Form {
+                Section("Current Setup") {
+                    TextField("Current can identifier", text: $troubleshootIdentifier)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+
+                    TextField("Missing fiber color", text: $troubleshootColor)
+                        .autocapitalization(.words)
+                        .autocorrectionDisabled()
+                }
+            }
+            .navigationTitle("Troubleshoot")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { isTroubleshootSheetPresented = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Run") {
+                        isTroubleshootSheetPresented = false
+                        Task {
+                            await viewModel.performTroubleshoot(currentCan: troubleshootIdentifier, missingColor: troubleshootColor)
+                        }
+                    }
+                    .disabled(troubleshootIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                              troubleshootColor.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+}
+
+private struct SpliceAssistActionButton: View {
+    let title: String
+    let symbol: String
+    let tint: Color
+    let isDisabled: Bool
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: JTSpacing.sm) {
+                Image(systemName: symbol)
+                    .font(.system(size: 28, weight: .bold))
+                Text(title)
+                    .font(JTTypography.subheadline)
+                    .multilineTextAlignment(.center)
+            }
+            .foregroundStyle(JTColors.onAccent)
+            .padding(.vertical, JTSpacing.lg)
+            .frame(maxWidth: .infinity)
+            .background(
+                LinearGradient(
+                    colors: [tint.opacity(0.95), tint.opacity(0.7)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ),
+                in: RoundedRectangle(cornerRadius: JTShapes.cardCornerRadius)
+            )
+        }
+        .buttonStyle(.plain)
+        .opacity(isDisabled ? 0.4 : 1)
+        .disabled(isDisabled)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SpliceAssistView()
+            .environmentObject(AppNavigationViewModel())
+    }
+}

--- a/Job Tracker/Features/SpliceAssist/SpliceAssistViewModel.swift
+++ b/Job Tracker/Features/SpliceAssist/SpliceAssistViewModel.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+import UIKit
+
+@MainActor
+final class SpliceAssistViewModel: ObservableObject {
+    enum Action {
+        case troubleshoot
+        case findAssignment
+        case analyze
+
+        var title: String {
+            switch self {
+            case .troubleshoot:
+                return "Troubleshooting"
+            case .findAssignment:
+                return "Assignment Finder"
+            case .analyze:
+                return "Splicing Analysis"
+            }
+        }
+
+        var symbolName: String {
+            switch self {
+            case .troubleshoot:
+                return "exclamationmark.triangle.fill"
+            case .findAssignment:
+                return "magnifyingglass"
+            case .analyze:
+                return "bolt.fill"
+            }
+        }
+    }
+
+    struct Message: Identifiable {
+        enum Kind {
+            case success
+            case error
+        }
+
+        let id = UUID()
+        let text: String
+        let kind: Kind
+    }
+
+    struct Result: Identifiable {
+        let id = UUID()
+        let action: Action
+        let content: String
+    }
+
+    // MARK: - Published state
+    @Published private(set) var mapImage: UIImage?
+    @Published var canIdentifier: String = ""
+    @Published var isT2SplitterPresent: Bool = false
+
+    @Published private(set) var isProcessing: Bool = false
+    @Published private(set) var message: Message?
+    @Published private(set) var result: Result?
+
+    private var mapImageBase64: String?
+    private let geminiService: GeminiService
+
+    init(geminiService: GeminiService = GeminiService()) {
+        self.geminiService = geminiService
+    }
+
+    // MARK: - Derived state
+    var hasMapImage: Bool { mapImageBase64 != nil }
+    var canRunAnalysis: Bool {
+        let trimmed = canIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        return hasMapImage && !trimmed.isEmpty
+    }
+
+    // MARK: - Image handling
+    func setMapImage(_ image: UIImage?) {
+        guard let image else {
+            mapImage = nil
+            mapImageBase64 = nil
+            result = nil
+            return
+        }
+
+        let preparedImage = image.aiFixingOrientationAndResizingIfNeeded(maxDimension: 2048) ?? image
+        guard let jpegData = preparedImage.jpegData(compressionQuality: 0.85) else {
+            message = Message(text: "Unable to prepare the selected image. Try choosing a different file.", kind: .error)
+            return
+        }
+
+        mapImage = UIImage(data: jpegData)
+        mapImageBase64 = jpegData.base64EncodedString()
+        result = nil
+        message = Message(text: "Map cropped for better accuracy!", kind: .success)
+    }
+
+    func clearMessage() {
+        message = nil
+    }
+
+    // MARK: - Actions
+    func performTroubleshoot(currentCan: String, missingColor: String) async {
+        let trimmedCan = currentCan.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedColor = missingColor.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedCan.isEmpty, !trimmedColor.isEmpty else {
+            message = Message(text: "Enter both the current can identifier and the missing fiber color.", kind: .error)
+            return
+        }
+
+        guard let mapImageBase64 else {
+            message = Message(text: "Upload and crop a map before troubleshooting.", kind: .error)
+            return
+        }
+
+        await runGeminiRequest(
+            action: .troubleshoot,
+            prompt: "Find the source of light for the \(trimmedColor) fiber at can \(trimmedCan).",
+            systemPrompt: Self.troubleshootSystemPrompt(currentCan: trimmedCan, missingColor: trimmedColor),
+            imageBase64: mapImageBase64
+        )
+    }
+
+    func performAssignmentSearch() async {
+        guard let mapImageBase64 else {
+            message = Message(text: "Upload and crop a map before searching for an assignment.", kind: .error)
+            return
+        }
+
+        await runGeminiRequest(
+            action: .findAssignment,
+            prompt: "Find a spare assignment in this cropped map.",
+            systemPrompt: Self.assignmentSystemPrompt,
+            imageBase64: mapImageBase64
+        )
+    }
+
+    func performAnalysis() async {
+        let trimmedIdentifier = canIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedIdentifier.isEmpty else {
+            message = Message(text: "Enter a splice can identifier before running the analysis.", kind: .error)
+            return
+        }
+
+        guard let mapImageBase64 else {
+            message = Message(text: "Upload and crop a map before running the analysis.", kind: .error)
+            return
+        }
+
+        await runGeminiRequest(
+            action: .analyze,
+            prompt: "Analyze for identifier \"\(trimmedIdentifier)\" in this cropped map.",
+            systemPrompt: Self.analysisSystemPrompt(for: trimmedIdentifier, isT2: isT2SplitterPresent),
+            imageBase64: mapImageBase64
+        )
+    }
+
+    // MARK: - Private helpers
+    private func runGeminiRequest(action: Action, prompt: String, systemPrompt: String, imageBase64: String) async {
+        isProcessing = true
+        result = nil
+        message = nil
+
+        do {
+            let response = try await geminiService.generateContent(
+                prompt: prompt,
+                systemPrompt: systemPrompt,
+                base64Image: imageBase64
+            )
+            result = Result(action: action, content: response)
+        } catch {
+            let description = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            message = Message(text: description, kind: .error)
+        }
+
+        isProcessing = false
+    }
+}
+
+private extension SpliceAssistViewModel {
+    static func troubleshootSystemPrompt(currentCan: String, missingColor: String) -> String {
+        """
+        You are a fiber optic network tracing expert. The user has provided a cropped image focusing on their work area.
+        1. Locate the can identifier \"\(currentCan)\" within the user's cropped map image.
+        2. From \"\(currentCan)\", visually trace the main fiber line backwards/upstream to find the immediately preceding splice can identifier also visible within the cropped area.
+        3. Your response must be ONLY in this structured format:
+        Upstream Source: The light for the **\(missingColor)** fiber at **\(currentCan)** originates from the upstream can: **[Upstream Can Identifier]**.
+        ---
+        Troubleshooting Steps:
+        1. **Travel to [Upstream Can Identifier]:** This is the most likely location of the fault.
+        2. **Inspect the Splice:** Open the can and locate the splice tray for the **\(missingColor)** fiber.
+        3. **Verify Connection:** Check if the **\(missingColor)** fiber was mistakenly used, was never spliced through, or has a bad connection.
+        """
+    }
+
+    static var assignmentSystemPrompt: String {
+        """
+        You are an expert map analyst working with a user-cropped image for high accuracy.
+        1. Scan the provided cropped map for a **hollow gray circle** icon.
+        2. Extract the full identifier text next to the first hollow gray circle you find.
+        3. Your response must be ONLY in this format:
+        Found Assignment: [Identifier]
+        ---
+        Explanation: Within the focused area you provided, the identifier **[Identifier]** was selected because it is marked with a hollow gray circle, indicating a spare, unassigned splice point.
+        """
+    }
+
+    static func analysisSystemPrompt(for identifier: String, isT2: Bool) -> String {
+        let splitterState = isT2 ? "PRESENT" : "NOT PRESENT"
+        let scenario = isT2 ? "T2" : "Direct Drop"
+
+        return """
+        You are a fiber optic expert analyzing a user-cropped image for high accuracy. Follow these steps precisely:
+        1. **Locate:** Find \"\(identifier)\" within the focused image.
+        2. **Parse:** Extract the final digit from the identifier.
+        3. **Map Color:** Based on a T2 splitter being \(splitterState), determine the correct color.
+        4. **Formulate Instructions:** Create detailed, bulleted splicing and push light instructions.
+
+        Your response must be ONLY in this structured format:
+        Reasoning:
+        - **Location:** The identifier \"\(identifier)\" was successfully located in the provided cropped area.
+        - **Parsed Digit:** The final digit is [Digit].
+        - **Assigned Color:** For a \(scenario) scenario, this corresponds to the **[Color]** fiber.
+        ---
+        Drop Splicing Actions:
+        1. [Step 1 for drop]
+        2. [Step 2 for drop]
+        3. [Step 3 for drop]
+        ---
+        Push Light Actions:
+        - The following fibers are not assigned here and must be pushed through: **[List of Colors]**.
+        1. [Step 1 for push]
+        2. [Step 2 for push]
+        """
+    }
+}

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -15,7 +15,9 @@
 			</array>
 		</dict>
 	</array>
-	<key>OPENAI_API_KEY</key>
-	<string>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</string>
+<key>OPENAI_API_KEY</key>
+<string>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</string>
+<key>GEMINI_API_KEY</key>
+<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add a SwiftUI Splice Assist experience that mirrors the web workflow with map uploads, action buttons, and Gemini-powered analysis
- register the Splice Assist destination inside the More tab navigation stack so it is discoverable from the menu
- add a GEMINI_API_KEY placeholder to the app’s Info.plist for configuring the API key

## Testing
- not run (macOS/iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5313be928832d929bf755b9cbb0dc