### PR TITLE
Prevent map taps firing when interacting with features

### DIFF
--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -72,6 +72,10 @@
                 state.layers.lines = L.layerGroup().addTo(map);
 
                 map.on('click', function(event) {
+                    const source = event.sourceTarget || event.propagatedFrom;
+                    if (source && source !== map) {
+                        return;
+                    }
                     postMessage('mapTapped', {
                         latitude: event.latlng.lat,
                         longitude: event.latlng.lng


### PR DESCRIPTION
## Summary
- ensure the map click handler ignores events originating from markers or polylines
- preserve existing mapTapped messages for background clicks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8950a0cb4832d80eca531a1ddf459