### PR TITLE
Expand project documentation

### DIFF
--- a/Documentation/Features/Admin.md
+++ b/Documentation/Features/Admin.md
@@ -1,0 +1,32 @@
+# Admin
+
+The Admin module exposes elevated controls for supervisors and company administrators. Its primary surface is the `AdminPanelViewModel`, which powers a roster management screen and wraps backend maintenance operations supplied by `FirebaseService`.
+
+## Responsibilities
+
+- Present the current roster of `AppUser` records sorted by last name.
+- Toggle the `isAdmin` and `isSupervisor` flags for crew members and propagate the changes through Firebase custom claims.
+- Display optimistic loading state while role flags are being mutated to avoid duplicate submissions.
+- Run backfill maintenance routines (for example, `adminBackfillParticipantsForAllJobs`) that ensure every job document has its participant list populated.
+- Surface success and failure alerts whenever an admin action completes, along with the number of records affected.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `AdminPanelViewModel` | Observable object driving the admin panel UI. Tracks roster snapshots, in-flight flag mutations, alert messaging, and maintenance progress. |
+| `AdminPanelService` | Protocol satisfied by `FirebaseService`. Abstracts updating user flags, refreshing custom claims, and running maintenance backfills. |
+| `MaintenanceStatus` | Captures the execution state of long-running admin tasks, including progress, last run count, and errors. |
+| `UsersViewModel` | Shared roster publisher consumed by the admin module to stay in sync with the rest of the app. |
+
+## Workflows
+
+1. **Flag Management** – When an admin toggles a user flag, the view model records the user ID in `updatingAdminIDs`/`updatingSupervisorIDs`. The UI can check `isMutating(userID:)` to disable controls. On completion, `alert` is set to a `success` or `error` message.
+2. **Roster Sync** – `attach(usersViewModel:)` subscribes to the shared users dictionary so the admin screen always displays the latest crew members without duplicating fetch logic.
+3. **Maintenance Backfill** – `runParticipantsBackfill()` kicks off the Firebase maintenance function. The progress callback updates the `MaintenanceStatus.Progress` struct, allowing the UI to render a live progress view. Completion updates `alert` and `lastRunCount` for reporting.
+
+## Integration Notes
+
+- The admin panel should only be reachable for users whose `AuthViewModel` exposes `isAdmin == true`.
+- Ensure Cloud Functions and Firestore security rules validate that only admins can invoke the maintenance endpoints described above.
+- When adding new admin maintenance tasks, expose them through `AdminPanelService` so the existing dependency injection remains intact for testing.

--- a/Documentation/Features/Authentication.md
+++ b/Documentation/Features/Authentication.md
@@ -1,3 +1,35 @@
 # Authentication
 
-This module hosts the login and sign-up flows alongside the shared `AuthViewModel` that keeps track of the current Firebase session state. Views in this folder route unauthenticated users into the rest of the shell once credentials are verified.
+The authentication feature contains the sign-in, sign-up, and password recovery flows along with the shared `AuthViewModel` that coordinates Firebase session state. Once a user is authenticated, the `AppShellView` in the Shared module reads the view model to present the main tab navigation.
+
+## Responsibilities
+
+- Register new technicians with first name, last name, position, email, and password fields via `FirebaseService.signUpUser`.
+- Authenticate returning users with email/password credentials and fetch their corresponding `AppUser` profile from Firestore.
+- Refresh the current session when the app launches or returns to the foreground by calling `checkAuthState()`.
+- Handle password reset requests through `FirebaseService.sendPasswordReset`.
+- Support account deletion through `deleteAccount(preserveJobs:)`, which removes the Firebase Auth user while retaining job history.
+- Expose convenience flags (`isAdmin`, `isSupervisor`) derived from the current user's profile to gate admin-only functionality.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `AuthViewModel` | Observable object published to the environment. Stores the current `AppUser`, `isSignedIn` flag, and role information. |
+| `LoginView` | Email/password entry surface with links to sign-up and password reset flows. |
+| `SignUpView` | Registration form that validates the input payload before invoking `signUp`. |
+| `AuthFlowView` | Wrapper that switches between login and registration flows and presents success/error toasts. |
+
+## Flow Summary
+
+1. **Startup** – `AuthViewModel` instantiates `checkAuthState()` to detect an existing Firebase user. If one exists, `FirebaseService.fetchCurrentUser` populates the view model and transitions to the authenticated shell.
+2. **Sign-In** – After credentials are submitted, the view model signs in, fetches the profile, updates `currentUser`, and clears any loading UI.
+3. **Sign-Up** – Valid input triggers a call to `signUpUser`. On success the newly created `AppUser` is stored, the session is considered signed in, and the shell is presented.
+4. **Password Reset** – The email address is passed to `sendPasswordReset` and the user receives a confirmation toast on success or an error on failure.
+5. **Sign-Out / Delete** – `signOut()` clears the current session and returns the app to the login flow. `deleteAccount` deletes the auth record and optionally the profile document while leaving job data intact for auditing.
+
+## Integration Notes
+
+- Wrap `AuthViewModel` in an `@StateObject` at the app entry point (`Job_TrackerApp.swift`) so views see consistent updates.
+- Downstream features should observe the view model through `@EnvironmentObject` to react to sign-in state and role changes.
+- Ensure Firebase rules restrict access based on the user ID and custom claims that `AuthViewModel` surfaces.

