### PR TITLE
Fix map feature click event propagation

### DIFF
--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -97,8 +97,8 @@
                 const marker = L.marker([pole.lat, pole.lng], { icon, bubblingMouseEvents: false });
                 marker.bindPopup(renderPopup(pole, 'Pole'));
                 marker.on('click', function(event) {
-                    if (event) {
-                        L.DomEvent.stopPropagation(event);
+                    if (event?.originalEvent) {
+                        L.DomEvent.stopPropagation(event.originalEvent);
                     }
                     postMessage('poleTapped', { id: pole.id });
                 });
@@ -121,8 +121,8 @@
                 const marker = L.marker([splice.lat, splice.lng], { icon, bubblingMouseEvents: false });
                 marker.bindPopup(renderPopup(splice, 'Splice'));
                 marker.on('click', function(event) {
-                    if (event) {
-                        L.DomEvent.stopPropagation(event);
+                    if (event?.originalEvent) {
+                        L.DomEvent.stopPropagation(event.originalEvent);
                     }
                     postMessage('spliceTapped', { id: splice.id });
                 });
@@ -150,8 +150,8 @@
                 ], options);
                 polyline.bindPopup(renderPopup(line, 'Line'));
                 polyline.on('click', function(event) {
-                    if (event) {
-                        L.DomEvent.stopPropagation(event);
+                    if (event?.originalEvent) {
+                        L.DomEvent.stopPropagation(event.originalEvent);
                     }
                     postMessage('lineTapped', { id: line.id });
                 });


### PR DESCRIPTION
## Summary
- adjust pole, splice, and line click handlers to stop propagation on the underlying DOM event
- ensure popups stay open until tapping elsewhere on the map

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68d890ae18c8832d9fcef19ac257c269