### PR TITLE
Refine MapFocusRequest equatable conformance

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -250,13 +250,13 @@ struct LineDraft: Identifiable {
     var notes: String = ""
 }
 
-struct MapFocusRequest: Identifiable, Equatable {
+struct MapFocusRequest: Identifiable {
     let id = UUID()
     let coordinate: CLLocationCoordinate2D
     let span: MKCoordinateSpan
 }
 
-extension MapFocusRequest {
+extension MapFocusRequest: Equatable {
     static func == (lhs: MapFocusRequest, rhs: MapFocusRequest) -> Bool {
         lhs.coordinate.latitude == rhs.coordinate.latitude &&
         lhs.coordinate.longitude == rhs.coordinate.longitude &&


### PR DESCRIPTION
## Summary
- remove direct Equatable conformance from MapFocusRequest declaration
- reintroduce Equatable via extension to retain custom equality logic

## Testing
- xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -configuration Debug -sdk iphonesimulator build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d75beca92c832d97a79451ac274767