--- a/Documentation/Features/Dashboard.md
+++ b/Documentation/Features/Dashboard.md
@@ -1,3 +1,38 @@
 # Dashboard
 
-Contains `DashboardView`, the primary home screen that summarizes today’s jobs, exposes creation shortcuts, and surfaces status, sharing, and smart routing tools for the active technician.
+The dashboard is the technician home screen. It surfaces the current week's assignments, highlights pending work, and exposes shortcuts into creation, sharing, and routing tools. `DashboardView` composes several reusable components and is powered by `DashboardViewModel`.
+
+## Responsibilities
+
+- Display the current weekday selection and allow quick navigation across the Monday–Friday work week.
+- Query the `JobsViewModel` for assignments on the selected date and split them into pending/completed sections.
+- Calculate nearest job distance strings when smart routing is enabled and a current location is available.
+- Present sync status banners that reflect pending Firestore writes from `JobsViewModel`.
+- Provide share sheets for daily summaries and individual jobs (via `DashboardShareSheets`).
+- Trigger job creation sheets, date pickers, and import toasts through `ActiveSheet` management.
+
+## Key Components
+
+| Component | Description |
+| --- | --- |
+| `DashboardView` | Main SwiftUI surface containing the header, weekday picker, summary metrics, and job lists. |
+| `DashboardViewModel` | Computes sections, summary counts, routing hints, and share payloads. Manages state for sheets and banners. |
+| `DashboardWeekdayPicker` | Horizontal selector displaying weekday abbreviations and routing taps back into `DashboardViewModel`. |
+| `DashboardSummaryCard` | Shows total, pending, and completed counts for the selected day. |
+| `DashboardJobSectionsView` | Renders pending and completed job lists with optional distance badges. |
+| `DashboardSyncBanner` | Animated banner showing upload progress when Firestore writes are in flight. |
+| `DashboardShareSheets` | Hosts ShareLink presenters for daily PDF exports and job-specific payloads. |
+
+## Data Flow
+
+1. **Configuration** – `DashboardView` calls `configureIfNeeded(jobsViewModel:)` so the view model can request weekly jobs from the shared `JobsViewModel`.
+2. **Selection** – Tapping a weekday updates `selectedDate`, which re-fetches the corresponding week's jobs and recalculates sections.
+3. **Routing** – When smart routing is on, distances are calculated using `Job.clLocation` and the current location provided by `LocationService`.
+4. **Sharing** – When a user taps the share action, `shareItems` is populated and `activeSheet` is set to `.share`, driving the system share sheet.
+5. **Sync Banners** – The view model listens to `NotificationCenter.jobsSyncStateDidChange` updates (triggered from `JobsViewModel`) to update `syncTotal`, `syncDone`, and `syncInFlight` counts.
+
+## Integration Notes
+
+- Inject the shared `JobsViewModel`, `LocationService`, and `AuthViewModel` as environment objects so the dashboard can access live data and routing preferences.
+- Respect `AuthViewModel.isSupervisor` to show supervisor-specific actions (e.g., import flows) when applicable.
+- When adding new dashboard cards, favour `GlassCard` and design system tokens for visual consistency.

--- a/Documentation/Features/Help.md
+++ b/Documentation/Features/Help.md
@@ -1,3 +1,24 @@
 # Help
 
