### PR TITLE
Fix accent color usage in map controls handle

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -1054,7 +1054,7 @@ private struct MapControlsCollapsedHandle: View {
             VStack(spacing: 6) {
                 Image(systemName: "slider.horizontal.3")
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
 
                 Text("Map Controls")
                     .font(.caption2.weight(.semibold))


### PR DESCRIPTION
## Summary
- replace the deprecated shorthand accent color reference in MapControlsCollapsedHandle with an explicit Color.accentColor usage to restore compilation

## Testing
- xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc55cbdcc0832dbe2eb3381f87672c