### PR TITLE
Prevent map feature taps from clearing selection

### DIFF
--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -147,10 +147,6 @@
                 }
 
                 map.on('click', function(event) {
-                    if (state.selectionActive) {
-                        setSelection(false);
-                        return;
-                    }
                     if (isInteractiveEvent(event)) {
                         return;
                     }


### PR DESCRIPTION
## Summary
- defer map click clearing until after filtering out interactive targets
- ensure map taps on markers and popups do not immediately clear the selection state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d899e7a768832dbbdfbce35e6e315e