-Documentation-forward surfaces such as `HelpCenterView` and the multi-step `InteractiveTutorialView` live here. These screens guide new hires through the app and deep-link into other features for contextual assistance.
+The Help feature contains self-service education surfaces that onboard new hires and provide contextual troubleshooting steps for seasoned technicians.
+
+## Responsibilities
+
+- Present a searchable help center (`HelpCenterView`) with quick links to top tasks and deep links into other feature tabs.
+- Host the multi-step `InteractiveTutorialView`, which walks new crew members through creating jobs, pairing with partners, and submitting paperwork.
+- Record tutorial progress using stages so technicians can resume where they left off.
+- Offer lightweight FAQ content, support contact shortcuts, and links to company policies.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `HelpCenterView` | Entry point showing featured articles, sections, and navigation into tutorials or other screens. |
+| `InteractiveTutorialView` | Flow-based tutorial powered by an internal state machine to move between stages (tested in `InteractiveTutorialStagesTests`). |
+| `HelpArticle` (if added) | Model representing a help topic. Typically sourced from static JSON or Firestore collections. |
+
+## Integration Notes
+
+- The Help tab is reachable from the authenticated shell via `MainTabView`. Use `AppNavigationViewModel` to trigger deep links when launching from push notifications or help links.
+- When expanding help content, prefer markdown/JSON payloads that can be fetched from Firestore so updates do not require app releases.
+- Tests in `InteractiveTutorialStagesTests` document the expected tutorial stage transitions and are a good reference when modifying the flow.

--- a/Documentation/Features/Jobs.md
+++ b/Documentation/Features/Jobs.md
@@ -1,8 +1,37 @@
 # Jobs
 
-This feature cluster covers job intake and management. It bundles:
+The Jobs feature handles creating, editing, importing, and sharing job records. It owns the Firestore synchronization logic for assignments and supplies the data that powers the dashboard, search, and timesheet experiences.
 
-- Core job workflows like `ExtraWorkView` and the shared `JobsViewModel`.
-- The **Editor** subfolder with creation, detail, import, and image utilities for single jobs.
-- The **Supervisor** tools that expose `SupervisorDashboardView` for higher-level oversight.
-- The **Sharing** utilities that generate and parse deep links for sending job summaries to teammates.
+## Responsibilities
+
+- Listen to Firestore for job documents belonging to the signed-in technician (participant) and expose them via `JobsViewModel.jobs`.
+- Maintain a global job search index (`searchJobs`) combining the lightweight public index with locally owned jobs.
+- Track pending writes and broadcast sync state updates so the dashboard and other screens can display upload progress.
+- Provide CRUD flows: creation (`CreateJobView`), editing (`JobDetailView`), supervisor imports (`SupervisorJobImportView`), and extra work capture (`ExtraWorkView`).
+- Generate share payloads (`SharedJobPayload`) and deep links for the iMessage extension and cross-device sharing.
+- Parse inbound share links using `DeepLinkRouter` to route to job detail screens.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `JobsViewModel` | Central observable object responsible for Firestore listeners, pending write tracking, and share payload building. |
+| `Job` | Codable model representing a job document with metadata, coordinates, media URLs, and participant IDs. |
+| `CreateJobView` / `JobDetailView` | SwiftUI forms for creating and editing jobs. Support photo uploads, status updates, and partner assignments. |
+| `SupervisorJobImportView` | Flow for importing CSVs or PDFs that supervisors provide. Uses parsing utilities tested in `JobSheetParserTests`. |
+| `JobImportPreviewView` | Preview surface that shows parsed jobs before committing them to Firestore. |
+| `DeepLinkRouter` | Resolves inbound URLs into navigation destinations tested via `DeepLinkRouterTests`. |
+
+## Data & Sync Flow
+
+1. **Fetching** – `fetchJobs(startDate:endDate:)` attaches a Firestore snapshot listener filtered by the current user ID. Metadata flags are used to determine pending writes and last server sync time.
+2. **Indexing** – `startSearchIndexForAllJobs()` listens to the global `job_search_index` collection. The view model merges these entries with locally fetched jobs to power cross-company search.
+3. **Creating/Updating** – Forms call helper methods on `FirebaseService` to create or update jobs. Pending write IDs are tracked so the UI can show optimistic state.
+4. **Sharing** – `JobsViewModel` builds `SharedJobPayload` values that encode job metadata and optional images. These are consumed by ShareLink, AirDrop, and the iMessage extension.
+5. **Notifications** – After job arrays change, `JobsViewModel` posts `.jobsDidChange` and `.jobsSyncStateDidChange` notifications for other features.
+
+## Integration Notes
+
+- Inject `JobsViewModel` as an `@StateObject` near the top of the authenticated shell. Other features observe it via `@EnvironmentObject`.
+- Ensure Firestore rules allow read/write access for participants listed in a job document while guarding cross-team data.
+- When adding new job attributes, update `Job`, the Firestore serialization logic, and any share payload or parser utilities that rely on the schema.

--- a/Documentation/Features/Search.md
+++ b/Documentation/Features/Search.md
@@ -1,3 +1,33 @@
 # Search
 
