### PR TITLE
Add Firebase-backed Job Tracker web app under website/app

### DIFF
--- a/website/app/README.md
+++ b/website/app/README.md
@@ -1,0 +1,39 @@
+# Job Tracker Firebase Web App
+
+This folder contains the Firebase-backed browser version of Job Tracker. It is intentionally nested under `website/app/` so it can be merged alongside the already-existing static website prototype without conflicting with `website/index.html`, `website/script.js`, `website/styles.css`, or `website/README.md` on `main`.
+
+## Implemented app areas
+
+- **Authentication** – Firebase email/password login, signup, password reset email, persisted session refresh, and sign-out.
+- **Dashboard** – Monday-Friday selector, daily job rollups, completion progress, Firebase sync status, next-job hint, daily summary copy/download, quick job creation, status updates, and job removal.
+- **Timesheets** – weekly timesheet editor with supervisor/partner fields, Gibson/Cable South/Other hour totals, Firestore-backed history, and text export.
+- **Yellow Sheets** – daily compliance checklist with job reference, materials, notes, technician signature, Firestore-backed history, and text export.
+- **Job Search** – global searchable job index across job number, address, status, type/assignment, date, notes, and materials with inline status updates.
+- **More** – functional Profile, Settings, and Find a Partner sections with Firestore-backed profile/settings and native-compatible partner request records.
+
+## Run locally
+
+From the repository root:
+
+```sh
+python3 -m http.server 8000 --directory website
+```
+
+Then open <http://localhost:8000/app/> in a browser and sign in with a real Firebase user or create a new account.
+
+## Firebase data model
+
+The web app reads and writes these existing app collections:
+
+- `users/{uid}` for profile, role, and web settings.
+- `jobs/{jobId}` using the native `Job` fields, including `date`, `status`, `createdBy`, `assignedTo`, and `participants`.
+- `timesheets/{uid_weekStart}` using the native rollup fields plus web row details for editing.
+- `yellowSheets/{uid_date}` using the native weekly fields plus daily checklist details for editing.
+- `partnerRequests/{requestId}` and `partnerships/{pairId}` using native-compatible partner request fields.
+
+## Deployment notes
+
+1. Keep `config.js` aligned with the Firebase project used by the native app.
+2. Ensure Firestore rules allow authenticated users to read/write their own `users`, visible `jobs`, personal timesheets/yellow sheets, and incoming/outgoing partner requests.
+3. Replace text exports with the native PDF generation pipeline or a shared server-side PDF service if browser-generated PDFs are required.
+4. Connect routing distances and address suggestions to production map providers when web mapping is added.

