### PR TITLE
Enable background arrival alerts

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -458,8 +458,11 @@
 				INFOPLIST_FILE = "Job-Tracker-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "We need your location to sort jobs for route tracking";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We need your location to sort jobs for automatic routing";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We need your location to sort jobs for automatic routing";
+                                INFOPLIST_KEY_UIBackgroundModes = (
+                                        location,
+                                );
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -499,8 +502,11 @@
 				INFOPLIST_FILE = "Job-Tracker-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "We need your location to sort jobs for route tracking";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We need your location to sort jobs for automatic routing";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We need your location to sort jobs for automatic routing";
+                                INFOPLIST_KEY_UIBackgroundModes = (
+                                        location,
+                                );
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;

--- a/Job Tracker/Features/Settings/SettingsView.swift
+++ b/Job Tracker/Features/Settings/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject private var themeManager: JTThemeManager
     @EnvironmentObject private var arrivalAlertManager: ArrivalAlertManager
+    @EnvironmentObject private var locationService: LocationService
 
     // Persisted settings
     @AppStorage("smartRoutingEnabled") private var smartRoutingEnabled = false
@@ -105,6 +106,10 @@ struct SettingsView: View {
                             SectionHeader(title: "Notifications")
                             Toggle("Notify me on arrival (today only)", isOn: $arrivalAlertsEnabledToday)
                                 .toggleStyle(.switch)
+                                .onChange(of: arrivalAlertsEnabledToday) { enabled in
+                                    guard enabled else { return }
+                                    locationService.requestAlwaysAuthorizationIfNeeded()
+                                }
                             if !arrivalAlertManager.status.message.isEmpty {
                                 Text(arrivalAlertManager.status.message)
                                     .font(.footnote)

--- a/Job Tracker/Features/Shared/Services/LocationService.swift
+++ b/Job Tracker/Features/Shared/Services/LocationService.swift
@@ -59,7 +59,7 @@ final class LocationService: NSObject, ObservableObject {
                 manager.startUpdatingLocation()
             } else {
                 // Background/inactive: significant-change only
-                manager.allowsBackgroundLocationUpdates = false
+                manager.allowsBackgroundLocationUpdates = true
                 manager.stopUpdatingLocation()
                 manager.startMonitoringSignificantLocationChanges()
             }
@@ -101,18 +101,32 @@ final class LocationService: NSObject, ObservableObject {
         guard status == .authorizedAlways || status == .authorizedWhenInUse else {
             stopSignificantChangeUpdates(); return
         }
-        manager.allowsBackgroundLocationUpdates = false
+        manager.allowsBackgroundLocationUpdates = true
         manager.stopUpdatingLocation()
         manager.startMonitoringSignificantLocationChanges()
     }
 
     func stopSignificantChangeUpdates() {
+        manager.allowsBackgroundLocationUpdates = false
         manager.stopMonitoringSignificantLocationChanges()
     }
 
     func stopAllUpdates() {
+        manager.allowsBackgroundLocationUpdates = false
         manager.stopUpdatingLocation()
         manager.stopMonitoringSignificantLocationChanges()
+    }
+
+    func requestAlwaysAuthorizationIfNeeded() {
+        let status = manager.authorizationStatus
+        switch status {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse:
+            manager.requestAlwaysAuthorization()
+        default:
+            break
+        }
     }
 
     // MARK: - Region Monitoring


### PR DESCRIPTION
## Summary
- request Always authorization for location when users enable arrival alerts
- allow background location updates and add background capability for geofencing notifications
- ensure background modes include location monitoring so arrival alerts fire outside the app

## Testing
- Not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68d56d1a8f34832d8a8040f2b957ac7b