### PR TITLE
Prevent map tap handling for interactive overlays

### DIFF
--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -71,9 +71,27 @@
                 state.layers.splices = L.layerGroup().addTo(map);
                 state.layers.lines = L.layerGroup().addTo(map);
 
+                function isInteractiveEvent(event) {
+                    const originalTarget = event.originalEvent?.target;
+                    if (originalTarget?.closest('.leaflet-marker-icon, .leaflet-interactive, .leaflet-popup, .leaflet-control')) {
+                        return true;
+                    }
+
+                    const propagatedFrom = event.propagatedFrom;
+                    if (propagatedFrom && propagatedFrom !== map) {
+                        return true;
+                    }
+
+                    const sourceTarget = event.sourceTarget;
+                    if (sourceTarget && sourceTarget !== map) {
+                        return true;
+                    }
+
+                    return false;
+                }
+
                 map.on('click', function(event) {
-                    const source = event.sourceTarget || event.propagatedFrom;
-                    if (source && source !== map) {
+                    if (isInteractiveEvent(event)) {
                         return;
                     }
                     postMessage('mapTapped', {


### PR DESCRIPTION
## Summary
- add a helper to detect when Leaflet click events originate from interactive overlays
- skip posting the mapTapped message when the event started from markers, popups, or controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d896801784832d9df8e5e63b81a727