### PR TITLE
Fix ControlPanelBadgeIcon accent color usage

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -878,7 +878,7 @@ private struct ControlPanelBadgeIcon: View {
     var body: some View {
         Image(systemName: "map")
             .font(.title3.weight(.semibold))
-            .foregroundStyle(.accentColor)
+            .foregroundStyle(Color.accentColor)
             .frame(width: 38, height: 38)
             .background(
                 Circle()


### PR DESCRIPTION
## Summary
- update the ControlPanelBadgeIcon to use Color.accentColor in foregroundStyle so SwiftUI resolves the member correctly

## Testing
- xcodebuild -workspace "Job Tracker.xcodeproj" -scheme "Job Tracker" build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc55ca4ab8832db008a69b8f8d0421