### PR TITLE
Update RouteService pole serialization for new model

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/RouteService.swift
+++ b/Job Tracker/Features/Shared/Mapping/RouteService.swift
@@ -88,30 +88,76 @@ final class RouteService: ObservableObject {
 extension Pole {
     
     func toDict() -> [String: Any] {
-        [
+        var dict: [String: Any] = [
             "id": id.uuidString,
+            "name": name,
             "lat": coordinate.latitude,
             "lon": coordinate.longitude,
-            "assignment": assignment,
-            "canAtLocation": canAtLocation,
+            "status": status.rawValue,
+            "material": material,
             "notes": notes
-            // NOTE: Photos could be stored as URLs here in the future.
         ]
+
+        if let installDate {
+            dict["installDate"] = Timestamp(date: installDate)
+        }
+
+        if let lastInspection {
+            dict["lastInspection"] = Timestamp(date: lastInspection)
+        }
+
+        if let imageUrl {
+            dict["imageUrl"] = imageUrl
+        }
+
+        return dict
     }
-    
+
     static func fromDict(_ dict: [String: Any]) -> Pole? {
         guard
             let idStr = dict["id"] as? String,
             let lat   = dict["lat"] as? CLLocationDegrees,
             let lon   = dict["lon"] as? CLLocationDegrees
         else { return nil }
-        
-        var pole = Pole(id: UUID(uuidString: idStr) ?? UUID(),
-                        coordinate: CLLocationCoordinate2D(latitude: lat,
-                                                            longitude: lon))
-        pole.assignment     = dict["assignment"]     as? String ?? ""
-        pole.canAtLocation  = dict["canAtLocation"]  as? Bool   ?? false
-        pole.notes          = dict["notes"]          as? String ?? ""
-        return pole
+
+        let id = UUID(uuidString: idStr) ?? UUID()
+        let name = dict["name"] as? String ?? "Pole"
+
+        let statusRaw = dict["status"] as? String
+        let status = statusRaw.flatMap(AssetStatus.init(rawValue:)) ?? .good
+
+        let installDate: Date?
+        if let timestamp = dict["installDate"] as? Timestamp {
+            installDate = timestamp.dateValue()
+        } else if let date = dict["installDate"] as? Date {
+            installDate = date
+        } else {
+            installDate = nil
+        }
+
+        let lastInspection: Date?
+        if let timestamp = dict["lastInspection"] as? Timestamp {
+            lastInspection = timestamp.dateValue()
+        } else if let date = dict["lastInspection"] as? Date {
+            lastInspection = date
+        } else {
+            lastInspection = nil
+        }
+
+        let material = dict["material"] as? String ?? "Unknown"
+        let notes = dict["notes"] as? String ?? ""
+        let imageUrl = dict["imageUrl"] as? String
+
+        return Pole(
+            id: id,
+            name: name,
+            coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+            status: status,
+            installDate: installDate,
+            lastInspection: lastInspection,
+            material: material,
+            notes: notes,
+            imageUrl: imageUrl
+        )
     }
 }


### PR DESCRIPTION
## Summary
- align RouteService pole serialization helpers with the current Pole fields including name, status, and media metadata
- provide defensive defaults when deserializing poles from Firestore data to keep the mapper resilient to missing fields
- preserve optional date values using Firestore timestamps so persisted poles retain inspection history

## Testing
- xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build

------
https://chatgpt.com/codex/tasks/task_e_68d7deef7b54832d843c931359bf9d34