### PR TITLE
Handle map edit mode toggling cleanup

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -88,7 +88,11 @@ class FiberMapViewModel: ObservableObject {
     @Published var lines: [FiberLine] = []
 
     // UI State
-    @Published var isEditMode = false
+    @Published var isEditMode = false {
+        didSet {
+            handleEditModeChange(from: oldValue)
+        }
+    }
     @Published var activeTool: EditTool?
     @Published var selectedAsset: AnyHashable?
     @Published var lineStartPole: Pole?
@@ -231,7 +235,19 @@ class FiberMapViewModel: ObservableObject {
         }
         updateInstruction()
     }
-    
+
+    private func handleEditModeChange(from previousValue: Bool) {
+        guard previousValue != isEditMode else { return }
+
+        lineStartPole = nil
+
+        if isEditMode {
+            updateInstruction()
+        } else {
+            editInstruction = nil
+        }
+    }
+
     private func updateInstruction() {
         if isEditMode {
             if let tool = activeTool {


### PR DESCRIPTION
## Summary
- add a property observer to the map edit mode flag so toggling clears in-progress tool state and recomputes instructions
- ensure disabling edit mode drops any active line drawing context and hides the instruction banner immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7def00580832d9216fdd24c605fe6