### PR TITLE
Add persistent storage for fiber map data

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/FiberMapStorage.swift
+++ b/Job Tracker/Features/Shared/Mapping/FiberMapStorage.swift
@@ -1,0 +1,60 @@
+import Foundation
+import CoreLocation
+
+struct FiberMapSnapshot: Codable, Equatable {
+    var poles: [Pole]
+    var splices: [SpliceEnclosure]
+    var lines: [FiberLine]
+}
+
+final class FiberMapStorage {
+    static let shared = FiberMapStorage()
+
+    private let fileManager: FileManager
+    private let directoryURL: URL
+    private let fileURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        directoryURL: URL? = nil,
+        fileName: String = "FiberMapData.json",
+        fileManager: FileManager = .default,
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.fileManager = fileManager
+        self.encoder = encoder
+        self.decoder = decoder
+
+        if let directoryURL {
+            self.directoryURL = directoryURL
+        } else if let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            self.directoryURL = documents
+        } else {
+            self.directoryURL = fileManager.temporaryDirectory
+        }
+
+        self.fileURL = self.directoryURL.appendingPathComponent(fileName)
+
+        if !fileManager.fileExists(atPath: self.directoryURL.path) {
+            try? fileManager.createDirectory(at: self.directoryURL, withIntermediateDirectories: true)
+        }
+    }
+
+    func load() throws -> FiberMapSnapshot? {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
+
+        let data = try Data(contentsOf: fileURL)
+        return try decoder.decode(FiberMapSnapshot.self, from: data)
+    }
+
+    func save(_ snapshot: FiberMapSnapshot) throws {
+        let data = try encoder.encode(snapshot)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    func save(poles: [Pole], splices: [SpliceEnclosure], lines: [FiberLine]) throws {
+        try save(FiberMapSnapshot(poles: poles, splices: splices, lines: lines))
+    }
+}

--- a/Job TrackerTests/FiberMapViewModelTests.swift
+++ b/Job TrackerTests/FiberMapViewModelTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import CoreLocation
+@testable import Job_Tracker
+
+final class FiberMapViewModelTests: XCTestCase {
+    private var tempDirectory: URL!
+    private var storage: FiberMapStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        storage = FiberMapStorage(directoryURL: tempDirectory, fileName: "FiberMapTest.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDirectory)
+        storage = nil
+        tempDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testPersistenceAcrossViewModelInstances() {
+        let viewModel = FiberMapViewModel(storage: storage)
+
+        let newPole = Pole(
+            id: UUID(),
+            name: "Persisted Pole",
+            coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2),
+            status: .good,
+            installDate: nil,
+            lastInspection: nil,
+            material: "Steel",
+            notes: "Persistence test",
+            imageUrl: nil
+        )
+
+        viewModel.saveItem(newPole)
+
+        let reloadedViewModel = FiberMapViewModel(storage: storage)
+        XCTAssertTrue(reloadedViewModel.poles.contains(where: { $0.id == newPole.id }))
+    }
+}


### PR DESCRIPTION
## Summary
- add a FiberMapStorage helper that persists fiber map poles, splices, and lines data in the documents directory
- update FiberMapViewModel to hydrate from persisted data and write changes after each mutation
- add a regression test to ensure edits persist across FiberMapViewModel instances

## Testing
- xcodebuild -version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fcf3db2c832d984d950d54a5d135