### PR TITLE
Replace deprecated authorization status API usage

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -570,7 +570,7 @@ class FiberMapViewModel: ObservableObject {
 
     func locateUser(
         using service: LocationServiceProviding,
-        authorizationStatus: CLAuthorizationStatus = CLLocationManager.authorizationStatus()
+        authorizationStatus: CLAuthorizationStatus = CLLocationManager().authorizationStatus
     ) {
         bindLocationService(service)
 


### PR DESCRIPTION
## Summary
- replace the deprecated CLLocationManager.authorizationStatus() default value with the modern authorizationStatus property

## Testing
- xcodebuild -scheme "Job Tracker" -destination 'generic/platform=iOS' build *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc55c99484832da1e7f2a6a607267d