### PR TITLE
Ensure tutorial highlights use named coordinate space

### DIFF
--- a/Job Tracker/Features/Help/InteractiveTutorialView.swift
+++ b/Job Tracker/Features/Help/InteractiveTutorialView.swift
@@ -444,7 +444,7 @@ struct InteractiveTutorialView: View {
         .overlayPreferenceValue(TutorialHighlightPreferenceKey.self) { targets in
             GeometryReader { proxy in
                 let items = targets.map { target -> TutorialHighlightItem in
-                    let rect = proxy[target.anchor].insetBy(dx: -target.padding, dy: -target.padding)
+                    let rect = proxy[target.anchor, in: .named(TutorialHighlightOverlay.coordinateSpaceName)].insetBy(dx: -target.padding, dy: -target.padding)
                     return TutorialHighlightItem(
                         id: target.id,
                         frame: rect,


### PR DESCRIPTION
## Summary
- resolve tutorial highlight target frames using the named overlay coordinate space so they stay aligned with their controls

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d80b737434832da15ec745f9271169