-Search surfaces job discovery, from the global `JobSearchView` and detail sheet to the `SearchCompleterDelegate` that wraps Apple’s suggestion APIs. Shared search UI elements like `SearchBar` live in the `Components` subfolder.
+The search feature lets technicians find jobs across the entire company roster and quickly navigate to detail views or initiate routing.
+
+## Responsibilities
+
+- Provide a debounced search bar UI that supports both free text and address lookups.
+- Query the combined search index exposed by `JobsViewModel` to match by address, customer name, can number, or job ID.
+- Integrate with MapKit autocomplete via `SearchCompleterDelegate` to suggest street addresses as the user types.
+- Display a result list with key metadata (status, partner, distance) and allow tapping into `JobSearchDetailView` for full context.
+- Offer call-to-action buttons for navigation, calling the customer, or opening the job in the Jobs tab.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `JobSearchView` | Entry view containing the search bar, segmented filters, and result list. |
+| `JobSearchViewModel` | Performs filtering, manages autocomplete results, and formats display strings. |
+| `SearchBar` | Reusable SwiftUI component with built-in debouncing and cancel handling. |
+| `SearchCompleterDelegate` | Bridges MapKit's `MKLocalSearchCompleter` into Combine publishers. |
+| `JobSearchDetailView` | Expanded detail sheet that shows the job summary, partners, notes, and quick actions. |
+
+## Matching Behaviour
+
+- Queries are normalised (case-insensitive, trimmed) and run against multiple fields of `JobSearchIndexEntry`.
+- Autocomplete suggestions can be selected to refine the query or immediately jump into an address-based search.
+- The view model computes `distanceString` values using the latest location provided by `LocationService` so techs can choose the closest job.
+
+## Integration Notes
+
+- Ensure `JobsViewModel` has started the global search index listener (`startSearchIndexForAllJobs`) before presenting the search tab; otherwise results will be empty.
+- When customising matching heuristics, update the test coverage in `JobSearchMatcherTests` to reflect the new behaviour.
+- Provide `LocationService` as an environment object if you want to display distance estimates in the result list.

--- a/Documentation/Features/Settings.md
+++ b/Documentation/Features/Settings.md
@@ -1,3 +1,33 @@
 # Settings
 
-Account-focused destinations like `SettingsView` and `ProfileView` are grouped here. They expose profile management, sign-out, and shortcuts into historical exports for the current technician.
+The Settings tab lets technicians configure routing preferences, manage notifications, customise the theme, and update account details.
+
+## Responsibilities
+
+- Toggle smart routing and choose whether to optimise routes by closest-first or farthest-first order.
+- Manage arrival alert notifications for the current day, prompting the user to grant location permissions when necessary.
+- Select the address suggestion provider (Apple Maps or Google Places) for job creation forms.
+- Launch the theme editor (`JTThemeManager`) so techs can tweak accent colours and saved presets.
+- Display the signed-in user's profile information and allow sign out, password reset, and account deletion.
+- Offer quick access to privacy policies and support email links.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `SettingsView` | Main SwiftUI surface composed of `GlassCard` sections for appearance, routing, notifications, maps, and account. |
+| `ProfileView` | Secondary screen for editing profile details or viewing partner/supervisor information. |
+| `JTThemeManager` | Environment object controlling the design system's current theme and presenting the theme editor sheet. |
+| `ArrivalAlertManager` | Service that monitors and schedules location-based notifications for job arrival reminders. |
+
+## Data Flow & State
+
+- Persistent preferences use `@AppStorage` keys (`smartRoutingEnabled`, `routingOptimizeBy`, `arrivalAlertsEnabledToday`, `addressSuggestionProvider`).
+- Deleting an account invokes `AuthViewModel.deleteAccount`, showing confirmation and error handling states while the request is in flight.
+- Arrival alerts check `LocationService` to ensure `always` authorization is available before toggling on.
+
+## Integration Notes
+
+- Provide `AuthViewModel`, `JTThemeManager`, `ArrivalAlertManager`, and `LocationService` as environment objects when presenting `SettingsView`.
+- If you add new persisted preferences, define a namespaced `@AppStorage` key and document the behaviour here so QA knows how to reset state.
+- Keep support URLs and contact emails centralised in constants to simplify white-labelling for other deployments.

--- a/Documentation/Features/Shared.md
+++ b/Documentation/Features/Shared.md
@@ -1,10 +1,26 @@
 # Shared
 
-Cross-cutting building blocks used by many screens are collected under Shared:
+Cross-cutting building blocks used by many screens are collected under `Features/Shared`. This module keeps foundational services, navigation scaffolding, and reusable UI components in one place.
 
