### PR TITLE
Fix continuation resume return value in fiber asset sync service

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/FiberAssetSyncService.swift
+++ b/Job Tracker/Features/Shared/Mapping/FiberAssetSyncService.swift
@@ -42,12 +42,12 @@ final class FirestoreFiberAssetSyncService: FiberAssetSyncService {
 
     func save(snapshot: FiberMapSnapshot) async throws {
         let data = snapshot.firestoreData()
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             document.setData(data, merge: true) { error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
-                    continuation.resume()
+                    continuation.resume(returning: ())
                 }
             }
         }


### PR DESCRIPTION
## Summary
- specify the checked throwing continuation as returning Void in the fiber asset sync service
- resume the continuation with an explicit Void value after a successful Firestore write

## Testing
- Tests not run (command unavailable: xcodebuild)


------
https://chatgpt.com/codex/tasks/task_e_68de5a996e8c832d8fcaf1f762117428