### PR TITLE
Anchor map map controls near bottom left

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -775,62 +775,67 @@ struct MapsView: View {
                 }
             }
 
-        VStack {
-            HStack(alignment: .top, spacing: 0) {
-                if showControls {
-                    MapControlsExpandedDrawer(
-                        viewModel: viewModel,
-                        onCollapse: {
-                            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                                showControls = false
-                            }
-                        },
-                        measuredWidth: $controlPanelWidth
-                    )
-                    .transition(.move(edge: .leading).combined(with: .opacity))
-                } else {
-                    MapControlsCollapsedHandle(
-                        onExpand: {
-                            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                                showControls = true
-                            }
-                        },
-                        measuredWidth: $collapsedDrawerWidth
-                    )
-                    .transition(.move(edge: .leading).combined(with: .opacity))
-                }
+            VStack(spacing: 0) {
                 Spacer()
-            }
-            .padding(.leading, 20)
-            .padding(.top, 20)
-            Spacer()
-        }
 
-        VStack {
-            let activeDrawerWidth = showControls
-                ? max(controlPanelWidth, collapsedDrawerWidth)
-                : collapsedDrawerWidth
+                HStack(alignment: .top, spacing: 0) {
+                    if showControls {
+                        MapControlsExpandedDrawer(
+                            viewModel: viewModel,
+                            onCollapse: {
+                                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                                    showControls = false
+                                }
+                            },
+                            measuredWidth: $controlPanelWidth
+                        )
+                        .transition(.move(edge: .leading).combined(with: .opacity))
+                    } else {
+                        MapControlsCollapsedHandle(
+                            onExpand: {
+                                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                                    showControls = true
+                                }
+                            },
+                            measuredWidth: $collapsedDrawerWidth
+                        )
+                        .transition(.move(edge: .leading).combined(with: .opacity))
+                    }
 
-            HStack(alignment: .top, spacing: 12) {
-                Button(action: locateUser) {
-                    Image(systemName: "location.circle.fill")
-                        .font(.title3.weight(.semibold))
-                        .padding(12)
-                        .background(.regularMaterial)
-                        .clipShape(Circle())
-                        .shadow(radius: 4)
+                    Spacer()
                 }
-                .accessibilityLabel(Text(Accessibility.locateButtonLabel))
+                .padding(.leading, 20)
+                .padding(.bottom, 20)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+
+            VStack(spacing: 0) {
+                let activeDrawerWidth = showControls
+                    ? max(controlPanelWidth, collapsedDrawerWidth)
+                    : collapsedDrawerWidth
 
                 Spacer()
+
+                HStack(alignment: .top, spacing: 12) {
+                    Button(action: locateUser) {
+                        Image(systemName: "location.circle.fill")
+                            .font(.title3.weight(.semibold))
+                            .padding(12)
+                            .background(.regularMaterial)
+                            .clipShape(Circle())
+                            .shadow(radius: 4)
+                    }
+                    .accessibilityLabel(Text(Accessibility.locateButtonLabel))
+
+                    Spacer()
+                }
+                .padding(
+                    .leading,
+                    max(activeDrawerWidth + 32, 20)
+                )
+                .padding(.bottom, 12)
             }
-            .padding(
-                .leading,
-                max(activeDrawerWidth + 32, 20)
-            )
-            .padding(.top, 20)
-            Spacer()
-        }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
         .animation(.spring(response: 0.35, dampingFraction: 0.85), value: showControls)
         .onAppear { viewModel.bindLocationService(locationService) }


### PR DESCRIPTION
## Summary
- anchor the map controls drawer to the bottom-left of the map with bottom padding to match the target position
- align the locate button overlay with the same anchor and offset it slightly below the controls

## Testing
- Not run (not available in containerized environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc711701fc832d8f2b3ad249629f0b