-- **Shell** contains the authenticated container (`ContentView`, `AppShellView`, `MainTabView`, `AppNavigationViewModel`).
-- **Components** houses reusable SwiftUI helpers such as `ActivityView`, `ImagePicker`, and the gradient background modifier.
-- **Services** wraps app-wide data sources like `FirebaseService` and `LocationService`.
-- **Mapping** groups the interactive `MapsView` experience plus geometry types and route syncing helpers.
-- **Messaging** includes the chat UI and `ChatViewModel` used by partner conversations.
-- **Team** centralizes pairing and roster support via `FindPartnerView` and `UsersViewModel`.
+## Submodules
+
+- **Shell** – Hosts the authenticated container (`ContentView`, `AppShellView`, `MainTabView`, `AppNavigationViewModel`) that wires environment objects, tab selection, and deep link routing.
+- **Components** – Reusable SwiftUI helpers such as `GlassCard`, `ActivityView` (for share sheets), `ImagePicker`, `DateRangePicker`, and gradient backgrounds.
+- **Services** – Wrappers around app-wide data sources including `FirebaseService`, `LocationService`, and `ArrivalAlertManager`. They abstract Firestore queries, Cloud Functions, push notifications, and Core Location.
+- **Mapping** – The interactive `MapsView`, `RouteService`, and geometry types used for smart routing and driving directions.
+- **Messaging** – Chat UI (`ChatView`) and `ChatViewModel` for partner conversations backed by Firestore collections.
+- **Team** – Roster utilities like `UsersViewModel` and `FindPartnerView` that allow technicians to pair up and monitor recent crew jobs.
+- **More** – Additional shared experiences such as `RecentCrewJobsView`, which surfaces partner activity within other tabs.
+
+## Responsibilities
+
+- Provide dependency injection points for services consumed across feature modules.
+- Normalize map and location logic so job-related views can render annotations and directions consistently.
+- Emit notifications (`Notification.Name`) that coordinate data refreshes between tabs (e.g., when jobs or partners change).
+- Offer UI building blocks that adopt the design system tokens, ensuring every screen shares the same look and feel.
+
+## Integration Notes
+
+- Initialize long-lived services (e.g., `FirebaseService`, `UsersViewModel`) in the app delegate or shell view and pass them via environment objects.
+- When adding a new cross-cutting helper, place it here so other features can reuse it without creating import cycles.
+- Follow the design system conventions (`JTColors`, `JTSpacing`, `JTShapes`) when composing new shared components.

--- a/Documentation/Features/SpliceAssist.md
+++ b/Documentation/Features/SpliceAssist.md
@@ -1,0 +1,33 @@
+# Splice Assist
+
+Splice Assist is an AI-powered troubleshooting tool that analyses uploaded splice maps to suggest fixes, spare assignments, and CAN insights. It leverages Google Gemini through `GeminiService`.
+
+## Responsibilities
+
+- Accept cropped splice map images from the user via `SpliceAssistImagePicker` and prepare them for AI analysis (orientation fix, resizing, JPEG compression).
+- Let technicians specify the current CAN identifier, whether a T2 splitter is present, and other context before running analysis.
+- Run Gemini multimodal prompts for three primary workflows: troubleshooting missing light, finding spare assignments, and general CAN analysis.
+- Present status messages and results back to the user, highlighting success or error states.
+- Prevent duplicate submissions while an AI request is running and clear previous results when new inputs are selected.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `SpliceAssistView` | SwiftUI surface with segmented actions, image upload controls, text fields, and result presentation. |
+| `SpliceAssistViewModel` | Manages image preparation, prompt construction, Gemini requests, and published state (`message`, `result`, `isProcessing`). |
+| `GeminiService` | API wrapper responsible for sending prompts and encoded images to the Gemini endpoint and returning structured responses. |
+| `SpliceAssistImagePicker` | Utility around `PHPickerViewController`/`UIImagePickerController` for selecting or cropping map images. |
+
+## Workflow
+
+1. **Image Selection** – Users import or crop a map image. The view model stores a Base64 representation so it can be reused across multiple Gemini requests without re-encoding.
+2. **Input Gathering** – Depending on the selected action (`Action` enum), users provide CAN identifiers or fibre colour context.
+3. **Gemini Request** – `runGeminiRequest` constructs a system prompt tailored to the action and posts it to the AI service alongside the encoded image.
+4. **Result Handling** – Responses are normalised into plain text and exposed through `result`. Errors update `message` with `.error` state.
+
+## Integration Notes
+
+- Store the Gemini API key securely (e.g., in an encrypted plist or remote config) and ensure `GeminiService` reads it at runtime.
+- Consider caching recent results if technicians often re-run the same analysis to save API quota.
+- Wrap network calls in `Task`/`async` contexts so the UI stays responsive. The view model is annotated with `@MainActor` to simplify UI updates.

