### PR TITLE
Ensure Firebase is configured before deep link import

### DIFF
--- a/Job Tracker/Job_TrackerApp.swift
+++ b/Job Tracker/Job_TrackerApp.swift
@@ -151,6 +151,7 @@ struct JobTrackerApp: App {
             }
             // Deep links
             .onOpenURL { url in
+                JobTrackerApp.ensureFirebaseConfigured()
                 guard let route = DeepLinkRouter.handle(url) else { return }
 
                 switch route {


### PR DESCRIPTION
## Summary
- ensure Firebase configuration is invoked when handling deep link imports so Firestore is ready on cold launches
- audited deep link handling paths and found no additional entry points that require changes

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d67a54e370832d8ac8cd1f12035158