### PR TITLE
Prevent map from swallowing touch events on web map features

### DIFF
--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -87,6 +87,12 @@
                 layer.clearLayers();
             }
 
+            function stopDomEvent(event) {
+                if (event?.originalEvent) {
+                    L.DomEvent.stop(event.originalEvent);
+                }
+            }
+
             function createPoleMarker(pole) {
                 const icon = L.divIcon({
                     className: 'custom-div-icon',
@@ -96,10 +102,10 @@
                 });
                 const marker = L.marker([pole.lat, pole.lng], { icon, bubblingMouseEvents: false });
                 marker.bindPopup(renderPopup(pole, 'Pole'));
+                marker.on('touchstart', stopDomEvent);
+                marker.on('pointerdown', stopDomEvent);
                 marker.on('click', function(event) {
-                    if (event?.originalEvent) {
-                        L.DomEvent.stopPropagation(event.originalEvent);
-                    }
+                    stopDomEvent(event);
                     postMessage('poleTapped', { id: pole.id });
                 });
                 return marker;
@@ -120,10 +126,10 @@
                 });
                 const marker = L.marker([splice.lat, splice.lng], { icon, bubblingMouseEvents: false });
                 marker.bindPopup(renderPopup(splice, 'Splice'));
+                marker.on('touchstart', stopDomEvent);
+                marker.on('pointerdown', stopDomEvent);
                 marker.on('click', function(event) {
-                    if (event?.originalEvent) {
-                        L.DomEvent.stopPropagation(event.originalEvent);
-                    }
+                    stopDomEvent(event);
                     postMessage('spliceTapped', { id: splice.id });
                 });
                 return marker;
@@ -149,10 +155,10 @@
                     [end.lat, end.lng]
                 ], options);
                 polyline.bindPopup(renderPopup(line, 'Line'));
+                polyline.on('touchstart', stopDomEvent);
+                polyline.on('pointerdown', stopDomEvent);
                 polyline.on('click', function(event) {
-                    if (event?.originalEvent) {
-                        L.DomEvent.stopPropagation(event.originalEvent);
-                    }
+                    stopDomEvent(event);
                     postMessage('lineTapped', { id: line.id });
                 });
                 return polyline;


### PR DESCRIPTION
## Summary
- add a shared DOM event stopper for feature layers in the fiber map
- prevent touch and pointer events on poles, splices, and lines from bubbling to the map
- ensure click handlers also stop the originating DOM event before messaging native code

## Testing
- not run (requires iOS environment)


------
https://chatgpt.com/codex/tasks/task_e_68d892829850832db08a7f382f21c3e6