### PR TITLE
Add standalone Job Tracker website prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Job Tracker778
 ├── imessage cs/                # iMessage extension for sharing job summaries
 ├── Job TrackerTests/           # XCTest coverage for services and view models
 ├── Documentation/              # Markdown feature guides and process docs
+├── website/                    # Standalone browser prototype for Job Tracker workflows
 └── Job Tracker.xcodeproj       # Xcode project workspace
 ```
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,26 @@
+# Job Tracker Website
+
+This folder contains a standalone browser version of the Job Tracker workspace. It is intentionally dependency-free so the website can be opened directly from `index.html`, served by any static host, or used as a prototype before wiring it to the same Firebase services as the iOS app.
+
+## Files
+
+- `index.html` – semantic page structure for the responsive dashboard, job board, team coordination, compliance checklist, and splice assist prototype.
+- `styles.css` – dark glassmorphism design system inspired by the native app's field-operations interface.
+- `script.js` – localStorage-backed interactivity for demo job creation, deletion, daily progress metrics, and splice troubleshooting checklist generation.
+
+## Run locally
+
+From the repository root:
+
+```sh
+python3 -m http.server 8000 --directory website
+```
+
+Then open <http://localhost:8000> in a browser.
+
+## Next integration steps
+
+1. Replace the demo `localStorage` job data in `script.js` with Firestore reads and writes that mirror `FirebaseService` in the iOS target.
+2. Add authentication so technicians, supervisors, and admins see role-appropriate sections.
+3. Connect document exports to the existing timesheet and yellow sheet PDF generation workflows.
+4. Route the splice assist form to the same AI-backed troubleshooting service used by the native app.

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A responsive web dashboard for Job Tracker technicians and supervisors."
+    />
+    <title>Job Tracker Web</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar" aria-label="Primary">
+        <a class="brand" href="#top" aria-label="Job Tracker home">
+          <span class="brand-mark">JT</span>
+          <span>
+            <strong>Job Tracker</strong>
+            <small>Web workspace</small>
+          </span>
+        </a>
+
+        <nav class="nav-links" aria-label="Workspace sections">
+          <a href="#dashboard">Dashboard</a>
+          <a href="#jobs">Jobs</a>
+          <a href="#team">Team</a>
+          <a href="#documents">Docs</a>
+          <a href="#assist">Assist</a>
+        </nav>
+
+        <div class="sidebar-card">
+          <small>Today</small>
+          <strong id="sidebarDate">Loading...</strong>
+          <span id="sidebarSummary">0 jobs scheduled</span>
+        </div>
+      </aside>
+
+      <main id="top" class="content">
+        <header class="hero" id="dashboard">
+          <div class="hero-copy">
+            <p class="eyebrow">Fiber field operations</p>
+            <h1>Plan routes, track job status, and finish paperwork from any browser.</h1>
+            <p>
+              This web version brings the core Job Tracker workflow to desktop and tablet teams:
+              daily dashboards, job creation, crew collaboration, document checklists, and splice support.
+            </p>
+            <div class="hero-actions">
+              <a class="button primary" href="#jobs">Add a job</a>
+              <a class="button secondary" href="#documents">Review paperwork</a>
+            </div>
+          </div>
+
+          <section class="hero-panel" aria-label="Daily progress summary">
+            <div>
+              <span class="metric-label">Completion</span>
+              <strong id="completionRate">0%</strong>
+            </div>
+            <div class="progress-track" aria-hidden="true">
+              <span id="completionBar"></span>
+            </div>
+            <dl class="metric-grid">
+              <div>
+                <dt>Pending</dt>
+                <dd id="pendingCount">0</dd>
+              </div>
+              <div>
+                <dt>In progress</dt>
+                <dd id="activeCount">0</dd>
+              </div>
+              <div>
+                <dt>Done</dt>
+                <dd id="doneCount">0</dd>
+              </div>
+            </dl>
+          </section>
+        </header>
+
+        <section class="section-grid" aria-label="Workspace overview">
+          <article class="feature-card">
+            <span class="icon">📍</span>
+            <h2>Smart routing</h2>
+            <p>Keep addresses, arrival windows, and status notes visible before the next dispatch.</p>
+          </article>
+          <article class="feature-card">
+            <span class="icon">🧾</span>
+            <h2>Paperwork hub</h2>
+            <p>Track weekly timesheets and yellow sheet readiness without leaving the dashboard.</p>
+          </article>
+          <article class="feature-card">
+            <span class="icon">💬</span>
+            <h2>Crew updates</h2>
+            <p>Coordinate partner requests, quick notes, and supervisor escalations in one place.</p>
+          </article>
+        </section>
+
+        <section class="workspace-card" id="jobs">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Daily job board</p>
+              <h2>Create and update jobs</h2>
+            </div>
+            <button class="button secondary" id="resetJobsButton" type="button">Reset demo data</button>
+          </div>
+
+          <form class="job-form" id="jobForm">
+            <label>
+              Job address
+              <input id="addressInput" name="address" placeholder="123 Fiber Rd" required />
+            </label>
+            <label>
+              Job type
+              <select id="typeInput" name="type">
+                <option>Install</option>
+                <option>Repair</option>
+                <option>Survey</option>
+                <option>Maintenance</option>
+              </select>
+            </label>
+            <label>
+              Status
+              <select id="statusInput" name="status">
+                <option>Pending</option>
+                <option>In Progress</option>
+                <option>Needs Ariel</option>
+                <option>Needs Underground</option>
+                <option>Done</option>
+              </select>
+            </label>
+            <label>
+              Crew note
+              <input id="noteInput" name="note" placeholder="Gate code, splice count, material needs" />
+            </label>
+            <button class="button primary" type="submit">Save job</button>
+          </form>
+
+          <div class="job-list" id="jobList" aria-live="polite"></div>
+        </section>
+
+        <section class="two-column">
+          <article class="workspace-card" id="team">
+            <p class="eyebrow">Crew room</p>
+            <h2>Team coordination</h2>
+            <ul class="timeline">
+              <li>
+                <strong>Partner finder</strong>
+                <span>Post help requests for long pulls, aerial work, and late-day callbacks.</span>
+              </li>
+              <li>
+                <strong>Supervisor view</strong>
+                <span>Review stuck jobs, imports, and status exceptions from the same web surface.</span>
+              </li>
+              <li>
+                <strong>Recent crew jobs</strong>
+                <span>Reuse notes from recent nearby jobs to speed up troubleshooting.</span>
+              </li>
+            </ul>
+          </article>
+
+          <article class="workspace-card" id="documents">
+            <p class="eyebrow">Compliance</p>
+            <h2>Paperwork checklist</h2>
+            <div class="checklist">
+              <label><input type="checkbox" /> Weekly timesheet reviewed</label>
+              <label><input type="checkbox" /> Yellow sheet photos attached</label>
+              <label><input type="checkbox" /> Extra work notes submitted</label>
+              <label><input type="checkbox" /> PDF export ready for supervisor</label>
+            </div>
+          </article>
+        </section>
+
+        <section class="workspace-card assist-card" id="assist">
+          <div>
+            <p class="eyebrow">Splice assist</p>
+            <h2>Bring troubleshooting prompts to the web.</h2>
+            <p>
+              The website shell leaves room for the same AI-assisted splice workflow as the iOS app:
+              upload a splice map, summarize CAN issues, and capture recommended next steps.
+            </p>
+          </div>
+          <form class="assist-form" id="assistForm">
+            <label>
+              Describe the issue
+              <textarea id="assistInput" rows="4" placeholder="Example: customer light is low after 288-count enclosure swap"></textarea>
+            </label>
+            <button class="button secondary" type="submit">Generate checklist</button>
+            <output id="assistOutput" aria-live="polite"></output>
+          </form>
+        </section>
+      </main>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,185 @@
+function createId() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+const defaultJobs = [
+  {
+    id: createId(),
+    address: "1410 Maple Fiber Ln",
+    type: "Install",
+    status: "Pending",
+    note: "Call customer 30 minutes before arrival.",
+  },
+  {
+    id: createId(),
+    address: "88 Ridge Cabinet Rd",
+    type: "Repair",
+    status: "In Progress",
+    note: "Low light after drop replacement.",
+  },
+  {
+    id: createId(),
+    address: "702 Splice Loop",
+    type: "Maintenance",
+    status: "Done",
+    note: "Yellow sheet photos attached.",
+  },
+];
+
+const storageKey = "job-tracker-web-jobs";
+const jobForm = document.querySelector("#jobForm");
+const resetJobsButton = document.querySelector("#resetJobsButton");
+const jobList = document.querySelector("#jobList");
+const assistForm = document.querySelector("#assistForm");
+const assistInput = document.querySelector("#assistInput");
+const assistOutput = document.querySelector("#assistOutput");
+
+let jobs = loadJobs();
+
+function loadJobs() {
+  const savedJobs = localStorage.getItem(storageKey);
+
+  if (!savedJobs) {
+    return defaultJobs;
+  }
+
+  try {
+    const parsedJobs = JSON.parse(savedJobs);
+    return Array.isArray(parsedJobs) ? parsedJobs : defaultJobs;
+  } catch {
+    return defaultJobs;
+  }
+}
+
+function saveJobs() {
+  localStorage.setItem(storageKey, JSON.stringify(jobs));
+}
+
+function renderDate() {
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  });
+
+  document.querySelector("#sidebarDate").textContent = formatter.format(new Date());
+}
+
+function renderSummary() {
+  const pending = jobs.filter((job) => job.status === "Pending").length;
+  const active = jobs.filter((job) => job.status === "In Progress").length;
+  const done = jobs.filter((job) => job.status === "Done").length;
+  const completion = jobs.length === 0 ? 0 : Math.round((done / jobs.length) * 100);
+
+  document.querySelector("#pendingCount").textContent = pending;
+  document.querySelector("#activeCount").textContent = active;
+  document.querySelector("#doneCount").textContent = done;
+  document.querySelector("#completionRate").textContent = `${completion}%`;
+  document.querySelector("#completionBar").style.width = `${completion}%`;
+  document.querySelector("#sidebarSummary").textContent = `${jobs.length} jobs scheduled`;
+}
+
+function statusClass(status) {
+  if (status === "Done") {
+    return "done";
+  }
+
+  if (status.startsWith("Needs")) {
+    return "warning";
+  }
+
+  return "";
+}
+
+function renderJobs() {
+  jobList.innerHTML = "";
+
+  if (jobs.length === 0) {
+    jobList.innerHTML = `<p class="empty-state">No jobs yet. Add the first address above.</p>`;
+    return;
+  }
+
+  for (const job of jobs) {
+    const item = document.createElement("article");
+    const details = document.createElement("div");
+    const address = document.createElement("h3");
+    const meta = document.createElement("div");
+    const typeBadge = document.createElement("span");
+    const statusBadge = document.createElement("span");
+    const note = document.createElement("span");
+    const removeButton = document.createElement("button");
+
+    item.className = "job-item";
+    meta.className = "job-meta";
+    typeBadge.className = "badge";
+    statusBadge.className = `badge ${statusClass(job.status)}`.trim();
+    removeButton.className = "button secondary";
+    removeButton.type = "button";
+    removeButton.dataset.deleteJob = job.id;
+
+    address.textContent = job.address;
+    typeBadge.textContent = job.type;
+    statusBadge.textContent = job.status;
+    note.textContent = job.note || "No note added";
+    removeButton.textContent = "Remove";
+
+    meta.append(typeBadge, statusBadge, note);
+    details.append(address, meta);
+    item.append(details, removeButton);
+    jobList.append(item);
+  }
+}
+
+function render() {
+  renderSummary();
+  renderJobs();
+}
+
+jobForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  const formData = new FormData(jobForm);
+  jobs = [
+    {
+      id: createId(),
+      address: formData.get("address").trim(),
+      type: formData.get("type"),
+      status: formData.get("status"),
+      note: formData.get("note").trim(),
+    },
+    ...jobs,
+  ];
+
+  saveJobs();
+  render();
+  jobForm.reset();
+});
+
+jobList.addEventListener("click", (event) => {
+  const deleteButton = event.target.closest("[data-delete-job]");
+
+  if (!deleteButton) {
+    return;
+  }
+
+  jobs = jobs.filter((job) => job.id !== deleteButton.dataset.deleteJob);
+  saveJobs();
+  render();
+});
+
+resetJobsButton.addEventListener("click", () => {
+  jobs = defaultJobs.map((job) => ({ ...job, id: createId() }));
+  saveJobs();
+  render();
+});
+
+assistForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  const issue = assistInput.value.trim();
+  const prefix = issue ? `For “${issue}”: ` : "";
+  assistOutput.value = `${prefix}verify light levels, inspect connectors, compare splice records, capture photos, and escalate with cabinet or CAN details.`;
+});
+
+renderDate();
+render();

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,480 @@
+:root {
+  color-scheme: dark;
+  --bg: #08111f;
+  --bg-soft: #101b2d;
+  --card: rgba(18, 31, 52, 0.82);
+  --card-strong: rgba(20, 40, 70, 0.96);
+  --line: rgba(154, 179, 219, 0.22);
+  --text: #eef5ff;
+  --muted: #aebbd0;
+  --accent: #62d5ff;
+  --accent-strong: #2f8cff;
+  --success: #63e6a9;
+  --warning: #ffd166;
+  --danger: #ff7a90;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(47, 140, 255, 0.28), transparent 34rem),
+    radial-gradient(circle at 80% 15%, rgba(98, 213, 255, 0.18), transparent 28rem),
+    var(--bg);
+  color: var(--text);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 18rem minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 2rem;
+  border-right: 1px solid var(--line);
+  background: rgba(8, 17, 31, 0.78);
+  backdrop-filter: blur(20px);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 14px 30px rgba(47, 140, 255, 0.28);
+  color: #04111f;
+  font-weight: 900;
+}
+
+.brand small,
+.sidebar-card small,
+.metric-label,
+.eyebrow {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: grid;
+  gap: 0.6rem;
+  margin: 3rem 0;
+}
+
+.nav-links a {
+  padding: 0.85rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 1rem;
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+
+.sidebar-card,
+.workspace-card,
+.feature-card,
+.hero-panel {
+  border: 1px solid var(--line);
+  border-radius: 1.5rem;
+  background: var(--card);
+  box-shadow: var(--shadow);
+}
+
+.sidebar-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+}
+
+.content {
+  display: grid;
+  gap: 1.5rem;
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(20rem, 0.65fr);
+  gap: 1.5rem;
+  align-items: stretch;
+  min-height: 33rem;
+  padding: clamp(2rem, 5vw, 4rem);
+  border: 1px solid var(--line);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(18, 31, 52, 0.92), rgba(12, 21, 37, 0.72)),
+    linear-gradient(135deg, rgba(98, 213, 255, 0.2), rgba(47, 140, 255, 0.1));
+  box-shadow: var(--shadow);
+}
+
+.hero-copy {
+  align-self: center;
+}
+
+.hero h1 {
+  max-width: 12ch;
+  margin: 0.5rem 0 1rem;
+  font-size: clamp(2.8rem, 8vw, 5.8rem);
+  line-height: 0.9;
+  letter-spacing: -0.08em;
+}
+
+.hero p {
+  max-width: 45rem;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.hero-actions,
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.9rem;
+  padding: 0 1.05rem;
+  border: 0;
+  border-radius: 999px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #04111f;
+}
+
+.button.secondary {
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.hero-panel {
+  display: grid;
+  align-content: center;
+  gap: 1.2rem;
+  padding: 1.5rem;
+  background: var(--card-strong);
+}
+
+.hero-panel strong {
+  font-size: 4rem;
+  letter-spacing: -0.07em;
+}
+
+.progress-track {
+  height: 0.8rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.progress-track span {
+  display: block;
+  width: 0%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--success), var(--accent));
+  transition: width 240ms ease;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.8rem;
+  margin: 0;
+}
+
+.metric-grid div {
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.metric-grid dt {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.metric-grid dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.8rem;
+  font-weight: 900;
+}
+
+.section-grid,
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.two-column {
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+}
+
+.feature-card,
+.workspace-card {
+  padding: 1.3rem;
+}
+
+.feature-card .icon {
+  font-size: 2rem;
+}
+
+.feature-card h2,
+.workspace-card h2 {
+  margin: 0.4rem 0;
+}
+
+.feature-card p,
+.workspace-card p,
+.timeline span {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.section-heading {
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.job-form {
+  display: grid;
+  grid-template-columns: 1.4fr 0.8fr 0.9fr 1.3fr auto;
+  gap: 0.8rem;
+  align-items: end;
+}
+
+label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  outline: none;
+  padding: 0.82rem 0.9rem;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(98, 213, 255, 0.12);
+}
+
+.job-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.job-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.job-item h3 {
+  margin: 0;
+}
+
+.job-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.55rem;
+  color: var(--muted);
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.badge.done {
+  background: rgba(99, 230, 169, 0.17);
+  color: var(--success);
+}
+
+.badge.warning {
+  background: rgba(255, 209, 102, 0.17);
+  color: var(--warning);
+}
+
+.timeline,
+.checklist {
+  display: grid;
+  gap: 1rem;
+  padding: 0;
+}
+
+.timeline li {
+  display: grid;
+  gap: 0.25rem;
+  padding-left: 1rem;
+  border-left: 3px solid var(--accent);
+}
+
+.checklist label {
+  display: flex;
+  align-items: center;
+  padding: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+
+.checklist input {
+  width: auto;
+  accent-color: var(--accent);
+}
+
+.assist-card {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.assist-form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+output {
+  min-height: 2rem;
+  color: var(--success);
+  line-height: 1.5;
+}
+
+@media (max-width: 1020px) {
+  .app-shell,
+  .hero,
+  .section-grid,
+  .two-column,
+  .assist-card,
+  .job-form {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .nav-links {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    margin: 1.5rem 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .content,
+  .sidebar {
+    padding: 1rem;
+  }
+
+  .hero {
+    min-height: auto;
+    padding: 1.3rem;
+  }
+
+  .hero h1 {
+    font-size: 3rem;
+  }
+
+  .nav-links,
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .job-item {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a dependency-free, browser-accessible prototype of the Job Tracker workflows so teams can preview dashboards, job entry, crew coordination, and splice assist without opening Xcode or wiring Firebase.
- Create a lightweight starting point that can be incrementally integrated with the app's `FirebaseService`, authentication, PDF exports, and AI splice-assist backend.

### Description
- Add a new `website/` section containing `index.html` (responsive dashboard, job board, team/docs, and splice assist UI) and `website/README.md` with local serving and next-integration steps.
- Add `website/styles.css` implementing a dark glassmorphism design system and responsive layouts for desktop/tablet/mobile.
- Add `website/script.js` which provides demo data, `localStorage`-backed job create/delete/reset flows, progress metrics, safe DOM rendering for job rows, and a splice-assist checklist prototype.
- Update the root `README.md` to list the new `website/` folder in the project structure.

### Testing
- Ran `node --check website/script.js` to validate the JavaScript syntax, which succeeded.
- Performed a basic HTML parse/smoke check using a small Python `HTMLParser` script against `website/index.html` and verified non-empty `website/styles.css`, `website/script.js`, and `website/README.md`, which succeeded.
- Served the site with `python3 -m http.server 8000 --directory website` and fetched the page with `curl -fsS http://127.0.0.1:8000`, which returned HTTP 200 and saved the index content successfully.
- Attempted a headless screenshot with `npx --yes playwright@1.53.0 screenshot --browser chromium http://127.0.0.1:8000 website/screenshot.png`, but the npm registry returned HTTP 403 for Playwright so the screenshot step was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc3f40a98832db99ca3f34e7e1044)