### PR TITLE
CI: Build unsigned iOS app using `xcodebuild build` and DerivedData

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    env:
+      PROJECT_PATH: Job Tracker.xcodeproj
+      TARGET_NAME: Job Tracker
+      DERIVED_DATA_PATH: ${{ runner.temp }}/DerivedData
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,13 +22,14 @@ jobs:
         with:
           xcode-version: 'latest-stable'
 
-      - name: Build Archive (Unsigned)
+      - name: Build App (Unsigned)
         run: |
-          xcodebuild archive \
-            -project "Job Tracker.xcodeproj" \
-            -scheme "Job Tracker" \
-            -archivePath $RUNNER_TEMP/JobTracker.xcarchive \
+          xcodebuild build \
+            -project "$PROJECT_PATH" \
+            -target "$TARGET_NAME" \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
             -sdk iphoneos \
+            -destination "generic/platform=iOS" \
             -configuration Release \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
@@ -34,7 +39,7 @@ jobs:
       - name: Create Payload Folder
         run: |
           mkdir -p Payload
-          cp -r $RUNNER_TEMP/JobTracker.xcarchive/Products/Applications/*.app Payload/
+          cp -r "$DERIVED_DATA_PATH/Build/Products/Release-iphoneos/"*.app Payload/
           zip -r JobTracker_Unsigned.ipa Payload
 
       - name: Upload Artifact


### PR DESCRIPTION
### Motivation
- Replace the archive-based build with a `xcodebuild build` that writes to `DerivedData` so an unsigned `.app` can be packaged reliably from CI.

### Description
- Added `PROJECT_PATH`, `TARGET_NAME`, and `DERIVED_DATA_PATH` env vars, renamed the step to `Build App (Unsigned)`, switched from `xcodebuild archive` to `xcodebuild build` with `-derivedDataPath` and `-destination "generic/platform=iOS"`, and updated the copy path to `"$DERIVED_DATA_PATH/Build/Products/Release-iphoneos/"*.app` used to create the unsigned IPA.

### Testing
- No automated CI runs were available for this change during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68b155664832d8183132766851973)