### PR TITLE
Fix MapFocusRequest equatable conformance and coordinator parent access

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -256,6 +256,15 @@ struct MapFocusRequest: Identifiable, Equatable {
     let span: MKCoordinateSpan
 }
 
+extension MapFocusRequest {
+    static func == (lhs: MapFocusRequest, rhs: MapFocusRequest) -> Bool {
+        lhs.coordinate.latitude == rhs.coordinate.latitude &&
+        lhs.coordinate.longitude == rhs.coordinate.longitude &&
+        lhs.span.latitudeDelta == rhs.span.latitudeDelta &&
+        lhs.span.longitudeDelta == rhs.span.longitudeDelta
+    }
+}
+
 private extension CLLocationCoordinate2D {
     static let defaultCenter = CLLocationCoordinate2D(latitude: 35.9800, longitude: -88.9400)
 }
@@ -1012,7 +1021,7 @@ private struct RouteMapperMapView: UIViewRepresentable {
         private let poleIdentifier = "RouteMapperPole"
         private let spliceIdentifier = "RouteMapperSplice"
 
-        private var parent: RouteMapperMapView
+        var parent: RouteMapperMapView
         private var lineDragStart: CLLocationCoordinate2D?
         private var isDraggingLine = false
 


### PR DESCRIPTION
## Summary
- implement a custom Equatable conformance for MapFocusRequest based on coordinate and span values
- allow the map coordinator to refresh its parent reference when the SwiftUI view updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d75a2194b8832da9702a35abc5a389