### PR TITLE
Fix coordinate space usage for tutorial highlight overlay

### DIFF
--- a/Job Tracker/Features/Help/InteractiveTutorialView.swift
+++ b/Job Tracker/Features/Help/InteractiveTutorialView.swift
@@ -444,7 +444,7 @@ struct InteractiveTutorialView: View {
         .overlayPreferenceValue(TutorialHighlightPreferenceKey.self) { targets in
             GeometryReader { proxy in
                 let items = targets.map { target -> TutorialHighlightItem in
-                    let rect = proxy[target.anchor, in: .named(TutorialHighlightOverlay.coordinateSpaceName)].insetBy(dx: -target.padding, dy: -target.padding)
+                    let rect = proxy[target.anchor, in: CoordinateSpace.named(TutorialHighlightOverlay.coordinateSpaceName)].insetBy(dx: -target.padding, dy: -target.padding)
                     return TutorialHighlightItem(
                         id: target.id,
                         frame: rect,


### PR DESCRIPTION
## Summary
- use an explicit CoordinateSpace for tutorial highlight calculations to satisfy new SwiftUI requirements

## Testing
- `xcodebuild -scheme "Job Tracker" -sdk iphonesimulator -configuration Debug build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d80d4c5b2c832d95b0d7e2486c6e6e