### PR TITLE
Add address search and map centering support

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/FiberMapStorage.swift
+++ b/Job Tracker/Features/Shared/Mapping/FiberMapStorage.swift
@@ -1,10 +1,17 @@
 import Foundation
 import CoreLocation
 
+struct MapCameraState: Codable, Equatable {
+    var latitude: Double
+    var longitude: Double
+    var zoom: Double?
+}
+
 struct FiberMapSnapshot: Codable, Equatable {
     var poles: [Pole]
     var splices: [SpliceEnclosure]
     var lines: [FiberLine]
+    var mapCamera: MapCameraState?
 }
 
 final class FiberMapStorage {
@@ -54,7 +61,7 @@ final class FiberMapStorage {
         try data.write(to: fileURL, options: .atomic)
     }
 
-    func save(poles: [Pole], splices: [SpliceEnclosure], lines: [FiberLine]) throws {
-        try save(FiberMapSnapshot(poles: poles, splices: splices, lines: lines))
+    func save(poles: [Pole], splices: [SpliceEnclosure], lines: [FiberLine], mapCamera: MapCameraState) throws {
+        try save(FiberMapSnapshot(poles: poles, splices: splices, lines: lines, mapCamera: mapCamera))
     }
 }

--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -49,6 +49,7 @@
                 },
                 polePositions: new Map(),
                 isReady: false,
+                searchMarker: null,
             };
 
             function postMessage(event, payload) {
@@ -282,6 +283,50 @@
                 });
             }
 
+            function handleCenterCommand(payload) {
+                ensureMap();
+                if (!state.map || !payload) { return; }
+
+                const latitude = payload.latitude;
+                const longitude = payload.longitude;
+                const zoom = payload.zoom ?? state.map.getZoom();
+
+                state.map.setView([latitude, longitude], zoom, { animate: true });
+
+                if (state.searchMarker) {
+                    state.map.removeLayer(state.searchMarker);
+                    state.searchMarker = null;
+                }
+
+                const highlight = L.circleMarker([latitude, longitude], {
+                    radius: 8,
+                    color: '#2563eb',
+                    weight: 2,
+                    fillColor: '#3b82f6',
+                    fillOpacity: 0.7,
+                    bubblingMouseEvents: false
+                }).addTo(state.map);
+
+                if (payload.label) {
+                    highlight.bindTooltip(payload.label, {
+                        permanent: true,
+                        direction: 'top'
+                    }).openTooltip();
+                }
+
+                state.searchMarker = highlight;
+
+                setTimeout(() => {
+                    if (state.searchMarker === highlight) {
+                        if (state.searchMarker.getTooltip()) {
+                            state.searchMarker.closeTooltip();
+                        }
+                        state.map.removeLayer(state.searchMarker);
+                        state.searchMarker = null;
+                    }
+                }, 5000);
+            }
+
             function handleCommand(command) {
                 if (!command) { return; }
                 if (command.type === 'snapshot') {
@@ -290,6 +335,8 @@
                     applyInteractionState(command.payload);
                 } else if (command.type === 'layers') {
                     updateVisibleLayers(command.payload || []);
+                } else if (command.type === 'centerMap') {
+                    handleCenterCommand(command.payload);
                 }
             }
 
@@ -300,6 +347,7 @@
                 applyInteractionState,
                 updateVisibleLayers,
                 handleCommand,
+                centerMap: handleCenterCommand,
                 clearSelection: () => setSelection(false)
             };
         })();

--- a/Job TrackerTests/FiberMapViewModelTests.swift
+++ b/Job TrackerTests/FiberMapViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import CoreLocation
 @testable import Job_Tracker
 
+@MainActor
 final class FiberMapViewModelTests: XCTestCase {
     private var tempDirectory: URL!
     private var storage: FiberMapStorage!
@@ -21,7 +22,7 @@ final class FiberMapViewModelTests: XCTestCase {
     }
 
     func testPersistenceAcrossViewModelInstances() {
-        let viewModel = FiberMapViewModel(storage: storage)
+        let viewModel = FiberMapViewModel(storage: storage, searchProvider: MockMapSearchProvider())
 
         let newPole = Pole(
             id: UUID(),
@@ -37,7 +38,57 @@ final class FiberMapViewModelTests: XCTestCase {
 
         viewModel.saveItem(newPole)
 
-        let reloadedViewModel = FiberMapViewModel(storage: storage)
+        let reloadedViewModel = FiberMapViewModel(storage: storage, searchProvider: MockMapSearchProvider())
         XCTAssertTrue(reloadedViewModel.poles.contains(where: { $0.id == newPole.id }))
+    }
+
+    func testSearchResultsUpdateAndPersistCenter() async throws {
+        let expectedResult = MapSearchResult(
+            title: "Test Location",
+            subtitle: "123 Test Street",
+            coordinate: CLLocationCoordinate2D(latitude: 37.3317, longitude: -122.0301)
+        )
+
+        let searchProvider = MockMapSearchProvider(results: [expectedResult])
+        let viewModel = FiberMapViewModel(storage: storage, searchProvider: searchProvider)
+
+        await viewModel.searchLocations(for: "Test")
+        XCTAssertEqual(viewModel.searchResults.count, 1)
+        XCTAssertEqual(viewModel.searchResults.first?.title, expectedResult.title)
+
+        guard let result = viewModel.searchResults.first else {
+            XCTFail("Missing search result")
+            return
+        }
+
+        viewModel.selectSearchResult(result)
+        XCTAssertEqual(viewModel.mapCamera.latitude, expectedResult.coordinate.latitude, accuracy: 0.0001)
+        XCTAssertEqual(viewModel.mapCamera.longitude, expectedResult.coordinate.longitude, accuracy: 0.0001)
+        XCTAssertEqual(viewModel.pendingCenterCommand?.label, expectedResult.title)
+        XCTAssertEqual(viewModel.pendingCenterCommand?.latitude, expectedResult.coordinate.latitude, accuracy: 0.0001)
+
+        viewModel.acknowledgeCenterCommand()
+        XCTAssertNil(viewModel.pendingCenterCommand)
+
+        let reloadedViewModel = FiberMapViewModel(storage: storage, searchProvider: MockMapSearchProvider())
+        XCTAssertEqual(reloadedViewModel.mapCamera.latitude, expectedResult.coordinate.latitude, accuracy: 0.0001)
+        XCTAssertEqual(reloadedViewModel.mapCamera.longitude, expectedResult.coordinate.longitude, accuracy: 0.0001)
+    }
+}
+
+private final class MockMapSearchProvider: MapSearchProviding {
+    var results: [MapSearchResult]
+    var error: Error?
+
+    init(results: [MapSearchResult] = [], error: Error? = nil) {
+        self.results = results
+        self.error = error
+    }
+
+    func searchLocations(matching query: String) async throws -> [MapSearchResult] {
+        if let error {
+            throw error
+        }
+        return results
     }
 }


### PR DESCRIPTION
## Summary
- add a SwiftUI search overlay that calls a new geocoding helper on the fiber map view model
- persist and replay the last map center, including a centerMap command to the Leaflet bridge with highlight support
- expand unit coverage to cover the geocoding path and persistence of the centered location

## Testing
- not run (requires Xcode/macOS)


------
https://chatgpt.com/codex/tasks/task_e_68d95aaece6c832d8915120e1592a8e8