### PR TITLE
Avoid redundant map rebuilds on SwiftUI updates

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/LeafletWebMapView.swift
+++ b/Job Tracker/Features/Shared/Mapping/LeafletWebMapView.swift
@@ -34,8 +34,6 @@ struct LeafletWebMapView: UIViewRepresentable {
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
         context.coordinator.webView = uiView
-        context.coordinator.sendSnapshotIfReady()
-        context.coordinator.sendInteractionState()
     }
 
     // MARK: - Coordinator


### PR DESCRIPTION
## Summary
- prevent LeafletWebMapView.updateUIView from forcing a new snapshot/interaction push so @Published changes like selection do not rebuild the map

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d94ed48414832da061f5b554678906