--- a/Documentation/Features/Timesheets.md
+++ b/Documentation/Features/Timesheets.md
@@ -1,3 +1,35 @@
 # Timesheets
 
-Weekly payroll tooling lives here: the SwiftUI screens for reviewing submitted work, editing day-by-day hours, generating PDFs, and their supporting view models such as `TimesheetViewModel`, `TimesheetJobsViewModel`, and `UserTimesheetsViewModel`.
+Timesheets track weekly hours for technicians and generate PDFs supervisors can sign off on. The module handles both individual day entries and historical exports.
+
+## Responsibilities
+
+- Fetch weekly timesheet documents for the signed-in user and optional partner via `UserTimesheetsViewModel`.
+- Allow editing of daily job entries (`JobEditView`) and hours within `WeeklyTimesheetView`.
+- Compute rollups for Gibson, Cable South, and total hours using `TimesheetViewModel`.
+- Generate shareable PDFs with `WeeklyTimesheetPDFGenerator` and upload/download links via Firebase Storage.
+- Display historical records in `PastTimesheetsView` for quick reference.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `Timesheet` | Codable Firestore model capturing week start, supervisors, technician names, per-day totals, and PDF URLs. |
+| `UserTimesheetsViewModel` | Coordinates fetching, refreshing, and caching timesheet documents for the active user. |
+| `TimesheetViewModel` | Handles form state for a single timesheet, validation, and saving back to Firestore. |
+| `TimesheetJobsViewModel` | Supplies job pickers used when adding or editing timesheet entries. |
+| `WeeklyTimesheetView` | Main UI for entering hours, selecting partners, and triggering PDF generation. |
+| `WeeklyTimesheetPDFGenerator` | Renders SwiftUI templates into PDFs for sharing with supervisors. |
+
+## Workflow
+
+1. **Loading** – On appear, `UserTimesheetsViewModel` fetches the week containing the selected date. It subscribes to Firestore snapshots to stay up to date.
+2. **Editing** – Users can adjust hours per day, assign partner names, and edit job notes. `TimesheetViewModel` validates input before saving.
+3. **PDF Export** – Tapping export invokes `WeeklyTimesheetPDFGenerator`, saves the PDF locally, uploads it if needed, and exposes a ShareLink.
+4. **History** – `PastTimesheetsView` shows prior weeks with quick access to their PDF downloads.
+
+## Integration Notes
+
+- Ensure Firestore indexes exist for queries filtering by `userId` and `weekStart`.
+- Because timesheets reference jobs, keep `JobsViewModel` available so `TimesheetJobsViewModel` can suggest relevant assignments.
+- Update the PDF layout when brand guidelines change by modifying the generator templates rather than ad-hoc drawing code.

--- a/Documentation/Features/YellowSheet.md
+++ b/Documentation/Features/YellowSheet.md
@@ -1,3 +1,35 @@
 # Yellow Sheet
 
-The yellow sheet workflow groups completed jobs per week. This folder contains the main `YellowSheetView`, detail and card components, data sources for historical records, and the PDF helpers housed under the `PDF` subfolder.
+Yellow sheets capture daily compliance checklists and signatures that complement the timesheet workflow. This module reuses many of the timesheet patterns while tailoring the experience to the yellow sheet document format.
+
+## Responsibilities
+
+- Fetch and display yellow sheet records for the signed-in technician using `UserYellowSheetsViewModel`.
+- Provide form-driven entry for daily safety checks, job notes, and material usage via `YellowSheetView`.
+- Allow supervisors to review previous submissions through `PastYellowSheetsView`.
+- Generate PDFs using `YellowSheetPDFGenerator`, including editable overlays for signatures and corrections.
+- Offer in-app PDF viewing and annotation through `EditablePDFView` and `PDFViewer`.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `YellowSheet` | Firestore model storing metadata, completion status, and generated PDF URLs. |
+| `UserYellowSheetsViewModel` | Coordinates Firestore listeners and exposes the current user's yellow sheets. |
+| `YellowSheetView` | Main editing surface for the active day. Integrates photo attachments and checklists. |
+| `YellowSheetDetailView` | Expanded view for reviewing submissions, downloading PDFs, or resending to supervisors. |
+| `YellowSheetPDFGenerator` | Renders SwiftUI content into PDFs. Shares PDF utilities with the timesheet module. |
+| `EditablePDFView` | Hosts PDFKit annotations for signatures or corrections before exporting. |
+
+## Workflow
+
+1. **Loading** – The user view model listens for documents filtered by user ID and date, updating the UI in real time as submissions change.
+2. **Editing** – Technicians complete checklist items, add notes, and attach supporting images. Changes are saved back to Firestore via `FirebaseService` helpers.
+3. **PDF Export** – Users generate a PDF for supervisor sign-off. The generator saves the file locally and optionally uploads it for sharing.
+4. **Review** – Supervisors can open past entries, view the PDF inline, and trigger exports or edits if corrections are needed.
+
+## Integration Notes
+
+- Yellow sheets often link to specific jobs. Keep job metadata handy so forms can pre-populate addresses or partner info.
+- Ensure Storage rules allow technicians to upload PDF exports while preventing cross-user access.
+- When altering the PDF layout, update both the generator and any tests that verify PDF metadata or file generation.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,12 +1,10 @@
 # Project Documentation
 
