### PR TITLE
Expose optional Binding helper initializer

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -575,7 +575,7 @@ struct LineEditView: View {
     @State var line: FiberLine
     var onSave: (FiberLine) -> Void
     var onCancel: () -> Void
-    
+
     var body: some View {
          NavigationStack {
             Form {
@@ -597,6 +597,17 @@ struct LineEditView: View {
                 ToolbarItem(placement: .confirmationAction) { Button("Save") { onSave(line) } }
             }
         }
+    }
+}
+
+extension Binding {
+    init(_ source: Binding<Value?>, default defaultValue: Value) {
+        self.init(
+            get: { source.wrappedValue ?? defaultValue },
+            set: { newValue in
+                source.wrappedValue = newValue
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add an internal Binding initializer wrapper so optional bindings with default values can be used across the app

## Testing
- xcodebuild -list -project 'Job Tracker.xcodeproj' *(fails: xcodebuild is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ef9b616c832dadf5ed2e65da2c88