--- a/website/app/config.js
+++ b/website/app/config.js
@@ -1,0 +1,5 @@
+window.JOB_TRACKER_FIREBASE_CONFIG = {
+  apiKey: "AIzaSyCWrTFZwm3MPGFGJsFkQDaVU9Nc2dPgoU0",
+  projectId: "work-app-ae617",
+  storageBucket: "work-app-ae617.appspot.com",
+};

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A browser version of Job Tracker for dashboards, jobs, timesheets, yellow sheets, search, profile, settings, and partner finding."
+    />
+    <title>Job Tracker Web</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="authScreen" class="auth-screen">
+      <section class="auth-card">
+        <div class="auth-copy">
+          <span class="brand-mark">JT</span>
+          <p class="eyebrow">Fiber field operations</p>
+          <h1>Job Tracker Web</h1>
+          <p>
+            Sign in with your Firebase-backed Job Tracker account or create a technician account
+            to manage dashboards, job search, timesheets, yellow sheets, and the More tools.
+          </p>
+        </div>
+
+        <div class="auth-panel">
+          <div class="segmented" role="tablist" aria-label="Authentication mode">
+            <button class="segment active" id="loginTab" type="button" data-auth-mode="login">Login</button>
+            <button class="segment" id="signupTab" type="button" data-auth-mode="signup">Sign up</button>
+          </div>
+
+          <form id="loginForm" class="auth-form">
+            <label>Email<input id="loginEmail" type="email" autocomplete="email" required /></label>
+            <label>Password<input id="loginPassword" type="password" autocomplete="current-password" required /></label>
+            <button class="button primary" type="submit">Login</button>
+            <button class="link-button" id="resetPasswordButton" type="button">Send password reset</button>
+          </form>
+
+          <form id="signupForm" class="auth-form hidden">
+            <div class="form-grid two">
+              <label>First name<input id="signupFirstName" autocomplete="given-name" required /></label>
+              <label>Last name<input id="signupLastName" autocomplete="family-name" required /></label>
+            </div>
+            <label>Email<input id="signupEmail" type="email" autocomplete="email" required /></label>
+            <div class="form-grid two">
+              <label>
+                Position
+                <select id="signupPosition">
+                  <option>Technician</option>
+                  <option>Supervisor</option>
+                  <option>Admin</option>
+                </select>
+              </label>
+              <label>Password<input id="signupPassword" type="password" autocomplete="new-password" minlength="6" required /></label>
+            </div>
+            <button class="button primary" type="submit">Create account</button>
+          </form>
+
+          <p id="authMessage" class="form-message" role="status" aria-live="polite"></p>
+        </div>
+      </section>
+    </div>
+
+    <div id="appShell" class="app-shell hidden">
+      <aside class="sidebar" aria-label="Primary">
+        <a class="brand" href="#dashboard" data-route="dashboard" aria-label="Job Tracker dashboard">
+          <span class="brand-mark">JT</span>
+          <span>
+            <strong>Job Tracker</strong>
+            <small id="signedInRole">Web workspace</small>
+          </span>
+        </a>
+
+        <nav class="nav-links" aria-label="Workspace sections">
+          <button class="nav-link active" type="button" data-route="dashboard">Dashboard</button>
+          <button class="nav-link" type="button" data-route="timesheets">Timesheets</button>
+          <button class="nav-link" type="button" data-route="yellowSheets">Yellow Sheets</button>
+          <button class="nav-link" type="button" data-route="search">Job Search</button>
+          <button class="nav-link" type="button" data-route="more">More</button>
+        </nav>
+
+        <div class="sidebar-card">
+          <small>Today</small>
+          <strong id="sidebarDate">Loading...</strong>
+          <span id="sidebarSummary">0 jobs scheduled</span>
+        </div>
+
+        <button class="button ghost full-width" id="signOutButton" type="button">Sign out</button>
+      </aside>
+
+      <main class="content">
+        <section class="view active" id="dashboardView" data-view="dashboard">
+          <header class="hero">
+            <div class="hero-copy">
+              <p class="eyebrow">Dashboard</p>
+              <h1>Plan the day, route the next stop, and close the paperwork loop.</h1>
+              <p id="dashboardGreeting">
+                Your web dashboard mirrors the app's daily assignment workflow with weekday filters,
+                smart routing hints, sync status, quick job actions, and shareable summaries.
+              </p>
+              <div class="hero-actions">
+                <button class="button primary" type="button" data-focus-job-form>Add job</button>
+                <button class="button secondary" id="shareDailySummaryButton" type="button">Share day summary</button>
+                <button class="button secondary" id="downloadDailySummaryButton" type="button">Download summary</button>
+              </div>
+            </div>
+            <section class="hero-panel" aria-label="Selected day summary">
+              <div>
+                <span class="metric-label">Completion</span>
+                <strong id="completionRate">0%</strong>
+              </div>
+              <div class="progress-track" aria-hidden="true"><span id="completionBar"></span></div>
+              <dl class="metric-grid">
+                <div><dt>Total</dt><dd id="totalCount">0</dd></div>
+                <div><dt>Pending</dt><dd id="pendingCount">0</dd></div>
+                <div><dt>Done</dt><dd id="doneCount">0</dd></div>
+              </dl>
+            </section>
+          </header>
+
+          <div class="weekday-picker" id="weekdayPicker" aria-label="Work week selector"></div>
+
+          <div class="sync-banner" id="syncBanner">
+            <span class="pulse"></span>
+            <span id="syncText">All local changes saved.</span>
+          </div>
+
+          <section class="section-grid four" aria-label="Dashboard rollups">
+            <article class="feature-card"><span class="icon">📍</span><h2 id="nextJobAddress">No next job</h2><p id="nextJobHint">Add jobs to get routing hints.</p></article>
+            <article class="feature-card"><span class="icon">⏱️</span><h2 id="dashboardHours">0 hrs</h2><p>Timesheet hours logged for the selected day.</p></article>
+            <article class="feature-card"><span class="icon">🟨</span><h2 id="yellowStatus">Not started</h2><p>Yellow sheet compliance status for the selected day.</p></article>
+            <article class="feature-card"><span class="icon">👥</span><h2 id="partnerStatus">No partner</h2><p>Current partner request or active crew pairing.</p></article>
+          </section>
+
+          <section class="workspace-card">
+            <div class="section-heading">
+              <div><p class="eyebrow">Create job</p><h2>Daily job entry</h2></div>
+              <button class="button secondary" id="refreshJobsButton" type="button">Refresh jobs</button>
+            </div>
+            <form class="job-form" id="jobForm">
+              <label>Job #<input id="jobNumberInput" name="jobNumber" placeholder="JT-1042" required /></label>
+              <label>Address<input id="addressInput" name="address" placeholder="123 Fiber Rd" required /></label>
+              <label>Scheduled date<input id="scheduledDateInput" name="scheduledDate" type="date" required /></label>
+              <label>
+                Type
+                <select id="typeInput" name="type"><option>Install</option><option>Repair</option><option>Survey</option><option>Maintenance</option><option>Splice</option></select>
+              </label>
+              <label>
+                Status
+                <select id="statusInput" name="status"><option>Pending</option><option>In Progress</option><option>Needs Ariel</option><option>Needs Underground</option><option>Needs Nid</option><option>Needs Can</option><option>Done</option><option>Talk to Rick</option></select>
+              </label>
+              <label>Crew note<input id="noteInput" name="note" placeholder="Gate code, splice count, material needs" /></label>
+              <button class="button primary" type="submit">Save job</button>
+            </form>
+          </section>
+
+          <section class="two-column">
+            <article class="workspace-card">
+              <div class="section-heading"><div><p class="eyebrow">Pending work</p><h2>Open jobs</h2></div></div>
+              <div class="job-list" id="pendingJobList" aria-live="polite"></div>
+            </article>
+            <article class="workspace-card">
+              <div class="section-heading"><div><p class="eyebrow">Completed</p><h2>Closed jobs</h2></div></div>
+              <div class="job-list" id="completedJobList" aria-live="polite"></div>
+            </article>
+          </section>
+        </section>
+
+        <section class="view" id="timesheetsView" data-view="timesheets">
+          <div class="page-heading"><p class="eyebrow">Timesheets</p><h1>Weekly timesheet</h1><p>Log Gibson, Cable South, and total hours by day, attach job notes, save the week, and export a supervisor-ready summary.</p></div>
+          <section class="workspace-card">
+            <div class="timesheet-toolbar">
+              <label>Week start<input id="timesheetWeekInput" type="date" /></label>
+              <label>Supervisor<input id="timesheetSupervisorInput" placeholder="Supervisor name" /></label>
+              <label>Partner<input id="timesheetPartnerInput" placeholder="Partner name" /></label>
+              <button class="button primary" id="saveTimesheetButton" type="button">Save timesheet</button>
+              <button class="button secondary" id="exportTimesheetButton" type="button">Export</button>
+            </div>
+            <div class="table-wrap">
+              <table class="data-table">
+                <thead><tr><th>Day</th><th>Job / location notes</th><th>Gibson</th><th>Cable South</th><th>Other</th><th>Total</th></tr></thead>
+                <tbody id="timesheetRows"></tbody>
+              </table>
+            </div>
+            <div class="summary-strip"><strong id="timesheetTotal">0 total hours</strong><span id="timesheetSavedState">Not saved yet</span></div>
+          </section>
+          <section class="workspace-card"><p class="eyebrow">History</p><h2>Past timesheets</h2><div class="compact-list" id="pastTimesheetsList"></div></section>
+        </section>
+
+        <section class="view" id="yellowSheetsView" data-view="yellowSheets">
+          <div class="page-heading"><p class="eyebrow">Yellow Sheets</p><h1>Daily compliance sheet</h1><p>Capture safety checks, material usage, job notes, and technician signature for the selected date.</p></div>
+          <section class="workspace-card yellow-form">
+            <div class="form-grid three">
+              <label>Date<input id="yellowDateInput" type="date" /></label>
+              <label>Job reference<select id="yellowJobSelect"></select></label>
+              <label>Technician signature<input id="yellowSignatureInput" placeholder="Type full name" /></label>
+            </div>
+            <div class="checklist" id="yellowChecklist">
+              <label><input type="checkbox" data-yellow-check="ppe" /> PPE and safety setup complete</label>
+              <label><input type="checkbox" data-yellow-check="photos" /> Required job photos attached</label>
+              <label><input type="checkbox" data-yellow-check="materials" /> Materials and equipment documented</label>
+              <label><input type="checkbox" data-yellow-check="customer" /> Customer / site notes reviewed</label>
+            </div>
+            <div class="form-grid two">
+              <label>Material usage<textarea id="yellowMaterialsInput" rows="4" placeholder="Drops, connectors, enclosures, NIDs"></textarea></label>
+              <label>Daily notes<textarea id="yellowNotesInput" rows="4" placeholder="Safety notes, blockers, extra work"></textarea></label>
+            </div>
+            <div class="hero-actions"><button class="button primary" id="saveYellowSheetButton" type="button">Save yellow sheet</button><button class="button secondary" id="exportYellowSheetButton" type="button">Export</button></div>
+          </section>
+          <section class="workspace-card"><p class="eyebrow">History</p><h2>Past yellow sheets</h2><div class="compact-list" id="pastYellowSheetsList"></div></section>
+        </section>
+
+        <section class="view" id="searchView" data-view="search">
+          <div class="page-heading"><p class="eyebrow">Job Search</p><h1>Address-aware job index</h1><p>Search by job number, address, type, status, date, or crew note, then inspect and update matching jobs.</p></div>
+          <section class="workspace-card">
+            <label class="search-box">Search jobs<input id="jobSearchInput" placeholder="Try: Maple, JT-1001, pending, splice, 2026-05-07" /></label>
+            <div class="job-list" id="searchResults"></div>
+          </section>
+        </section>
+
+        <section class="view" id="moreView" data-view="more">
+          <div class="page-heading"><p class="eyebrow">More</p><h1>Profile, settings, and partner tools</h1><p>The required More sections are available here with local persistence.</p></div>
+          <section class="more-tabs" role="tablist" aria-label="More sections">
+            <button class="segment active" type="button" data-more-tab="profile">Profile</button>
+            <button class="segment" type="button" data-more-tab="settings">Settings</button>
+            <button class="segment" type="button" data-more-tab="partner">Find a partner</button>
+          </section>
+
+          <section class="workspace-card more-panel active" id="profilePanel" data-more-panel="profile">
+            <div class="section-heading"><div><p class="eyebrow">Profile</p><h2>Account details</h2></div><button class="button secondary" id="saveProfileButton" type="button">Save profile</button></div>
+            <div class="form-grid three">
+              <label>First name<input id="profileFirstName" /></label>
+              <label>Last name<input id="profileLastName" /></label>
+              <label>Position<select id="profilePosition"><option>Technician</option><option>Supervisor</option><option>Admin</option></select></label>
+              <label>Email<input id="profileEmail" type="email" disabled /></label>
+              <label>Phone<input id="profilePhone" placeholder="(555) 123-4567" /></label>
+              <label>Home yard<input id="profileYard" placeholder="North Yard" /></label>
+            </div>
+          </section>
+
+          <section class="workspace-card more-panel" id="settingsPanel" data-more-panel="settings">
+            <div class="section-heading"><div><p class="eyebrow">Settings</p><h2>Routing, alerts, and appearance</h2></div><button class="button secondary" id="saveSettingsButton" type="button">Save settings</button></div>
+            <div class="settings-grid">
+              <label class="toggle-row"><span><strong>Smart routing</strong><small>Prioritize the next closest open job.</small></span><input id="smartRoutingInput" type="checkbox" /></label>
+              <label class="toggle-row"><span><strong>Arrival alerts</strong><small>Remind me when I arrive at a job.</small></span><input id="arrivalAlertsInput" type="checkbox" /></label>
+              <label>Optimize by<select id="routingOptimizeInput"><option>Distance</option><option>Schedule</option><option>Status priority</option></select></label>
+              <label>Address suggestions<select id="addressProviderInput"><option>Apple Maps</option><option>Google Places</option><option>Manual entry</option></select></label>
+              <label>Theme<select id="themeInput"><option>Dark</option><option>High contrast</option><option>Ocean</option></select></label>
+            </div>
+          </section>
+
+          <section class="workspace-card more-panel" id="partnerPanel" data-more-panel="partner">
+            <div class="section-heading"><div><p class="eyebrow">Find a partner</p><h2>Crew pairing requests</h2></div></div>
+            <form class="partner-form" id="partnerForm">
+              <label>Partner<select id="partnerUserInput" required></select></label>
+              <label>Needed for<select id="partnerNeedInput"><option>Aerial work</option><option>Underground pull</option><option>Splice assist</option><option>Late callback</option></select></label>
+              <label>Location<input id="partnerLocationInput" placeholder="Cabinet, address, or yard" required /></label>
+              <label>When<input id="partnerWhenInput" type="time" required /></label>
+              <label>Note<input id="partnerNoteInput" placeholder="What help is needed?" /></label>
+              <button class="button primary" type="submit">Send request</button>
+            </form>
+            <div class="compact-list" id="partnerRequestsList"></div>
+          </section>
+        </section>
+      </main>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+    <script src="config.js"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -1,0 +1,734 @@
+const config = window.JOB_TRACKER_FIREBASE_CONFIG;
+const authBase = "https://identitytoolkit.googleapis.com/v1";
+const tokenBase = "https://securetoken.googleapis.com/v1/token";
+const firestoreBase = `https://firestore.googleapis.com/v1/projects/${config.projectId}/databases/(default)/documents`;
+const sessionKey = "job-tracker-web-firebase-session";
+const statuses = ["Pending", "In Progress", "Needs Ariel", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick"];
+const weekDays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
+const shortDays = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+
+let currentUser = null;
+let authSession = readSession();
+let selectedDate = workdayForToday();
+let appState = { jobs: [], users: [], timesheets: {}, yellowSheets: {}, partnerRequests: [] };
+let currentMoreTab = "profile";
+
+const $ = (selector) => document.querySelector(selector);
+const $$ = (selector) => [...document.querySelectorAll(selector)];
+
+function createId() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function readSession() {
+  try { return JSON.parse(localStorage.getItem(sessionKey)); } catch { return null; }
+}
+
+function writeSession(session) {
+  authSession = session;
+  localStorage.setItem(sessionKey, JSON.stringify(session));
+}
+
+function clearSession() {
+  authSession = null;
+  localStorage.removeItem(sessionKey);
+}
+
+function toInputDate(date) {
+  const value = new Date(date);
+  value.setMinutes(value.getMinutes() - value.getTimezoneOffset());
+  return value.toISOString().slice(0, 10);
+}
+
+function toTimestamp(value) {
+  if (!value) return new Date().toISOString();
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) return `${value}T12:00:00.000Z`;
+  return new Date(value).toISOString();
+}
+
+function dateLabel(dateString, options = { weekday: "short", month: "short", day: "numeric" }) {
+  return new Intl.DateTimeFormat(undefined, options).format(new Date(`${dateString}T12:00:00`));
+}
+
+function mondayFor(date = new Date()) {
+  const value = new Date(date);
+  const day = value.getDay();
+  value.setDate(value.getDate() - day + (day === 0 ? -6 : 1));
+  return toInputDate(value);
+}
+
+function workdayForToday() {
+  const today = new Date();
+  const day = today.getDay();
+  if (day === 0) return addDays(mondayFor(today), 4);
+  if (day === 6) return mondayFor(today);
+  return toInputDate(today);
+}
+
+function addDays(dateString, days) {
+  const value = new Date(`${dateString}T12:00:00`);
+  value.setDate(value.getDate() + days);
+  return toInputDate(value);
+}
+
+function showToast(message) {
+  const toast = $("#toast");
+  toast.textContent = message;
+  toast.classList.add("show");
+  window.clearTimeout(showToast.timer);
+  showToast.timer = window.setTimeout(() => toast.classList.remove("show"), 3000);
+}
+
+function setMessage(message) {
+  $("#authMessage").textContent = message;
+}
+
+function showSync(message = "All server changes synced.") {
+  $("#syncText").textContent = message;
+}
+
+async function authRequest(path, payload) {
+  const response = await fetch(`${authBase}/${path}?key=${config.apiKey}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body.error?.message?.replaceAll("_", " ") || "Authentication request failed");
+  return body;
+}
+
+async function refreshTokenIfNeeded() {
+  if (!authSession?.refreshToken) throw new Error("Not signed in");
+  if (Date.now() < authSession.expiresAt - 60_000) return authSession.idToken;
+
+  const response = await fetch(`${tokenBase}?key=${config.apiKey}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: authSession.refreshToken }),
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body.error?.message || "Could not refresh session");
+  writeSession({
+    uid: body.user_id,
+    email: authSession.email,
+    idToken: body.id_token,
+    refreshToken: body.refresh_token,
+    expiresAt: Date.now() + Number(body.expires_in) * 1000,
+  });
+  return authSession.idToken;
+}
+
+async function apiFetch(url, options = {}) {
+  const token = await refreshTokenIfNeeded();
+  const response = await fetch(url, {
+    ...options,
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}`, ...(options.headers || {}) },
+  });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+  if (!response.ok) throw new Error(body?.error?.message || "Server request failed");
+  return body;
+}
+
+function encodeValue(value, key = "") {
+  if (value === null || value === undefined) return { nullValue: null };
+  if (["date", "weekStart", "createdAt", "savedAt"].includes(key)) return { timestampValue: toTimestamp(value) };
+  if (Array.isArray(value)) return { arrayValue: { values: value.map((item) => encodeValue(item)) } };
+  if (typeof value === "boolean") return { booleanValue: value };
+  if (typeof value === "number") return Number.isInteger(value) ? { integerValue: value } : { doubleValue: value };
+  if (typeof value === "object") return { mapValue: { fields: encodeFields(value) } };
+  return { stringValue: String(value) };
+}
+
+function encodeFields(data) {
+  return Object.fromEntries(Object.entries(data).filter(([, value]) => value !== undefined).map(([key, value]) => [key, encodeValue(value, key)]));
+}
+
+function decodeValue(value) {
+  if (!value) return null;
+  if ("stringValue" in value) return value.stringValue;
+  if ("integerValue" in value) return Number(value.integerValue);
+  if ("doubleValue" in value) return Number(value.doubleValue);
+  if ("booleanValue" in value) return value.booleanValue;
+  if ("timestampValue" in value) return value.timestampValue.slice(0, 10);
+  if ("arrayValue" in value) return (value.arrayValue.values || []).map(decodeValue);
+  if ("mapValue" in value) return decodeFields(value.mapValue.fields || {});
+  return null;
+}
+
+function decodeFields(fields = {}) {
+  return Object.fromEntries(Object.entries(fields).map(([key, value]) => [key, decodeValue(value)]));
+}
+
+function decodeDoc(doc) {
+  const id = doc.name.split("/").pop();
+  return { id, ...decodeFields(doc.fields || {}) };
+}
+
+async function getDoc(collection, id) {
+  try { return decodeDoc(await apiFetch(`${firestoreBase}/${collection}/${id}`)); }
+  catch (error) { if (error.message.toLowerCase().includes("not found")) return null; throw error; }
+}
+
+async function listDocs(collection) {
+  const body = await apiFetch(`${firestoreBase}/${collection}`);
+  return (body.documents || []).map(decodeDoc);
+}
+
+async function setDoc(collection, id, data) {
+  const body = { fields: encodeFields(data) };
+  await apiFetch(`${firestoreBase}/${collection}/${id}`, { method: "PATCH", body: JSON.stringify(body) });
+}
+
+async function deleteDoc(collection, id) {
+  await apiFetch(`${firestoreBase}/${collection}/${id}`, { method: "DELETE" });
+}
+
+async function signIn(email, password) {
+  const body = await authRequest("accounts:signInWithPassword", { email, password, returnSecureToken: true });
+  writeSession({ uid: body.localId, email: body.email, idToken: body.idToken, refreshToken: body.refreshToken, expiresAt: Date.now() + Number(body.expiresIn) * 1000 });
+  await loadCurrentUser();
+}
+
+async function signUp(payload) {
+  const body = await authRequest("accounts:signUp", { email: payload.email, password: payload.password, returnSecureToken: true });
+  writeSession({ uid: body.localId, email: body.email, idToken: body.idToken, refreshToken: body.refreshToken, expiresAt: Date.now() + Number(body.expiresIn) * 1000 });
+  currentUser = { id: body.localId, firstName: payload.firstName, lastName: payload.lastName, email: body.email, position: payload.position, isAdmin: false, isSupervisor: payload.position === "Supervisor", phone: "", yard: "" };
+  await setDoc("users", currentUser.id, currentUser);
+}
+
+async function loadCurrentUser() {
+  let user = await getDoc("users", authSession.uid);
+  if (!user) {
+    const [firstName] = (authSession.email || "Technician").split("@");
+    user = { id: authSession.uid, firstName, lastName: "", email: authSession.email, position: "Technician", isAdmin: false, isSupervisor: false, phone: "", yard: "" };
+    await setDoc("users", user.id, user);
+  }
+  currentUser = user;
+}
+
+async function loadAppData() {
+  showSync("Syncing with Firebase…");
+  const [jobs, users, timesheets, yellowSheets, partnerRequests] = await Promise.all([
+    listDocs("jobs"),
+    listDocs("users"),
+    listDocs("timesheets"),
+    listDocs("yellowSheets"),
+    listDocs("partnerRequests"),
+  ]);
+  appState.users = users;
+  appState.jobs = jobs.filter((job) => canSeeJob(job));
+  appState.timesheets = Object.fromEntries(timesheets.filter((sheet) => sheet.userId === currentUser.id).map((sheet) => [sheet.weekStart, normalizeTimesheet(sheet)]));
+  appState.yellowSheets = Object.fromEntries(yellowSheets.filter((sheet) => sheet.userId === currentUser.id).map((sheet) => [sheet.date || sheet.weekStart, normalizeYellowSheet(sheet)]));
+  appState.partnerRequests = partnerRequests.filter((request) => request.fromUid === currentUser.id || request.toUid === currentUser.id);
+  showSync();
+}
+
+function canSeeJob(job) {
+  if (currentUser.isAdmin || currentUser.isSupervisor) return true;
+  return [job.createdBy, job.assignedTo].includes(currentUser.id) || (job.participants || []).includes(currentUser.id);
+}
+
+function normalizeJob(job) {
+  return {
+    id: job.id || createId(),
+    address: job.address,
+    date: job.date,
+    status: job.status,
+    assignedTo: job.assignedTo || currentUser.id,
+    createdBy: job.createdBy || currentUser.id,
+    notes: job.notes || "",
+    jobNumber: job.jobNumber || "",
+    assignments: job.assignments || "",
+    materialsUsed: job.materialsUsed || "",
+    photos: job.photos || [],
+    participants: Array.from(new Set([...(job.participants || []), currentUser.id, job.assignedTo || currentUser.id].filter(Boolean))),
+    latitude: job.latitude || null,
+    longitude: job.longitude || null,
+    hours: Number(job.hours || 0),
+    nidFootage: job.nidFootage || "",
+    canFootage: job.canFootage || "",
+  };
+}
+
+function normalizeTimesheet(sheet) {
+  const days = sheet.days || weekDays.map((name) => ({ name, notes: "", gibson: 0, cableSouth: 0, other: 0 }));
+  return { id: sheet.id || sheet.weekStart, userId: currentUser.id, partnerId: sheet.partnerId || "", weekStart: sheet.weekStart, supervisor: sheet.supervisor || "", name1: sheet.name1 || `${currentUser.firstName} ${currentUser.lastName}`.trim(), name2: sheet.name2 || "", gibsonHours: sheet.gibsonHours || "0", cableSouthHours: sheet.cableSouthHours || "0", totalHours: sheet.totalHours || "0", dailyTotalHours: sheet.dailyTotalHours || {}, days, savedAt: sheet.savedAt || null, pdfURL: sheet.pdfURL || "" };
+}
+
+function normalizeYellowSheet(sheet) {
+  return { id: sheet.id || sheet.date, userId: currentUser.id, partnerId: sheet.partnerId || "", date: sheet.date || sheet.weekStart || selectedDate, weekStart: sheet.weekStart || mondayFor(sheet.date || selectedDate), totalJobs: Number(sheet.totalJobs || 0), jobId: sheet.jobId || "", checks: sheet.checks || {}, materials: sheet.materials || "", notes: sheet.notes || "", signature: sheet.signature || "", savedAt: sheet.savedAt || null, pdfURL: sheet.pdfURL || "" };
+}
+
+function showApp() {
+  $("#authScreen").classList.add("hidden");
+  $("#appShell").classList.remove("hidden");
+}
+
+function showAuth() {
+  $("#appShell").classList.add("hidden");
+  $("#authScreen").classList.remove("hidden");
+}
+
+async function enterApp() {
+  showApp();
+  hydrateUserForms();
+  await loadAppData();
+  renderAll();
+}
+
+function setAuthMode(mode) {
+  $("#loginForm").classList.toggle("hidden", mode !== "login");
+  $("#signupForm").classList.toggle("hidden", mode !== "signup");
+  $("#loginTab").classList.toggle("active", mode === "login");
+  $("#signupTab").classList.toggle("active", mode === "signup");
+  setMessage("");
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  try {
+    setMessage("Signing in…");
+    await signIn($("#loginEmail").value.trim(), $("#loginPassword").value);
+    setMessage("");
+    await enterApp();
+    showToast(`Welcome back, ${currentUser.firstName}.`);
+  } catch (error) { setMessage(error.message); }
+}
+
+async function handleSignup(event) {
+  event.preventDefault();
+  try {
+    setMessage("Creating account…");
+    await signUp({ firstName: $("#signupFirstName").value.trim(), lastName: $("#signupLastName").value.trim(), email: $("#signupEmail").value.trim(), position: $("#signupPosition").value, password: $("#signupPassword").value });
+    setMessage("");
+    await enterApp();
+    showToast("Account created and synced.");
+  } catch (error) { setMessage(error.message); }
+}
+
+async function resetPassword() {
+  const email = $("#loginEmail").value.trim();
+  if (!email) { setMessage("Enter your email first, then request a reset."); return; }
+  try {
+    await authRequest("accounts:sendOobCode", { requestType: "PASSWORD_RESET", email });
+    setMessage(`Password reset instructions were sent to ${email}.`);
+  } catch (error) { setMessage(error.message); }
+}
+
+function logout() {
+  clearSession();
+  currentUser = null;
+  appState = { jobs: [], users: [], timesheets: {}, yellowSheets: {}, partnerRequests: [] };
+  showAuth();
+  showToast("Signed out.");
+}
+
+function renderDate() {
+  $("#sidebarDate").textContent = dateLabel(toInputDate(new Date()), { weekday: "long", month: "short", day: "numeric" });
+}
+
+function selectedJobs() {
+  return appState.jobs.filter((job) => job.date === selectedDate);
+}
+
+function isOpen(job) { return job.status !== "Done"; }
+function statusClass(status) { return status === "Done" ? "done" : status?.startsWith("Needs") || status === "Talk to Rick" ? "warning" : status === "In Progress" ? "danger" : ""; }
+
+function renderWeekdayPicker() {
+  const monday = mondayFor(selectedDate);
+  const picker = $("#weekdayPicker");
+  picker.innerHTML = "";
+  weekDays.forEach((_, index) => {
+    const date = addDays(monday, index);
+    const jobs = appState.jobs.filter((job) => job.date === date);
+    const button = document.createElement("button");
+    button.className = `day-button ${date === selectedDate ? "active" : ""}`.trim();
+    button.type = "button";
+    button.innerHTML = `<strong>${shortDays[index]}</strong><span>${dateLabel(date, { month: "short", day: "numeric" })}</span><small>${jobs.length} jobs</small>`;
+    button.addEventListener("click", () => { selectedDate = date; $("#scheduledDateInput").value = selectedDate; renderAll(); });
+    picker.append(button);
+  });
+}
+
+function renderDashboard() {
+  const jobs = selectedJobs();
+  const pending = jobs.filter(isOpen);
+  const done = jobs.filter((job) => job.status === "Done");
+  const completion = jobs.length === 0 ? 0 : Math.round((done.length / jobs.length) * 100);
+  const nextJob = pending[0];
+  const timesheet = getTimesheet(mondayFor(selectedDate));
+  const dayIndex = Math.max(0, Math.min(4, new Date(`${selectedDate}T12:00:00`).getDay() - 1));
+  const yellow = getYellowSheet(selectedDate);
+  const partner = appState.partnerRequests.find((request) => request.status === "accepted");
+
+  $("#dashboardGreeting").textContent = `Hi ${currentUser.firstName}, here is ${dateLabel(selectedDate)}. Updates save to Firebase and stay aligned with the native app collections.`;
+  $("#sidebarSummary").textContent = `${jobs.length} jobs on selected day`;
+  $("#totalCount").textContent = jobs.length;
+  $("#pendingCount").textContent = pending.length;
+  $("#doneCount").textContent = done.length;
+  $("#completionRate").textContent = `${completion}%`;
+  $("#completionBar").style.width = `${completion}%`;
+  $("#nextJobAddress").textContent = nextJob ? nextJob.address : "No next job";
+  $("#nextJobHint").textContent = nextJob ? `${nextJob.jobNumber || "No job #"} • ${nextJob.status}` : "Create or assign jobs to get routing hints.";
+  $("#dashboardHours").textContent = `${sumDay(timesheet.days[dayIndex]).toFixed(1)} hrs`;
+  $("#yellowStatus").textContent = yellow.signature ? "Signed" : yellowHasContent(yellow) ? "In progress" : "Not started";
+  $("#partnerStatus").textContent = partner ? partnerName(partner) : "No partner";
+  renderJobList($("#pendingJobList"), pending, true);
+  renderJobList($("#completedJobList"), done, true);
+}
+
+function renderJobList(container, jobs, withActions = false) {
+  container.innerHTML = "";
+  if (jobs.length === 0) { container.innerHTML = `<p class="empty-state">No jobs match this section.</p>`; return; }
+  jobs.forEach((job) => container.append(jobCard(job, withActions)));
+}
+
+function jobCard(job, withActions = false) {
+  const item = document.createElement("article");
+  item.className = "job-item";
+  const details = document.createElement("div");
+  const title = document.createElement("h3");
+  const meta = document.createElement("div");
+  title.textContent = `${job.jobNumber || "No job #"} · ${job.address}`;
+  meta.className = "job-meta";
+  [job.type || job.assignments || "Job", dateLabel(job.date), job.status, job.notes || "No note added"].forEach((value, index) => {
+    const span = document.createElement("span");
+    span.textContent = value;
+    span.className = index === 2 ? `badge ${statusClass(job.status)}`.trim() : index < 3 ? "badge" : "";
+    meta.append(span);
+  });
+  details.append(title, meta);
+  item.append(details);
+  if (withActions) {
+    const actions = document.createElement("div");
+    actions.className = "job-actions";
+    const select = document.createElement("select");
+    statuses.forEach((status) => {
+      const option = document.createElement("option");
+      option.value = status; option.textContent = status; option.selected = status === job.status; select.append(option);
+    });
+    select.addEventListener("change", () => updateJob(job.id, { status: select.value }));
+    const remove = document.createElement("button");
+    remove.className = "button danger"; remove.type = "button"; remove.textContent = "Remove"; remove.addEventListener("click", () => removeJob(job.id));
+    actions.append(select, remove); item.append(actions);
+  }
+  return item;
+}
+
+async function updateJob(id, patch) {
+  const job = appState.jobs.find((item) => item.id === id);
+  if (!job) return;
+  const updated = normalizeJob({ ...job, ...patch });
+  await setDoc("jobs", id, updated);
+  await loadAppData();
+  renderAll();
+  showToast("Job saved to Firebase.");
+}
+
+async function removeJob(id) {
+  const job = appState.jobs.find((item) => item.id === id);
+  if (!job) return;
+  if (job.createdBy === currentUser.id || currentUser.isAdmin || currentUser.isSupervisor) await deleteDoc("jobs", id);
+  else await setDoc("jobs", id, normalizeJob({ ...job, participants: (job.participants || []).filter((uid) => uid !== currentUser.id) }));
+  await loadAppData();
+  renderAll();
+  showToast("Job removed.");
+}
+
+async function handleJobSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(event.currentTarget);
+  const job = normalizeJob({
+    id: createId(),
+    jobNumber: formData.get("jobNumber").trim(),
+    address: formData.get("address").trim(),
+    date: formData.get("scheduledDate"),
+    type: formData.get("type"),
+    assignments: formData.get("type"),
+    status: formData.get("status"),
+    notes: formData.get("note").trim(),
+  });
+  await setDoc("jobs", job.id, job);
+  selectedDate = job.date;
+  event.currentTarget.reset();
+  $("#scheduledDateInput").value = selectedDate;
+  await loadAppData();
+  renderAll();
+  showToast("Job created in Firebase.");
+}
+
+function getTimesheet(weekStart) {
+  if (!appState.timesheets[weekStart]) appState.timesheets[weekStart] = normalizeTimesheet({ id: `${currentUser.id}_${weekStart}`, userId: currentUser.id, weekStart });
+  return appState.timesheets[weekStart];
+}
+
+function sumDay(day) { return Number(day?.gibson || 0) + Number(day?.cableSouth || 0) + Number(day?.other || 0); }
+
+function renderTimesheet() {
+  const weekStart = $("#timesheetWeekInput").value || mondayFor(selectedDate);
+  const sheet = getTimesheet(weekStart);
+  $("#timesheetWeekInput").value = weekStart;
+  $("#timesheetSupervisorInput").value = sheet.supervisor;
+  $("#timesheetPartnerInput").value = sheet.name2;
+  const tbody = $("#timesheetRows");
+  tbody.innerHTML = "";
+  sheet.days.forEach((day, index) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `<td><strong>${day.name}</strong><br><small>${dateLabel(addDays(weekStart, index), { month: "short", day: "numeric" })}</small></td><td><textarea rows="2" data-timesheet-field="notes" data-day-index="${index}">${day.notes || ""}</textarea></td><td><input type="number" min="0" step="0.25" value="${day.gibson || 0}" data-timesheet-field="gibson" data-day-index="${index}"></td><td><input type="number" min="0" step="0.25" value="${day.cableSouth || 0}" data-timesheet-field="cableSouth" data-day-index="${index}"></td><td><input type="number" min="0" step="0.25" value="${day.other || 0}" data-timesheet-field="other" data-day-index="${index}"></td><td><strong>${sumDay(day).toFixed(2)}</strong></td>`;
+    tbody.append(row);
+  });
+  const total = sheet.days.reduce((sum, day) => sum + sumDay(day), 0);
+  $("#timesheetTotal").textContent = `${total.toFixed(2)} total hours`;
+  $("#timesheetSavedState").textContent = sheet.savedAt ? `Saved ${new Date(sheet.savedAt).toLocaleString()}` : "Not saved yet";
+  renderPastTimesheets();
+}
+
+function captureTimesheet() {
+  const weekStart = $("#timesheetWeekInput").value;
+  const sheet = getTimesheet(weekStart);
+  sheet.supervisor = $("#timesheetSupervisorInput").value.trim();
+  sheet.name1 = `${currentUser.firstName} ${currentUser.lastName}`.trim();
+  sheet.name2 = $("#timesheetPartnerInput").value.trim();
+  $$("[data-timesheet-field]").forEach((input) => { const day = sheet.days[Number(input.dataset.dayIndex)]; const field = input.dataset.timesheetField; day[field] = field === "notes" ? input.value : Number(input.value || 0); });
+  const total = sheet.days.reduce((sum, day) => sum + sumDay(day), 0);
+  sheet.gibsonHours = String(sheet.days.reduce((sum, day) => sum + Number(day.gibson || 0), 0));
+  sheet.cableSouthHours = String(sheet.days.reduce((sum, day) => sum + Number(day.cableSouth || 0), 0));
+  sheet.totalHours = String(total);
+  sheet.dailyTotalHours = Object.fromEntries(sheet.days.map((day, index) => [addDays(weekStart, index), String(sumDay(day))]));
+  return sheet;
+}
+
+async function handleSaveTimesheet() {
+  const sheet = captureTimesheet();
+  sheet.savedAt = new Date().toISOString();
+  await setDoc("timesheets", sheet.id, sheet);
+  await loadAppData();
+  renderAll();
+  showToast("Timesheet saved to Firebase.");
+}
+
+function renderPastTimesheets() {
+  const sheets = Object.values(appState.timesheets).filter((sheet) => sheet.savedAt);
+  const list = $("#pastTimesheetsList");
+  list.innerHTML = "";
+  if (sheets.length === 0) { list.innerHTML = `<p class="empty-state">Saved weekly timesheets will appear here.</p>`; return; }
+  sheets.sort((a, b) => b.weekStart.localeCompare(a.weekStart)).forEach((sheet) => { const item = document.createElement("article"); item.className = "compact-item"; item.innerHTML = `<div><h3>Week of ${dateLabel(sheet.weekStart)}</h3><span>${Number(sheet.totalHours || 0).toFixed(2)} hours • Supervisor: ${sheet.supervisor || "Not set"}</span></div>`; list.append(item); });
+}
+
+function getYellowSheet(date) {
+  if (!appState.yellowSheets[date]) appState.yellowSheets[date] = normalizeYellowSheet({ id: `${currentUser.id}_${date}`, userId: currentUser.id, date });
+  return appState.yellowSheets[date];
+}
+
+function yellowHasContent(sheet) { return Object.values(sheet.checks || {}).some(Boolean) || sheet.materials || sheet.notes || sheet.signature; }
+
+function renderYellowSheet() {
+  const date = $("#yellowDateInput").value || selectedDate;
+  const sheet = getYellowSheet(date);
+  $("#yellowDateInput").value = date;
+  const select = $("#yellowJobSelect");
+  select.innerHTML = `<option value="">General day sheet</option>`;
+  appState.jobs.filter((job) => job.date === date).forEach((job) => { const option = document.createElement("option"); option.value = job.id; option.textContent = `${job.jobNumber || "No job #"} · ${job.address}`; option.selected = job.id === sheet.jobId; select.append(option); });
+  $$('[data-yellow-check]').forEach((input) => { input.checked = Boolean(sheet.checks?.[input.dataset.yellowCheck]); });
+  $("#yellowMaterialsInput").value = sheet.materials;
+  $("#yellowNotesInput").value = sheet.notes;
+  $("#yellowSignatureInput").value = sheet.signature;
+  renderPastYellowSheets();
+}
+
+function captureYellowSheet() {
+  const date = $("#yellowDateInput").value;
+  const sheet = getYellowSheet(date);
+  sheet.jobId = $("#yellowJobSelect").value;
+  sheet.materials = $("#yellowMaterialsInput").value.trim();
+  sheet.notes = $("#yellowNotesInput").value.trim();
+  sheet.signature = $("#yellowSignatureInput").value.trim();
+  sheet.weekStart = mondayFor(date);
+  sheet.totalJobs = appState.jobs.filter((job) => job.date === date).length;
+  sheet.checks = {};
+  $$('[data-yellow-check]').forEach((input) => { sheet.checks[input.dataset.yellowCheck] = input.checked; });
+  return sheet;
+}
+
+async function handleSaveYellowSheet() {
+  const sheet = captureYellowSheet();
+  sheet.savedAt = new Date().toISOString();
+  await setDoc("yellowSheets", sheet.id, sheet);
+  await loadAppData();
+  renderAll();
+  showToast("Yellow sheet saved to Firebase.");
+}
+
+function renderPastYellowSheets() {
+  const sheets = Object.values(appState.yellowSheets).filter((sheet) => sheet.savedAt);
+  const list = $("#pastYellowSheetsList");
+  list.innerHTML = "";
+  if (sheets.length === 0) { list.innerHTML = `<p class="empty-state">Saved yellow sheets will appear here.</p>`; return; }
+  sheets.sort((a, b) => b.date.localeCompare(a.date)).forEach((sheet) => { const checks = Object.values(sheet.checks || {}).filter(Boolean).length; const item = document.createElement("article"); item.className = "compact-item"; item.innerHTML = `<div><h3>${dateLabel(sheet.date)}</h3><span>${checks}/4 checks complete • Signature: ${sheet.signature || "Missing"}</span></div>`; list.append(item); });
+}
+
+function downloadText(filename, text) { const blob = new Blob([text], { type: "text/plain" }); const link = document.createElement("a"); link.href = URL.createObjectURL(blob); link.download = filename; link.click(); URL.revokeObjectURL(link.href); }
+async function copyText(text, fallbackName) { try { await navigator.clipboard.writeText(text); showToast("Summary copied to clipboard."); } catch { downloadText(fallbackName, text); showToast("Clipboard unavailable, downloaded a text summary instead."); } }
+function dailySummaryText() { const lines = [`Job Tracker Daily Summary`, `Date: ${dateLabel(selectedDate)}`, `Technician: ${currentUser.firstName} ${currentUser.lastName}`, ""]; selectedJobs().forEach((job) => lines.push(`${job.jobNumber || "No job #"} • ${job.status} • ${job.address} • ${job.notes || "No note"}`)); if (selectedJobs().length === 0) lines.push("No jobs scheduled."); return lines.join("\n"); }
+function timesheetText() { const sheet = captureTimesheet(); return [`Job Tracker Timesheet`, `Week: ${sheet.weekStart}`, `Technician: ${sheet.name1}`, `Supervisor: ${sheet.supervisor || "Not set"}`, `Partner: ${sheet.name2 || "None"}`, "", ...sheet.days.map((day) => `${day.name}: ${sumDay(day).toFixed(2)} hrs - ${day.notes || "No notes"}`), `Total: ${sheet.totalHours} hrs`].join("\n"); }
+function yellowSheetText() { const sheet = captureYellowSheet(); const checks = Object.entries(sheet.checks).map(([key, value]) => `${key}: ${value ? "yes" : "no"}`).join("\n"); return [`Job Tracker Yellow Sheet`, `Date: ${sheet.date}`, `Technician: ${currentUser.firstName} ${currentUser.lastName}`, `Signature: ${sheet.signature || "Missing"}`, "", checks, "", `Materials: ${sheet.materials || "None"}`, `Notes: ${sheet.notes || "None"}`].join("\n"); }
+
+function renderSearch() {
+  const query = $("#jobSearchInput").value.trim().toLowerCase();
+  const filtered = query ? appState.jobs.filter((job) => [job.jobNumber, job.address, job.type, job.status, job.notes, job.date, job.assignments, job.materialsUsed].join(" ").toLowerCase().includes(query)) : appState.jobs;
+  renderJobList($("#searchResults"), filtered, true);
+}
+
+function hydrateUserForms() {
+  $("#signedInRole").textContent = currentUser.position || "Technician";
+  $("#profileFirstName").value = currentUser.firstName || "";
+  $("#profileLastName").value = currentUser.lastName || "";
+  $("#profilePosition").value = currentUser.position || "Technician";
+  $("#profileEmail").value = currentUser.email || authSession.email || "";
+  $("#profilePhone").value = currentUser.phone || "";
+  $("#profileYard").value = currentUser.yard || "";
+  const settings = currentUser.webSettings || {};
+  $("#smartRoutingInput").checked = settings.smartRouting !== false;
+  $("#arrivalAlertsInput").checked = Boolean(settings.arrivalAlerts);
+  $("#routingOptimizeInput").value = settings.optimizeBy || "Distance";
+  $("#addressProviderInput").value = settings.addressProvider || "Apple Maps";
+  $("#themeInput").value = settings.theme || "Dark";
+  applyTheme(settings.theme || "Dark");
+}
+
+async function saveProfile() {
+  currentUser = { ...currentUser, firstName: $("#profileFirstName").value.trim(), lastName: $("#profileLastName").value.trim(), position: $("#profilePosition").value, isSupervisor: $("#profilePosition").value === "Supervisor", phone: $("#profilePhone").value.trim(), yard: $("#profileYard").value.trim() };
+  await setDoc("users", currentUser.id, currentUser);
+  await loadAppData();
+  hydrateUserForms();
+  renderAll();
+  showToast("Profile saved to Firebase.");
+}
+
+function applyTheme(theme) { document.body.classList.toggle("high-contrast", theme === "High contrast"); document.body.classList.toggle("ocean", theme === "Ocean"); }
+
+async function saveSettings() {
+  currentUser.webSettings = { smartRouting: $("#smartRoutingInput").checked, arrivalAlerts: $("#arrivalAlertsInput").checked, optimizeBy: $("#routingOptimizeInput").value, addressProvider: $("#addressProviderInput").value, theme: $("#themeInput").value };
+  await setDoc("users", currentUser.id, currentUser);
+  applyTheme(currentUser.webSettings.theme);
+  showToast("Settings saved to Firebase.");
+}
+
+function setMoreTab(tab) { currentMoreTab = tab; $$('[data-more-tab]').forEach((button) => button.classList.toggle("active", button.dataset.moreTab === tab)); $$('[data-more-panel]').forEach((panel) => panel.classList.toggle("active", panel.dataset.morePanel === tab)); }
+function userName(uid) { const user = appState.users.find((item) => item.id === uid); return user ? `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.email : uid; }
+function partnerName(request) { return request.fromUid === currentUser.id ? userName(request.toUid) : userName(request.fromUid); }
+
+function renderPartnerUsers() {
+  const select = $("#partnerUserInput");
+  select.innerHTML = "";
+  appState.users.filter((user) => user.id !== currentUser.id).forEach((user) => { const option = document.createElement("option"); option.value = user.id; option.textContent = `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.email; select.append(option); });
+  if (!select.children.length) select.innerHTML = `<option value="">No other users found</option>`;
+}
+
+function renderPartnerRequests() {
+  renderPartnerUsers();
+  const list = $("#partnerRequestsList");
+  list.innerHTML = "";
+  if (appState.partnerRequests.length === 0) { list.innerHTML = `<p class="empty-state">No incoming or outgoing partner requests.</p>`; return; }
+  appState.partnerRequests.sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt))).forEach((request) => {
+    const item = document.createElement("article");
+    item.className = "compact-item";
+    const inbound = request.toUid === currentUser.id;
+    const details = document.createElement("div");
+    details.innerHTML = `<h3>${inbound ? "From" : "To"} ${partnerName(request)}</h3><span>${request.need || "Partner request"} • ${request.location || "No location"} • ${request.when || "Any time"} • ${request.status || "pending"}</span>`;
+    const actions = document.createElement("div");
+    actions.className = "job-actions";
+    if (inbound && request.status === "pending") {
+      const accept = document.createElement("button"); accept.className = "button primary"; accept.type = "button"; accept.textContent = "Accept"; accept.addEventListener("click", () => updatePartnerRequest(request.id, "accepted"));
+      const decline = document.createElement("button"); decline.className = "button danger"; decline.type = "button"; decline.textContent = "Decline"; decline.addEventListener("click", () => updatePartnerRequest(request.id, "declined"));
+      actions.append(accept, decline);
+    }
+    item.append(details, actions);
+    list.append(item);
+  });
+}
+
+async function handlePartnerSubmit(event) {
+  event.preventDefault();
+  const toUid = $("#partnerUserInput").value;
+  if (!toUid) { showToast("No partner user is available to request."); return; }
+  const request = { id: createId(), fromUid: currentUser.id, toUid, status: "pending", createdAt: new Date().toISOString(), need: $("#partnerNeedInput").value, location: $("#partnerLocationInput").value.trim(), when: $("#partnerWhenInput").value, note: $("#partnerNoteInput").value.trim() };
+  await setDoc("partnerRequests", request.id, request);
+  event.currentTarget.reset();
+  await loadAppData();
+  renderAll();
+  showToast("Partner request sent.");
+}
+
+async function updatePartnerRequest(id, status) {
+  const request = appState.partnerRequests.find((item) => item.id === id);
+  await setDoc("partnerRequests", id, { ...request, status });
+  if (status === "accepted") await setDoc("partnerships", [request.fromUid, request.toUid].sort().join("_"), { members: [request.fromUid, request.toUid], createdAt: new Date().toISOString() });
+  await loadAppData();
+  renderAll();
+  showToast(`Request ${status}.`);
+}
+
+function navigate(route) {
+  $$('[data-view]').forEach((view) => view.classList.toggle("active", view.dataset.view === route));
+  $$('[data-route]').forEach((button) => button.classList.toggle("active", button.dataset.route === route));
+  if (route === "timesheets") renderTimesheet();
+  if (route === "yellowSheets") renderYellowSheet();
+  if (route === "search") renderSearch();
+  if (route === "more") setMoreTab(currentMoreTab);
+}
+
+function renderAll() {
+  if (!currentUser) return;
+  renderDate();
+  renderWeekdayPicker();
+  renderDashboard();
+  renderTimesheet();
+  renderYellowSheet();
+  renderSearch();
+  renderPartnerRequests();
+}
+
+function bindEvents() {
+  $$('[data-auth-mode]').forEach((button) => button.addEventListener("click", () => setAuthMode(button.dataset.authMode)));
+  $("#loginForm").addEventListener("submit", handleLogin);
+  $("#signupForm").addEventListener("submit", handleSignup);
+  $("#resetPasswordButton").addEventListener("click", resetPassword);
+  $("#signOutButton").addEventListener("click", logout);
+  $$('[data-route]').forEach((button) => button.addEventListener("click", (event) => { event.preventDefault(); navigate(button.dataset.route); }));
+  $$('[data-focus-job-form]').forEach((button) => button.addEventListener("click", () => $("#jobNumberInput").focus()));
+  $("#jobForm").addEventListener("submit", (event) => handleJobSubmit(event).catch((error) => showToast(error.message)));
+  $("#refreshJobsButton").addEventListener("click", () => loadAppData().then(renderAll).then(() => showToast("Jobs refreshed from Firebase.")));
+  $("#shareDailySummaryButton").addEventListener("click", () => copyText(dailySummaryText(), `job-tracker-${selectedDate}.txt`));
+  $("#downloadDailySummaryButton").addEventListener("click", () => downloadText(`job-tracker-${selectedDate}.txt`, dailySummaryText()));
+  $("#timesheetWeekInput").addEventListener("change", renderTimesheet);
+  $("#saveTimesheetButton").addEventListener("click", () => handleSaveTimesheet().catch((error) => showToast(error.message)));
+  $("#exportTimesheetButton").addEventListener("click", () => downloadText(`timesheet-${$("#timesheetWeekInput").value}.txt`, timesheetText()));
+  $("#yellowDateInput").addEventListener("change", renderYellowSheet);
+  $("#saveYellowSheetButton").addEventListener("click", () => handleSaveYellowSheet().catch((error) => showToast(error.message)));
+  $("#exportYellowSheetButton").addEventListener("click", () => downloadText(`yellow-sheet-${$("#yellowDateInput").value}.txt`, yellowSheetText()));
+  $("#jobSearchInput").addEventListener("input", renderSearch);
+  $$('[data-more-tab]').forEach((button) => button.addEventListener("click", () => setMoreTab(button.dataset.moreTab)));
+  $("#saveProfileButton").addEventListener("click", () => saveProfile().catch((error) => showToast(error.message)));
+  $("#saveSettingsButton").addEventListener("click", () => saveSettings().catch((error) => showToast(error.message)));
+  $("#partnerForm").addEventListener("submit", (event) => handlePartnerSubmit(event).catch((error) => showToast(error.message)));
+}
+
+function initializeInputs() {
+  $("#scheduledDateInput").value = selectedDate;
+  $("#timesheetWeekInput").value = mondayFor(selectedDate);
+  $("#yellowDateInput").value = selectedDate;
+}
+
+async function bootstrap() {
+  bindEvents();
+  initializeInputs();
+  if (!config?.apiKey || !config?.projectId) { setMessage("Firebase config is missing. Update website/config.js before signing in."); return; }
+  if (!authSession?.refreshToken) return;
+  try { await refreshTokenIfNeeded(); await loadCurrentUser(); await enterApp(); }
+  catch (error) { clearSession(); showAuth(); setMessage(error.message); }
+}
+
+bootstrap();

--- a/website/app/styles.css
+++ b/website/app/styles.css
@@ -1,0 +1,257 @@
+:root {
+  color-scheme: dark;
+  --bg: #07111f;
+  --bg-soft: #101b2d;
+  --card: rgba(18, 31, 52, 0.84);
+  --card-strong: rgba(20, 40, 70, 0.96);
+  --line: rgba(154, 179, 219, 0.22);
+  --text: #eef5ff;
+  --muted: #aebbd0;
+  --accent: #62d5ff;
+  --accent-strong: #2f8cff;
+  --success: #63e6a9;
+  --warning: #ffd166;
+  --danger: #ff7a90;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(47, 140, 255, 0.3), transparent 34rem),
+    radial-gradient(circle at 82% 12%, rgba(98, 213, 255, 0.18), transparent 28rem),
+    var(--bg);
+  color: var(--text);
+}
+body.high-contrast { --bg: #000; --card: rgba(0, 0, 0, 0.94); --line: rgba(255, 255, 255, 0.46); --accent: #fff45f; --accent-strong: #ffffff; --muted: #e0e0e0; }
+body.ocean { --bg: #061b23; --accent: #55f0d2; --accent-strong: #2ca6ff; }
+button, input, select, textarea { font: inherit; }
+button { cursor: pointer; }
+a { color: inherit; }
+.hidden, .view, .more-panel { display: none !important; }
+.view.active, .more-panel.active { display: grid !important; }
+
+.auth-screen {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 1.5rem;
+}
+.auth-card {
+  display: grid;
+  grid-template-columns: 0.95fr 1.05fr;
+  width: min(100%, 980px);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 2rem;
+  background: linear-gradient(135deg, rgba(18, 31, 52, 0.95), rgba(8, 17, 31, 0.86));
+  box-shadow: var(--shadow);
+}
+.auth-copy, .auth-panel { padding: clamp(1.5rem, 5vw, 3rem); }
+.auth-copy { background: linear-gradient(135deg, rgba(98, 213, 255, 0.18), transparent); }
+.auth-copy h1, .page-heading h1, .hero h1 { margin: 0.4rem 0 1rem; letter-spacing: -0.06em; line-height: 0.95; }
+.auth-copy h1 { font-size: clamp(2.8rem, 7vw, 5rem); }
+.auth-copy p, .page-heading p, .hero p, .feature-card p, .workspace-card p, .compact-item span { color: var(--muted); line-height: 1.65; }
+.auth-form { display: grid; gap: 0.9rem; margin-top: 1.2rem; }
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 18rem minmax(0, 1fr);
+  min-height: 100vh;
+}
+.sidebar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100vh;
+  padding: 2rem;
+  border-right: 1px solid var(--line);
+  background: rgba(8, 17, 31, 0.8);
+  backdrop-filter: blur(20px);
+}
+.brand { display: flex; align-items: center; gap: 0.85rem; text-decoration: none; }
+.brand-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 14px 30px rgba(47, 140, 255, 0.28);
+  color: #04111f;
+  font-weight: 900;
+}
+.brand small, .sidebar-card small, .metric-label, .eyebrow {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.nav-links { display: grid; gap: 0.55rem; }
+.nav-link {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 1rem;
+  background: transparent;
+  color: var(--muted);
+  text-align: left;
+}
+.nav-link:hover, .nav-link:focus-visible, .nav-link.active {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text);
+}
+.sidebar-card, .workspace-card, .feature-card, .hero-panel, .sync-banner, .weekday-picker {
+  border: 1px solid var(--line);
+  border-radius: 1.5rem;
+  background: var(--card);
+  box-shadow: var(--shadow);
+}
+.sidebar-card { display: grid; gap: 0.35rem; padding: 1rem; margin-top: auto; }
+.content { display: grid; gap: 1.5rem; width: min(100%, 1220px); margin: 0 auto; padding: 2rem; }
+.view { gap: 1.5rem; }
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(20rem, 0.65fr);
+  gap: 1.5rem;
+  min-height: 30rem;
+  padding: clamp(2rem, 5vw, 4rem);
+  border: 1px solid var(--line);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(18, 31, 52, 0.94), rgba(12, 21, 37, 0.74)),
+    linear-gradient(135deg, rgba(98, 213, 255, 0.2), rgba(47, 140, 255, 0.1));
+  box-shadow: var(--shadow);
+}
+.hero-copy { align-self: center; }
+.hero h1 { max-width: 13ch; font-size: clamp(2.8rem, 7vw, 5.4rem); }
+.hero-actions, .section-heading, .summary-strip, .timesheet-toolbar { display: flex; flex-wrap: wrap; gap: 0.8rem; align-items: center; }
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0 1.05rem;
+  border: 0;
+  border-radius: 999px;
+  font-weight: 850;
+  text-decoration: none;
+}
+.button.primary { background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #04111f; }
+.button.secondary, .button.ghost { border: 1px solid var(--line); background: rgba(255, 255, 255, 0.08); color: var(--text); }
+.button.danger { background: rgba(255, 122, 144, 0.18); color: var(--danger); border: 1px solid rgba(255, 122, 144, 0.35); }
+.full-width { width: 100%; }
+.link-button { border: 0; background: transparent; color: var(--accent); font-weight: 800; text-align: left; }
+.hero-panel { display: grid; align-content: center; gap: 1.2rem; padding: 1.5rem; background: var(--card-strong); }
+.hero-panel strong { font-size: 4rem; letter-spacing: -0.07em; }
+.progress-track { height: 0.8rem; overflow: hidden; border-radius: 999px; background: rgba(255, 255, 255, 0.12); }
+.progress-track span { display: block; width: 0%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, var(--success), var(--accent)); transition: width 240ms ease; }
+.metric-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.8rem; margin: 0; }
+.metric-grid div { padding: 0.9rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,0.05); }
+.metric-grid dt { color: var(--muted); font-size: 0.8rem; }
+.metric-grid dd { margin: 0.25rem 0 0; font-size: 1.8rem; font-weight: 900; }
+
+.weekday-picker { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.65rem; padding: 0.75rem; }
+.day-button { border: 1px solid transparent; border-radius: 1rem; padding: 0.8rem; background: rgba(255,255,255,0.05); color: var(--muted); text-align: left; }
+.day-button.active { border-color: var(--accent); color: var(--text); background: rgba(98, 213, 255, 0.12); }
+.day-button strong { display: block; color: inherit; }
+.sync-banner { display: flex; align-items: center; gap: 0.65rem; padding: 0.9rem 1rem; color: var(--muted); }
+.pulse { width: 0.65rem; height: 0.65rem; border-radius: 999px; background: var(--success); box-shadow: 0 0 0 6px rgba(99,230,169,0.12); }
+
+.section-grid, .two-column, .form-grid, .settings-grid { display: grid; gap: 1rem; }
+.section-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.section-grid.four { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.two-column { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+.form-grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.form-grid.three, .settings-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.feature-card, .workspace-card { padding: 1.3rem; }
+.feature-card .icon { font-size: 2rem; }
+.feature-card h2, .workspace-card h2 { margin: 0.35rem 0; }
+.section-heading { justify-content: space-between; margin-bottom: 1rem; }
+.page-heading { padding: 1rem 0 0.5rem; }
+.page-heading h1 { font-size: clamp(2.4rem, 6vw, 4rem); }
+
+.job-form { display: grid; grid-template-columns: 0.75fr 1.4fr 0.9fr 0.8fr 1fr 1.3fr auto; gap: 0.8rem; align-items: end; }
+.partner-form { display: grid; grid-template-columns: 1fr 1.2fr 0.7fr 1.3fr auto; gap: 0.8rem; align-items: end; margin-bottom: 1rem; }
+label { display: grid; gap: 0.45rem; color: var(--muted); font-size: 0.9rem; font-weight: 750; }
+input, select, textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  outline: none;
+  padding: 0.82rem 0.9rem;
+}
+select option { background: #101b2d; color: var(--text); }
+input:disabled { opacity: 0.7; }
+textarea { resize: vertical; }
+input:focus, select:focus, textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(98, 213, 255, 0.12); }
+.search-box input { font-size: 1.2rem; padding: 1rem; }
+
+.job-list, .compact-list { display: grid; gap: 0.75rem; margin-top: 1rem; }
+.job-item, .compact-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+.job-item h3, .compact-item h3 { margin: 0; }
+.job-meta { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.55rem; color: var(--muted); }
+.job-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.5rem; }
+.badge { border-radius: 999px; padding: 0.25rem 0.65rem; background: rgba(255, 255, 255, 0.1); color: var(--text); font-size: 0.8rem; font-weight: 850; }
+.badge.done { background: rgba(99,230,169,0.17); color: var(--success); }
+.badge.warning { background: rgba(255,209,102,0.17); color: var(--warning); }
+.badge.danger { background: rgba(255,122,144,0.17); color: var(--danger); }
+.empty-state { margin: 0; padding: 1rem; border: 1px dashed var(--line); border-radius: 1rem; color: var(--muted); }
+
+.table-wrap { overflow-x: auto; }
+.data-table { width: 100%; border-collapse: collapse; min-width: 820px; }
+.data-table th, .data-table td { padding: 0.7rem; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+.data-table th { color: var(--muted); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.data-table input, .data-table textarea { min-width: 7rem; }
+.summary-strip { justify-content: space-between; margin-top: 1rem; padding: 1rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,0.05); }
+
+.checklist { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.8rem; margin: 1rem 0; }
+.checklist label, .toggle-row { display: flex; align-items: center; gap: 0.7rem; padding: 0.85rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,0.05); color: var(--text); }
+.checklist input, .toggle-row input { width: auto; accent-color: var(--accent); }
+.toggle-row { justify-content: space-between; }
+.toggle-row small { display: block; color: var(--muted); font-weight: 600; margin-top: 0.2rem; }
+.more-tabs, .segmented { display: inline-flex; width: fit-content; gap: 0.35rem; padding: 0.35rem; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,0.06); }
+.segment { border: 0; border-radius: 999px; padding: 0.65rem 1rem; background: transparent; color: var(--muted); font-weight: 850; }
+.segment.active { background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #04111f; }
+.form-message { min-height: 1.4rem; color: var(--warning); }
+.toast { position: fixed; right: 1rem; bottom: 1rem; z-index: 5; transform: translateY(140%); max-width: 28rem; padding: 0.9rem 1rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--card-strong); box-shadow: var(--shadow); color: var(--text); transition: transform 180ms ease; }
+.toast.show { transform: translateY(0); }
+
+@media (max-width: 1120px) {
+  .app-shell, .hero, .section-grid, .section-grid.four, .two-column, .job-form, .partner-form, .settings-grid { grid-template-columns: 1fr; }
+  .sidebar { position: static; height: auto; border-right: 0; border-bottom: 1px solid var(--line); }
+  .nav-links { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+  .nav-link { text-align: center; }
+}
+@media (max-width: 760px) {
+  .auth-card, .form-grid.two, .form-grid.three, .checklist, .weekday-picker { grid-template-columns: 1fr; }
+  .content, .sidebar, .auth-screen { padding: 1rem; }
+  .hero { min-height: auto; padding: 1.3rem; }
+  .hero h1 { font-size: 2.8rem; }
+  .hero-panel strong { font-size: 3rem; }
+  .metric-grid, .nav-links { grid-template-columns: 1fr; }
+  .job-item, .compact-item { grid-template-columns: 1fr; }
+  .job-actions { justify-content: flex-start; }
+  .more-tabs, .segmented { width: 100%; display: grid; grid-template-columns: 1fr; border-radius: 1.2rem; }
+}


### PR DESCRIPTION
### Motivation

- Provide a browser-based Job Tracker workspace that can be merged alongside the existing static website without colliding with existing top-level site files.
- Mirror the native app's Firestore collections so web users share the same jobs, timesheets, yellow sheets, users, and partner request data.
- Offer a lightweight, client-only implementation that supports authentication, daily planning, job CRUD, timesheets, yellow sheets, search, profile/settings, and partner requests.

### Description

- Added a new web app under `website/app/` including `index.html`, `script.js`, `styles.css`, `config.js`, and `README.md` that implement the full browser UI and styling.
- Implemented Firebase integration using the REST endpoints (Identity Toolkit + Secure Token + Firestore REST) with session persistence, token refresh, and `encodeValue`/`decodeValue` helpers to map to Firestore document shapes in `script.js`.
- Implemented core features: email/password sign in/up/reset, dashboard with weekday picker and rollups, job creation/updates/removal, weekly timesheet editor, daily yellow sheet checklist, global job search, profile/settings persistence, partner requests and partnerships, and export/copy text summaries.
- Included `website/app/README.md` with run instructions (`python3 -m http.server 8000 --directory website`) and deployment notes, and `config.js` stub for Firebase project config.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc3f40a98832db99ca3f34e7e1044)