### PR TITLE
Add CAN-specific formatting for individual job sharing

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardShareSheets.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardShareSheets.swift
@@ -31,11 +31,11 @@ struct DashboardDailyShareSheet: View {
 }
 
 struct DashboardJobShareSheet: View {
-    let url: URL
+    let items: [Any]
     let subject: String
 
     var body: some View {
-        ActivityView(activityItems: [url], subject: subject)
+        ActivityView(activityItems: items, subject: subject)
     }
 }
 
@@ -57,5 +57,5 @@ private struct DashboardDatePickerSheetPreviewContainer: View {
 }
 
 #Preview("Job Share Sheet") {
-    DashboardJobShareSheet(url: URL(string: "https://example.com/job")!, subject: "Job link for May 1, 2025")
+    DashboardJobShareSheet(items: [URL(string: "https://example.com/job")!], subject: "Job link for May 1, 2025")
 }

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DashboardView: View {
     @EnvironmentObject var jobsViewModel: JobsViewModel
     @EnvironmentObject var locationService: LocationService
+    @EnvironmentObject var authViewModel: AuthViewModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.shellChromeHeight) private var shellChromeHeight
 
@@ -105,7 +106,7 @@ struct DashboardView: View {
                         },
                         onDelete: { job in jobsViewModel.deleteJob(documentID: job.id) },
                         onShare: { job in
-                            Task { await viewModel.share(job: job) }
+                            Task { await viewModel.share(job: job, userRole: authViewModel.currentUser?.normalizedPosition) }
                         }
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -172,8 +173,8 @@ struct DashboardView: View {
                 }
             }
             .sheet(isPresented: showSystemShareBinding) {
-                if let url = viewModel.jobShareURL {
-                    DashboardJobShareSheet(url: url, subject: viewModel.shareSubject)
+                if !viewModel.jobShareItems.isEmpty {
+                    DashboardJobShareSheet(items: viewModel.jobShareItems, subject: viewModel.shareSubject)
                 }
             }
             .onAppear {

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -41,7 +41,7 @@ final class DashboardViewModel: ObservableObject {
     @Published var shareItems: [Any] = []
     @Published var isPreparingDailyShare = false
     @Published var isGeneratingShareLink = false
-    @Published var jobShareURL: URL?
+    @Published var jobShareItems: [Any] = []
     @Published var showSystemShareForJob = false
     @Published var showImportToast = false
     @Published var importToastMessage = ""
@@ -226,14 +226,26 @@ final class DashboardViewModel: ObservableObject {
         presentDailyShareSheet()
     }
 
-    func share(job: Job) async {
+    func share(job: Job, userRole: String?) async {
         guard !isGeneratingShareLink else { return }
+        let normalizedRole = userRole?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalizedRole == "can" {
+            let canShareText = canRoleShareText(for: job)
+            guard !canShareText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                presentShareError(message: "Couldn't create share text for this job.")
+                return
+            }
+            jobShareItems = [canShareText]
+            showSystemShareForJob = true
+            return
+        }
+
         isGeneratingShareLink = true
         defer { isGeneratingShareLink = false }
 
         do {
             let url = try await SharedJobService.shared.publishShareLink(job: job)
-            jobShareURL = url
+            jobShareItems = [url]
             showSystemShareForJob = true
         } catch {
             presentShareError(message: "Couldn't create link: \(error.localizedDescription)")
@@ -341,6 +353,7 @@ final class DashboardViewModel: ObservableObject {
     func dismissSheets() {
         activeSheet = nil
         showSystemShareForJob = false
+        jobShareItems = []
     }
 
     // MARK: - Toasts & Sync
@@ -465,6 +478,28 @@ final class DashboardViewModel: ObservableObject {
             if suffixes.contains(cleaned) { break }
         }
         return tokens.joined(separator: " ")
+    }
+
+    private func canRoleShareText(for job: Job) -> String {
+        let line1 = houseNumberAndStreet(from: job.address).trimmingCharacters(in: .whitespacesAndNewlines)
+        let line2 = (job.assignments ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let line3 = "Can-\((job.canFootage ?? "").trimmingCharacters(in: .whitespacesAndNewlines))’F"
+        let line4 = "Nid-\((job.nidFootage ?? "").trimmingCharacters(in: .whitespacesAndNewlines))’"
+        let line5 = fiberType(from: job.materialsUsed)
+        return [line1, line2, line3, line4, line5].joined(separator: "\n")
+    }
+
+    private func fiberType(from materials: String?) -> String {
+        let trimmed = (materials ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        if let range = trimmed.range(of: "fiber:", options: [.caseInsensitive]) {
+            let fiberValue = trimmed[range.upperBound...]
+                .split(separator: ",")
+                .first
+                .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
+            if !fiberValue.isEmpty { return fiberValue }
+        }
+        return trimmed
     }
 
     func openJobInMaps(_ job: Job, suggestionProviderRaw: String) {

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -13,7 +13,7 @@ struct JobSearchDetailView: View {
     @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
 
     @State private var isGeneratingShareLink = false
-    @State private var shareURL: URL? = nil
+    @State private var shareItems: [Any] = []
     @State private var showShareSheet = false
     @State private var isAdding = false
     @State private var errorMessage: String? = nil
@@ -131,10 +131,12 @@ struct JobSearchDetailView: View {
             .padding(.bottom, JTSpacing.lg)
             .background(.ultraThinMaterial)
         }
-        .sheet(isPresented: $showShareSheet, onDismiss: { shareURL = nil }) {
-            if let url = shareURL {
+        .sheet(isPresented: $showShareSheet, onDismiss: {
+            shareItems = []
+        }) {
+            if !shareItems.isEmpty {
                 let subject = metadata.address.primary
-                ActivityView(activityItems: [url], subject: "Job link for \(subject)")
+                ActivityView(activityItems: shareItems, subject: "Job link for \(subject)")
             }
         }
         .alert(item: $alertState) { state in
@@ -246,14 +248,31 @@ struct JobSearchDetailView: View {
     private func share(job: Job) {
         guard !isGeneratingShareLink else { return }
         alertState = nil
-        shareURL = nil
+        shareItems = []
+
+        let normalizedRole = authViewModel.currentUser?.normalizedPosition
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if normalizedRole == "can" {
+            let shareText = canRoleShareText(for: job)
+            let trimmedText = shareText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedText.isEmpty else {
+                let message = "We couldn’t create the CAN share format for this job."
+                alertState = AlertState(kind: .share, message: message)
+                return
+            }
+            shareItems = [trimmedText]
+            showShareSheet = true
+            return
+        }
+
         isGeneratingShareLink = true
 
         Task {
             do {
                 let url = try await SharedJobService.shared.publishShareLink(job: job)
                 await MainActor.run {
-                    shareURL = url
+                    shareItems = [url]
                     isGeneratingShareLink = false
                     showShareSheet = true
                 }
@@ -266,6 +285,46 @@ struct JobSearchDetailView: View {
                 }
             }
         }
+    }
+
+    private func canRoleShareText(for job: Job) -> String {
+        let line1 = houseNumberAndStreet(from: job.address).trimmingCharacters(in: .whitespacesAndNewlines)
+        let line2 = displayValue(job.assignments) ?? ""
+        let line3 = "Can-\(displayValue(job.canFootage) ?? "")’F"
+        let line4 = "Nid-\(displayValue(job.nidFootage) ?? "")’"
+        let line5 = fiberType(from: job.materialsUsed)
+        return [line1, line2, line3, line4, line5].joined(separator: "\n")
+    }
+
+    private func houseNumberAndStreet(from full: String) -> String {
+        if let comma = full.firstIndex(of: ",") {
+            return String(full[..<comma]).trimmingCharacters(in: .whitespaces)
+        }
+
+        let suffixes: Set<String> = [
+            "st", "street", "rd", "road", "ave", "avenue", "blvd", "circle", "cir", "ln", "lane",
+            "dr", "drive", "ct", "court", "pkwy", "pl", "place", "ter", "terrace"
+        ]
+        var tokens: [Substring] = []
+        for token in full.split(separator: " ") {
+            tokens.append(token)
+            let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: ",.")).lowercased()
+            if suffixes.contains(cleaned) { break }
+        }
+        return tokens.joined(separator: " ")
+    }
+
+    private func fiberType(from materials: String?) -> String {
+        let trimmed = displayValue(materials) ?? ""
+        guard !trimmed.isEmpty else { return "" }
+        if let range = trimmed.range(of: "fiber:", options: [.caseInsensitive]) {
+            let value = trimmed[range.upperBound...]
+                .split(separator: ",")
+                .first
+                .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
+            if !value.isEmpty { return value }
+        }
+        return trimmed
     }
 
     private func addToDashboard() {


### PR DESCRIPTION
### Motivation
- Implement role-aware sharing so users with the `can` role get a precise, multi-line plain-text job format when sharing an individual job from the Dashboard card or Job Details view. 
- Preserve the existing deep-link share flow for all non-`can` roles so other crews continue to receive the standard shared URL.

### Description
- Pass the current user role into the dashboard share action and update `share(job:)` to `share(job:userRole:)` so the ViewModel can branch on role before generating the share payload. 
- Add a CAN-specific formatter `canRoleShareText(for:)` that builds the required five-line output and helper logic to extract the street-only address (`houseNumberAndStreet`) and fiber type parsing (`fiberType`). 
- Switch job share payloads from a single `URL` to generic `jobShareItems: [Any]` and update `DashboardJobShareSheet` to accept `items: [Any]` so the Activity sheet can present either text (CAN) or URL (other roles). 
- Apply the same CAN branching and formatted-text share behavior to the Job Details / search detail share flow in `JobSearchDetailView`, keeping the previous `SharedJobService` link publishing for non-CAN users.

### Testing
- Ran `git diff --check` which passed with no whitespace errors. 
- Attempted to run `xcodebuild` for a local build check, but `xcodebuild` is not available in this environment so an on-device or CI build should be run to fully verify compilation and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67fb50df0832d8fddcd81d8f5ba9c)