### PR TITLE
Fix split view initialization in AppShellView

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppShellView.swift
+++ b/Job Tracker/Features/Shared/Shell/AppShellView.swift
@@ -32,10 +32,10 @@ struct AppShellView: View {
     }
 
     private var splitLayout: some View {
-        NavigationSplitView(selection: sidebarSelection) {
+        NavigationSplitView {
             SidebarList(selection: sidebarSelection)
-        } detail: { selectedDestination in
-            AppShellDetailView(destination: selectedDestination ?? navigation.activeDestination)
+        } detail: {
+            AppShellDetailView(destination: sidebarSelection.wrappedValue ?? navigation.activeDestination)
         }
         .navigationSplitViewColumnWidth(min: 260, ideal: 300)
     }


### PR DESCRIPTION
## Summary
- remove the unsupported selection parameter from the NavigationSplitView initializer
- resolve the selected destination inside the detail view using the sidebar binding

## Testing
- `xcodebuild -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -destination 'generic/platform=iOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f92fbbfc832d892a9f3f6490fc5f