### PR TITLE
Refine split view detail selection handling

### DIFF
--- a/Job Tracker/Features/Shared/Shell/AppShellView.swift
+++ b/Job Tracker/Features/Shared/Shell/AppShellView.swift
@@ -32,10 +32,10 @@ struct AppShellView: View {
     }
 
     private var splitLayout: some View {
-        NavigationSplitView(selection: sidebarSelection) {
+        NavigationSplitView {
             SidebarList(selection: sidebarSelection)
-        } detail: { selectedDestination in
-            AppShellDetailView(destination: selectedDestination ?? navigation.activeDestination)
+        } detail: {
+            AppShellDetailView(selection: sidebarSelection)
         }
         .navigationSplitViewColumnWidth(min: 260, ideal: 300)
     }
@@ -74,10 +74,15 @@ private struct SidebarList: View {
 }
 
 private struct AppShellDetailView: View {
-    let destination: AppNavigationViewModel.Destination
+    let selection: Binding<AppNavigationViewModel.Destination?>
 
     @EnvironmentObject private var jobsViewModel: JobsViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var navigation: AppNavigationViewModel
+
+    private var destination: AppNavigationViewModel.Destination {
+        selection.wrappedValue ?? navigation.activeDestination
+    }
 
     @ViewBuilder
     var body: some View {


### PR DESCRIPTION
## Summary
- pass the sidebar selection binding into the detail view
- resolve the active destination inside AppShellDetailView using the selection binding with a navigation fallback

## Testing
- `xcodebuild -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -destination 'generic/platform=iOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f92fbbfc832d892a9f3f6490fc5f