### PR TITLE
Allow coordinator to refresh parent reference

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -1021,6 +1021,8 @@ private struct RouteMapperMapView: UIViewRepresentable {
         private let poleIdentifier = "RouteMapperPole"
         private let spliceIdentifier = "RouteMapperSplice"
 
+        // The coordinator's parent must stay mutable so updateUIView can refresh
+        // the reference to the representable when SwiftUI recreates it.
         var parent: RouteMapperMapView
         private var lineDragStart: CLLocationCoordinate2D?
         private var isDraggingLine = false


### PR DESCRIPTION
## Summary
- document why the coordinator keeps a mutable reference to its parent representable

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d75bfb527c832d8f0a43f0be4b0fcb