### PR TITLE
Align floating controls with control panel width

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -747,6 +747,7 @@ struct MapsView: View {
     @StateObject private var viewModel = FiberMapViewModel()
     @State private var showControls = true
     @State private var searchQuery = ""
+    @State private var controlPanelWidth: CGFloat = 0
     @EnvironmentObject private var locationService: LocationService
 
     var body: some View {
@@ -852,6 +853,15 @@ struct MapsView: View {
                     if showControls {
                         ControlPanelView(viewModel: viewModel)
                             .padding([.leading, .top])
+                            .background(
+                                GeometryReader { geometry in
+                                    Color.clear
+                                        .onAppear { controlPanelWidth = geometry.size.width }
+                                        .onChange(of: geometry.size) { newSize in
+                                            controlPanelWidth = newSize.width
+                                        }
+                                }
+                            )
                             .transition(.move(edge: .leading).combined(with: .opacity))
                     }
                     Spacer()
@@ -888,7 +898,12 @@ struct MapsView: View {
 
                     Spacer()
                 }
-                .padding(.leading, showControls ? 282 : 20)
+                .padding(
+                    .leading,
+                    showControls
+                        ? (controlPanelWidth > 0 ? controlPanelWidth + 32 : 32)
+                        : 20
+                )
                 .padding(.top, 20)
                 Spacer()
             }


### PR DESCRIPTION
## Summary
- measure the control panel width inside MapsView using a GeometryReader
- store the control panel width in state and use it to align the floating buttons
- provide a fallback leading padding when controls are hidden

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d992b85644832d8a8d53c3a7c7c3bd