### PR TITLE
Rename Route Mapper destination to Map

### DIFF
--- a/Job Tracker/Features/Help/HelpCenterView.swift
+++ b/Job Tracker/Features/Help/HelpCenterView.swift
@@ -151,9 +151,9 @@ struct HelpCenterView: View {
                 action: { navigation.navigate(to: .yellowSheet) }
             ),
             HelpTopic(
-                title: "Route Mapper",
+                title: "Map",
                 icon: "map.fill",
-                summary: "Plot poles, measure footage, and export a polished route map.",
+                summary: "Plot poles, measure footage, and export a polished map.",
                 bullets: [
                     "**Step 1:** Search for an address or drop a pin to center the map, then tap to place poles in order.",
                     "**Step 2:** Long-press between poles to insert a new point, drag to refine placement, or tap a pin for details.",
@@ -164,11 +164,11 @@ struct HelpCenterView: View {
                 action: { navigation.navigate(to: .maps) }
             ),
             HelpTopic(
-                title: "Route Mapper Sessions & Markup",
+                title: "Map Sessions & Markup",
                 icon: "person.2.circle",
                 summary: "Collaborate live, draw markups, and manage shared annotations.",
                 bullets: [
-                    "**Step 1:** Open **Route Mapper** and tap **Start Session** to host or **Join** to enter a coworker’s code.",
+                    "**Step 1:** Open **Map** and tap **Start Session** to host or **Join** to enter a coworker’s code.",
                     "**Step 2:** Share the session code or invite link; the online badge updates as teammates connect.",
                     "**Step 3:** Expand the markup drawer to pick drawing tools, shapes, colors, line widths, and underground dash styles.",
                     "**Step 4:** Use undo, delete, or clear actions to manage shared markups—changes broadcast instantly to everyone.",

--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -1029,7 +1029,7 @@ struct MapsView: View {
             }
             .sheet(isPresented: $showInviteShare) {
                 if let code = sessionID {
-                    ActivityView(activityItems: ["Join my Route Mapper session with code: \(code)"])
+                    ActivityView(activityItems: ["Join my Map session with code: \(code)"])
                 }
             }
             .onAppear {
@@ -1060,7 +1060,7 @@ struct MapsView: View {
                 .allowsHitTesting(!isFullScreen)
                 .accessibilityHidden(isFullScreen)
         }
-        .navigationTitle("Route Mapper")
+        .navigationTitle("Map")
         .sheet(isPresented: $showingHelp) { RouteMapperHelp() }
         .sheet(item: $selectedPole) { pole in
             PoleInspectorView(pole: pole) { updated in
@@ -1677,7 +1677,7 @@ struct MapsView: View {
             NavigationView {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
-                        Text("Route Mapper Guide").font(.title2).bold()
+                        Text("Map Guide").font(.title2).bold()
                         Group {
                             Text("Search: Use the search bar; tap a suggestion to zoom and drop a pole.")
                             Text("Add poles: Tap the map to drop poles in order. Long-press to insert between existing poles.")
@@ -1940,7 +1940,7 @@ struct MapsView: View {
         static func generate(poles: [Pole], mapImage: UIImage, totalDistance: Double) -> URL? {
             let pdfMeta = [
                 kCGPDFContextCreator: "Job Tracker",
-                kCGPDFContextAuthor:  "Route Mapper"
+                kCGPDFContextAuthor:  "Map"
             ] as CFDictionary
             let tmpURL = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("Route_\(UUID().uuidString).pdf")

--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -25,7 +25,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .dashboard:   return "Dashboard"
             case .timesheets:  return "Timesheets"
             case .yellowSheet: return "Yellow Sheet"
-            case .maps:        return "Route Mapper"
+            case .maps:        return "Map"
             case .recentCrewJobs: return "Recent Crew Jobs"
             case .search:      return "Job Search"
             case .more:        return "More"


### PR DESCRIPTION
## Summary
- rename the maps destination title to “Map” and ensure navigation labels pick up the new copy
- refresh help center topics and mapping UI strings to use the Map name consistently, including share text and PDF metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d751b7fa5c832db12fedde041962b2