### PR TITLE
Use explicit SwiftUI coordinate space for tutorial overlay

### DIFF
--- a/Job Tracker/Features/Help/InteractiveTutorialView.swift
+++ b/Job Tracker/Features/Help/InteractiveTutorialView.swift
@@ -444,7 +444,7 @@ struct InteractiveTutorialView: View {
         .overlayPreferenceValue(TutorialHighlightPreferenceKey.self) { targets in
             GeometryReader { proxy in
                 let items = targets.map { target -> TutorialHighlightItem in
-                    let rect = proxy[target.anchor, in: CoordinateSpace.named(TutorialHighlightOverlay.coordinateSpaceName)].insetBy(dx: -target.padding, dy: -target.padding)
+                    let rect = proxy[target.anchor, in: SwiftUI.CoordinateSpace.named(TutorialHighlightOverlay.coordinateSpaceName)].insetBy(dx: -target.padding, dy: -target.padding)
                     return TutorialHighlightItem(
                         id: target.id,
                         frame: rect,


### PR DESCRIPTION
## Summary
- update the tutorial highlight overlay to reference SwiftUI.CoordinateSpace explicitly

## Testing
- `xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68d80f3e03bc832d9d32b048d40ee033