-This folder hosts feature-level documentation that used to live alongside the
-Swift source files. Keeping the markdown outside of the `Job Tracker` app
-bundle prevents Xcode from trying to copy multiple `README.md` files into the
-same destination while still making the docs easy to browse.
+This folder collects long-form guides for each feature area in Job Tracker. The Markdown files were moved out of the Xcode target so documentation updates no longer trigger resource conflicts during builds. Browse the sections below for architecture notes, view model responsibilities, and integration details.
 
 ## Feature Guides
 
+- [Admin](Features/Admin.md)
 - [Authentication](Features/Authentication.md)
 - [Dashboard](Features/Dashboard.md)
 - [Help](Features/Help.md)
@@ -14,5 +12,18 @@ same destination while still making the docs easy to browse.
 - [Search](Features/Search.md)
 - [Settings](Features/Settings.md)
 - [Shared](Features/Shared.md)
+- [Splice Assist](Features/SpliceAssist.md)
 - [Timesheets](Features/Timesheets.md)
 - [Yellow Sheet](Features/YellowSheet.md)
+
+## Companion Experiences
+
+- **watchOS** – The *Job Tracker Companion Watch App* mirrors daily job summaries and uses `WatchBridge` to stay in sync with the iOS app. The same Firebase models are reused, while the interface is tailored for glanceable updates.
+- **iMessage Extension** – The *imessage cs* target renders job cards that supervisors can share in Messages. Payloads are produced by the `Jobs` feature's sharing helpers and parsed by `MessagesViewController` in the extension target.
+
+## Supporting Materials
+
+- The [Design System guide](../Job%20Tracker/DesignSystem/DesignSystem.md) documents shared colors, typography, glass cards, and button styles.
+- Tests under `Job TrackerTests/` demonstrate integration points for Firestore, search matching, and PDF exports. Reviewing the tests is a fast way to see expected behaviours for each feature's view model.
+
+When you add a new feature module, place a matching Markdown file under `Documentation/Features/` and link it above. This keeps the engineering and product teams aligned on workflows, data contracts, and UI responsibilities.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# Job Tracker
+
+Job Tracker is a SwiftUI application for fiber technicians and supervisors. It centralizes daily job assignments, collaborative tools, compliance paperwork, and supervisor controls in a single workspace backed by Firebase. The repository also contains a watchOS companion for quick-glance updates and an iMessage extension for sharing assignments in conversation.
+
+The app targets modern Apple platforms (iOS 17+ and watchOS 10+) and leans on Combine, MapKit, and the system share APIs to deliver live collaboration features such as partner chat, location-aware routing, and document exports.
+
+## Feature Highlights
+
+- **Authentication** – Email/password sign-in backed by Firebase Auth, password reset, and account deletion that preserves historical job documents.
+- **Dashboard** – Technician home screen with smart routing, sync status, quick creation shortcuts, and sharing flows for daily job summaries.
+- **Jobs** – CRUD surface for job records, media uploads, supervisor import tools, deep link routing, and iMessage share payloads.
+- **Search** – Address-aware search across the global job index with MapKit autocomplete and detailed result inspection.
+- **Timesheets & Yellow Sheets** – Weekly timesheet tracking, PDF export, and yellow sheet compliance workflow with editable PDF annotations.
+- **Settings** – Smart routing preferences, arrival alert toggles, theme customization, and account management.
+- **Admin & Team Tools** – Admin flag management, maintenance utilities, roster sync, partner pairing, and crew chat.
+- **Assistive Workflows** – Gemini-powered splice troubleshooting, Help center tutorials, and watchOS glanceable status updates.
+
+See the [Documentation](Documentation/README.md) index for deep dives into each feature area.
+
+## Architecture Overview
+
+The project is structured around lightweight feature modules under `Job Tracker/Features`. Each feature encapsulates its SwiftUI views, Combine view models, and service facades. Shared building blocks live under `Features/Shared`, including:
+
+- **Shell**: Tab scaffolding, authenticated navigation, and global view model wiring.
+- **Services**: `FirebaseService`, `LocationService`, and `ArrivalAlertManager` for Firestore, Auth, and Core Location integration.
+- **Mapping & Messaging**: MapKit wrappers, route calculations, and partner chat surfaces.
+
+Models (`Job`, `AppUser`, `PartnerRequest`) live under `Job Tracker/Models` and use Codable/Firebase annotations. The design system tokens and reusable components are centralised in `Job Tracker/DesignSystem`.
+
+### Data & Integrations
+
+- **Firebase**: Firestore backs job, timesheet, and yellow sheet documents. Firebase Auth powers account management and custom claims for admin/supervisor roles.
+- **Generative AI**: `Features/SpliceAssist` wraps the Gemini API to analyse uploaded splice maps for troubleshooting, assignment suggestions, and CAN analysis.
+- **Maps & Location**: MapKit and Core Location surface routing assistance, arrival alerts, and job distance calculations.
+- **Sharing**: ShareLink, PDF generation, and deep-link routes enable exporting jobs to teammates, supervisors, and the iMessage extension.
+
+## Project Structure
+
+```
+Job Tracker778
+├── Job Tracker/                # Primary iOS app sources
+│   ├── Features/               # Feature-specific views and view models
+│   ├── Models/                 # Shared data models for Firestore
+│   ├── DesignSystem/           # Colors, typography, glass cards, reusable controls
+│   ├── Assets.xcassets/        # App icon and image assets
+│   └── GoogleService-Info.plist# Firebase configuration (replace with your own)
+├── Job Tracker Companion Watch App/  # watchOS companion app
+├── imessage cs/                # iMessage extension for sharing job summaries
+├── Job TrackerTests/           # XCTest coverage for services and view models
+├── Documentation/              # Markdown feature guides and process docs
+└── Job Tracker.xcodeproj       # Xcode project workspace
+```
+
+## Getting Started
+
+1. **Prerequisites**
+   - Xcode 15 or newer.
+   - A Firebase project with Firestore, Authentication (email/password), and Storage enabled.
+   - Optional: A Gemini API key for Splice Assist.
+
+2. **Configuration**
+   - Replace `Job Tracker/GoogleService-Info.plist` with the configuration for your Firebase project.
+   - Populate any environment secrets used by `FirebaseService` (e.g. Gemini key, storage buckets). The service expects appropriate keys in the app bundle or your preferred secret storage.
+   - Review `FirebaseService.swift` for endpoints specific to your deployment (Firestore collection names, callable functions).
+
+3. **Build & Run**
+   - Open `Job Tracker.xcodeproj` in Xcode.
+   - Select the *Job Tracker* target and your preferred simulator or device.
+   - Build and run (`⌘R`). Ensure push notification and location permissions are granted for arrival alerts and smart routing.
+
+4. **Companion Apps**
+   - **watchOS**: Select the *Job Tracker Companion Watch App* target to build the Watch app. `WatchBridge` mirrors daily jobs and leverages the same Firebase-backed models.
+   - **iMessage Extension**: The *imessage cs* target adds interactive job cards to Messages. Use a Messages simulator to preview.
+
+## Testing
+
+Automated tests live under `Job TrackerTests`. The suite exercises:
+
+- Admin panel mutations and maintenance workflows.
+- Deep link routing and job share payload parsing.
+- Job search matching heuristics and crew job summaries.
+- Yellow sheet and timesheet PDF generation pipelines.
+
+Run the full suite from Xcode (`⌘U`) or via command line:
+
+```sh
+xcodebuild test -scheme "Job Tracker" -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+## Contributing & Documentation
+
+- Review the [Design System guide](Job%20Tracker/DesignSystem/DesignSystem.md) for UI consistency.
+- Use the [feature guides](Documentation/README.md) for workflows and view model responsibilities.
+- Keep Firebase rules and Cloud Functions aligned with the data access patterns described in the documentation.
+
+For issues or enhancements, open a ticket describing the desired behaviour, environment, and screenshots/logs when applicable.


### PR DESCRIPTION
## Summary
- add a top-level README with setup instructions, architecture overview, and feature highlights
- update the documentation index and expand every feature guide with responsibilities, key types, and workflows
- document new Admin and Splice Assist modules and reference companion watchOS and iMessage targets

## Testing
- no tests were run (not required for documentation updates)

------
https://chatgpt.com/codex/tasks/task_e_68d57d4b87ac832d8fabe72ae496d993