### PR TITLE
Add locate-me support to fiber map

### DIFF
--- a/Job Tracker/Features/Shared/Services/LocationService.swift
+++ b/Job Tracker/Features/Shared/Services/LocationService.swift
@@ -10,6 +10,13 @@ import CoreLocation
 import Combine
 import SwiftUI
 
+protocol LocationServiceProviding: AnyObject {
+    var current: CLLocation? { get }
+    var currentPublisher: AnyPublisher<CLLocation?, Never> { get }
+    func startStandardUpdates()
+    func requestAlwaysAuthorizationIfNeeded()
+}
+
 final class LocationService: NSObject, ObservableObject {
     @Published var current: CLLocation?
     let regionEventsPublisher: AnyPublisher<RegionEvent, Never>
@@ -164,6 +171,10 @@ final class LocationService: NSObject, ObservableObject {
             manager.stopMonitoring(for: region)
         }
     }
+}
+
+extension LocationService: LocationServiceProviding {
+    var currentPublisher: AnyPublisher<CLLocation?, Never> { $current.eraseToAnyPublisher() }
 }
 
 extension LocationService: CLLocationManagerDelegate {

--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -290,6 +290,8 @@
                 const latitude = payload.latitude;
                 const longitude = payload.longitude;
                 const zoom = payload.zoom ?? state.map.getZoom();
+                const kind = payload.kind || 'searchResult';
+                const isUserLocation = kind === 'userLocation';
 
                 state.map.setView([latitude, longitude], zoom, { animate: true });
 
@@ -298,14 +300,23 @@
                     state.searchMarker = null;
                 }
 
-                const highlight = L.circleMarker([latitude, longitude], {
+                const highlightOptions = isUserLocation ? {
+                    radius: 10,
+                    color: '#1d4ed8',
+                    weight: 2,
+                    fillColor: '#60a5fa',
+                    fillOpacity: 0.5,
+                    bubblingMouseEvents: false
+                } : {
                     radius: 8,
                     color: '#2563eb',
                     weight: 2,
                     fillColor: '#3b82f6',
                     fillOpacity: 0.7,
                     bubblingMouseEvents: false
-                }).addTo(state.map);
+                };
+
+                const highlight = L.circleMarker([latitude, longitude], highlightOptions).addTo(state.map);
 
                 if (payload.label) {
                     highlight.bindTooltip(payload.label, {
@@ -324,7 +335,7 @@
                         state.map.removeLayer(state.searchMarker);
                         state.searchMarker = null;
                     }
-                }, 5000);
+                }, isUserLocation ? 7000 : 5000);
             }
 
             function handleCommand(command) {


### PR DESCRIPTION
## Summary
- inject LocationService into MapsView with a new "locate me" control that centers the map
- extend FiberMapViewModel and the web bridge to publish user-location center commands with command metadata
- teach FiberBridge to style the user-location center command and add unit coverage for location updates and accessibility

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d96a7dc4cc832d982ae2cd0af106bc