### PR TITLE
Preserve create job sheet on job list updates

### DIFF
--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -199,7 +199,9 @@ final class DashboardViewModel: ObservableObject {
     }
 
     func handleJobsListChange(_ jobs: [Job], currentLocation: CLLocation?) {
-        activeSheet = nil
+        if activeSheet != .createJob {
+            activeSheet = nil
+        }
         updateNearestJob(with: jobs, currentLocation: currentLocation)
     }
 


### PR DESCRIPTION
## Summary
- keep the create job sheet visible when the jobs list refreshes so inline edits do not close the form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbebf453d8832d9f18c6a4d6b66fa7