### PR TITLE
Fix unsigned IPA GitHub Actions build: add shared scheme and harden workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,42 +13,47 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Force Disable Code Signing
-        # This manually strips signing requirements from the project file itself before building
-        run: |
-          sed -i '' 's/CODE_SIGNING_ALLOWED = YES/CODE_SIGNING_ALLOWED = NO/g' "Job Tracker.xcodeproj/project.pbxproj"
-          sed -i '' 's/CODE_SIGNING_REQUIRED = YES/CODE_SIGNING_REQUIRED = NO/g' "Job Tracker.xcodeproj/project.pbxproj"
+      - name: Select Xcode Version
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Show Shared Schemes
+        run: xcodebuild -list -project "Job Tracker.xcodeproj"
 
       - name: Resolve Swift Packages
         run: xcodebuild -resolvePackageDependencies -project "Job Tracker.xcodeproj" -scheme "Job Tracker"
 
-      - name: Build for Testing (Unsigned)
+      - name: Build iOS App (Unsigned)
         run: |
+          set -eo pipefail
           xcodebuild build \
             -project "Job Tracker.xcodeproj" \
             -scheme "Job Tracker" \
             -configuration Release \
+            -sdk iphoneos \
             -destination 'generic/platform=iOS' \
             -derivedDataPath ./build \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
             PROVISIONING_PROFILE_SPECIFIER="" \
-            AD_HOC_CODE_SIGNING_ALLOWED=YES \
-            COMPILER_INDEX_STORE_ENABLE=NO | xcpretty || true
-          # We use "|| true" because xcodebuild might return 65 even if the .app was created
+            DEVELOPMENT_TEAM="" \
+            COMPILER_INDEX_STORE_ENABLE=NO
 
       - name: Package IPA
         run: |
-          mkdir -p Payload
-          # Search specifically for the .app file in the build folder
-          APP_PATH=$(find ./build -name "*.app" -type d | head -n 1)
-          if [ -z "$APP_PATH" ]; then
-            echo "Error: No .app bundle found. The build likely failed."
+          set -eo pipefail
+          APP_PATH="./build/Build/Products/Release-iphoneos/Job Tracker.app"
+
+          if [ ! -d "$APP_PATH" ]; then
+            echo "Expected app bundle not found at: $APP_PATH"
+            echo "Available app bundles:"
+            find ./build -name "*.app" -type d || true
             exit 1
           fi
-          cp -r "$APP_PATH" Payload/
-          zip -r JobTracker_Unsigned.ipa Payload
+
+          mkdir -p Payload
+          cp -R "$APP_PATH" Payload/
+          ditto -c -k --sequesterRsrc --keepParent Payload JobTracker_Unsigned.ipa
 
       - name: Upload IPA
         uses: actions/upload-artifact@v4

--- a/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
+++ b/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDDA111C2D579EC0007BADFF"
+               BuildableName = "Job Tracker.app"
+               BlueprintName = "Job Tracker"
+               ReferencedContainer = "container:Job Tracker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDDA111C2D579EC0007BADFF"
+            BuildableName = "Job Tracker.app"
+            BlueprintName = "Job Tracker"
+            ReferencedContainer = "container:Job Tracker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDDA111C2D579EC0007BADFF"
+            BuildableName = "Job Tracker.app"
+            BlueprintName = "Job Tracker"
+            ReferencedContainer = "container:Job Tracker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Motivation
- Ensure the CI runner can resolve and build the `Job Tracker` scheme by committing a shared Xcode scheme into the repository.
- Remove brittle in-CI edits to `project.pbxproj` that were used to disable signing and instead keep signing disabled via `xcodebuild` flags.
- Make build failures visible instead of being masked and prevent packaging the wrong `.app` when multiple targets exist (watchOS / iMessage). 

### Description
- Added a committed shared scheme at `Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme` for the `Job Tracker` app target so `xcodebuild -scheme "Job Tracker"` works on CI. 
- Rewrote `.github/workflows/main.yml` to select Xcode (`sudo xcode-select`), list schemes (`xcodebuild -list`), resolve Swift packages, and build with explicit unsigned overrides (`CODE_SIGNING_ALLOWED=NO`, etc.) targeting `-sdk iphoneos`. 
- Removed the previous `sed` mutations against `project.pbxproj` and removed the `|| true` masking so `xcodebuild` failures surface immediately. 
- Made IPA packaging deterministic by using the Release iphoneos output path `./build/Build/Products/Release-iphoneos/Job Tracker.app` and packaging with `ditto`, and added diagnostics when the expected app bundle is missing. 

### Testing
- Parsed the new shared scheme XML successfully using `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme')
print('xcscheme xml ok')
PY` which succeeded. 
- Parsed the updated workflow YAML successfully using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main.yml")'` which succeeded. 
- Full `xcodebuild` compile and IPA production were not executed in this environment and must be validated on a macOS runner (e.g., GitHub Actions `macos-latest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ba8f21c0832d8a7479e659deb938)