### PR TITLE
Web parity: sign-in UX, job detail dialog, shared-job import/claim, profile shortcuts, and implementation notes

### DIFF
--- a/website/app/PARITY_IMPLEMENTATION_NOTES.md
+++ b/website/app/PARITY_IMPLEMENTATION_NOTES.md
@@ -1,0 +1,16 @@
+# Web App Parity Implementation Notes
+
+These notes intentionally live outside `PARITY_PLAN.md` so the current PR can merge cleanly over the already-merged baseline plan.
+
+## Completed in this follow-up
+
+1. Added a first-class Job Detail dialog for dashboard/search results with edit, route, share, and remove actions.
+2. Added shared-job import preview/claiming from pasted tokens or `jobtracker://importJob?token=...` links.
+3. Added Profile shortcuts to past timesheets and yellow sheets.
+4. Kept the original parity plan stable to avoid merge conflicts with the already-merged baseline documentation.
+
+## Still remaining
+
+- Replace text exports with browser PDF generation or a shared server-side PDF service that matches the native PDF output.
+- Continue visual-system polish for closer SwiftUI parity, including icon affordances and tighter glass-card spacing.
+- Expand the shared-job import route into a richer preview/deep-link handoff if the web app is hosted with a production URL.

--- a/website/app/PARITY_PLAN.md
+++ b/website/app/PARITY_PLAN.md
@@ -1,0 +1,60 @@
+# Job Tracker Web App Parity Plan
+
+This audit compares the Firebase-backed web app in `website/app/` against the native iOS flow that matters for the web release: dashboard, job creation/detail/search, timesheets, yellow sheets, sharing, More/Profile/Settings/Find a Partner, and login.
+
+## What was checked
+
+- Native authentication flow in `Job Tracker/Features/Authentication/AuthFlowView.swift`.
+- Native tab structure and More destinations in `Job Tracker/Features/Shared/Shell/MainTabView.swift` and `Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift`.
+- Web routes, forms, Firebase REST calls, and client-side state in `website/app/index.html`, `website/app/styles.css`, and `website/app/script.js`.
+
+## Immediate fixes completed
+
+1. Match the native auth flow more closely by using three segmented actions: Sign In, Sign Up, and Reset.
+2. Replace the login-only password reset button with a dedicated Reset form, matching the app copy and validation path.
+3. Align signup positions with the native crew position picker: Aerial, Underground, Nid, and Can.
+4. Add client-side validation before Firebase requests so blank/short values fail with clear messages instead of awkward browser or API errors.
+5. Guard against missing Firebase config before building Firestore URLs and fix the missing-config message to point at `website/app/config.js`.
+6. Correct the More page copy to say Firebase-backed persistence instead of local persistence.
+7. Add a web Share action that writes the native-compatible minimal `sharedJobs` payload and copies a `jobtracker://importJob?token=...` link.
+
+## Remaining parity work
+
+### 1. Visual system pass
+
+- Replace the current desktop-first hero treatment with a closer SwiftUI glass-card layout: centered auth header, segmented controls, card spacing, and button sizing that mirrors the native `JTPrimaryButton` and `JTTextField` components.
+- Add icon affordances to web inputs where the app uses SF Symbols: envelope, lock, person, map pin, clock, and document symbols.
+- Normalize terminology and capitalization so the web uses the same labels as the app: `Sign In`, `Create Account`, `Yellow Sheet`, `Find a Partner`, and native status labels.
+
+### 2. Dashboard parity
+
+- Keep the current Monday-Friday picker, selected-day rollups, next-job card, timesheet hours, yellow sheet state, and partner card.
+- Add a dedicated job detail drawer or route from dashboard cards so users can inspect/edit one job without relying only on inline status changes.
+- Add route/map affordances for addresses after map-provider integration is selected.
+
+### 3. Job creation, detail, search, and sharing
+
+- Promote job detail editing to first-class web UI: status, notes, assignment/material fields, footage fields, participants, and remove/unshare actions.
+- Expand sharing with an import-preview route for pasted/deep-linked tokens so the browser can consume the same `SharedJobPayload` flow it can now publish.
+- Expand search results so each result can open the same detail drawer and show matching fields.
+
+### 4. Timesheets and yellow sheets
+
+- Keep the current web editors for weekly timesheets and daily yellow sheets.
+- Replace text exports with browser PDF generation or a shared server-side PDF service that matches the native PDF output.
+- Add profile shortcuts to past timesheets and past yellow sheets, matching the native Profile screen.
+
+### 5. More tab scope
+
+- Required for web release: Profile, Settings, and Find a Partner.
+- Consider adding Recent Crew Jobs only after the required web scope is stable because it exists in native More but was not in the web release minimum.
+- Keep Admin/Supervisor-only sections out of the default web navigation unless the role gate and Firestore rules are confirmed.
+
+### 6. Testing checklist
+
+- Login, signup, reset, sign-out, and persisted-session refresh.
+- Create/update/remove jobs as technician and supervisor/admin roles.
+- Save/reopen timesheets and yellow sheets across refreshes.
+- Search by job number, address, type, status, date, notes, assignment, and materials.
+- Send/accept/decline partner requests between two test users.
+- Verify the UI at phone, tablet, and desktop widths.

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -16,44 +16,50 @@
         <div class="auth-copy">
           <span class="brand-mark">JT</span>
           <p class="eyebrow">Fiber field operations</p>
-          <h1>Job Tracker Web</h1>
-          <p>
-            Sign in with your Firebase-backed Job Tracker account or create a technician account
-            to manage dashboards, job search, timesheets, yellow sheets, and the More tools.
-          </p>
+          <h1 id="authHeadline">Welcome Back</h1>
+          <p id="authLead">Sign in with the credentials you use across the Job Tracker apps.</p>
         </div>
 
         <div class="auth-panel">
-          <div class="segmented" role="tablist" aria-label="Authentication mode">
-            <button class="segment active" id="loginTab" type="button" data-auth-mode="login">Login</button>
-            <button class="segment" id="signupTab" type="button" data-auth-mode="signup">Sign up</button>
+          <div class="segmented auth-segmented" role="tablist" aria-label="Authentication actions">
+            <button class="segment active" id="loginTab" type="button" data-auth-mode="login" aria-controls="loginForm" aria-selected="true">Sign In</button>
+            <button class="segment" id="signupTab" type="button" data-auth-mode="signup" aria-controls="signupForm" aria-selected="false">Sign Up</button>
+            <button class="segment" id="resetTab" type="button" data-auth-mode="reset" aria-controls="resetForm" aria-selected="false">Reset</button>
           </div>
 
-          <form id="loginForm" class="auth-form">
-            <label>Email<input id="loginEmail" type="email" autocomplete="email" required /></label>
+          <form id="loginForm" class="auth-form" novalidate>
+            <label>Email Address<input id="loginEmail" type="email" autocomplete="email" required /></label>
             <label>Password<input id="loginPassword" type="password" autocomplete="current-password" required /></label>
-            <button class="button primary" type="submit">Login</button>
-            <button class="link-button" id="resetPasswordButton" type="button">Send password reset</button>
+            <button class="button primary" type="submit">Sign In</button>
+            <button class="link-button" type="button" data-auth-mode="signup">Need an account? Create one</button>
+            <button class="link-button" type="button" data-auth-mode="reset">Forgot password?</button>
           </form>
 
-          <form id="signupForm" class="auth-form hidden">
+          <form id="signupForm" class="auth-form hidden" novalidate>
             <div class="form-grid two">
-              <label>First name<input id="signupFirstName" autocomplete="given-name" required /></label>
-              <label>Last name<input id="signupLastName" autocomplete="family-name" required /></label>
+              <label>First Name<input id="signupFirstName" autocomplete="given-name" required /></label>
+              <label>Last Name<input id="signupLastName" autocomplete="family-name" required /></label>
             </div>
-            <label>Email<input id="signupEmail" type="email" autocomplete="email" required /></label>
-            <div class="form-grid two">
-              <label>
-                Position
-                <select id="signupPosition">
-                  <option>Technician</option>
-                  <option>Supervisor</option>
-                  <option>Admin</option>
-                </select>
-              </label>
-              <label>Password<input id="signupPassword" type="password" autocomplete="new-password" minlength="6" required /></label>
-            </div>
-            <button class="button primary" type="submit">Create account</button>
+            <label>Email Address<input id="signupEmail" type="email" autocomplete="email" required /></label>
+            <label>Password<input id="signupPassword" type="password" autocomplete="new-password" minlength="8" required /></label>
+            <label class="position-picker">
+              Crew Position
+              <select id="signupPosition">
+                <option>Aerial</option>
+                <option>Underground</option>
+                <option>Nid</option>
+                <option>Can</option>
+              </select>
+            </label>
+            <button class="button primary" type="submit">Create Account</button>
+            <button class="link-button" type="button" data-auth-mode="login">Already have an account? Sign in</button>
+          </form>
+
+          <form id="resetForm" class="auth-form hidden" novalidate>
+            <label>Email Address<input id="resetEmail" type="email" autocomplete="email" required /></label>
+            <p class="helper-text">We'll send a secure link to reset your password.</p>
+            <button class="button primary" type="submit">Email Reset Link</button>
+            <button class="link-button" type="button" data-auth-mode="login">Back to sign in</button>
           </form>
 
           <p id="authMessage" class="form-message" role="status" aria-live="polite"></p>
@@ -216,10 +222,21 @@
             <label class="search-box">Search jobs<input id="jobSearchInput" placeholder="Try: Maple, JT-1001, pending, splice, 2026-05-07" /></label>
             <div class="job-list" id="searchResults"></div>
           </section>
+
+          <section class="workspace-card">
+            <div class="section-heading">
+              <div><p class="eyebrow">Shared jobs</p><h2>Import shared job link</h2></div>
+            </div>
+            <form class="share-import-form" id="shareImportForm">
+              <label>Token or link<input id="shareTokenInput" placeholder="jobtracker://importJob?token=..." /></label>
+              <button class="button primary" type="submit">Preview import</button>
+            </form>
+            <div class="compact-list" id="shareImportPreview"></div>
+          </section>
         </section>
 
         <section class="view" id="moreView" data-view="more">
-          <div class="page-heading"><p class="eyebrow">More</p><h1>Profile, settings, and partner tools</h1><p>The required More sections are available here with local persistence.</p></div>
+          <div class="page-heading"><p class="eyebrow">More</p><h1>Profile, settings, and partner tools</h1><p>The required More sections are available here with Firebase-backed persistence.</p></div>
           <section class="more-tabs" role="tablist" aria-label="More sections">
             <button class="segment active" type="button" data-more-tab="profile">Profile</button>
             <button class="segment" type="button" data-more-tab="settings">Settings</button>
@@ -231,11 +248,12 @@
             <div class="form-grid three">
               <label>First name<input id="profileFirstName" /></label>
               <label>Last name<input id="profileLastName" /></label>
-              <label>Position<select id="profilePosition"><option>Technician</option><option>Supervisor</option><option>Admin</option></select></label>
+              <label>Position<select id="profilePosition"><option>Aerial</option><option>Underground</option><option>Nid</option><option>Can</option><option>Supervisor</option><option>Admin</option></select></label>
               <label>Email<input id="profileEmail" type="email" disabled /></label>
               <label>Phone<input id="profilePhone" placeholder="(555) 123-4567" /></label>
               <label>Home yard<input id="profileYard" placeholder="North Yard" /></label>
             </div>
+            <div class="profile-shortcuts" id="profileShortcuts" aria-label="Profile shortcuts"></div>
           </section>
 
           <section class="workspace-card more-panel" id="settingsPanel" data-more-panel="settings">
@@ -265,8 +283,37 @@
       </main>
     </div>
 
+    <dialog class="job-detail-dialog" id="jobDetailDialog" aria-labelledby="jobDetailTitle">
+      <form class="job-detail-panel" id="jobDetailForm" method="dialog">
+        <div class="section-heading">
+          <div><p class="eyebrow">Job Detail</p><h2 id="jobDetailTitle">Edit job</h2></div>
+          <button class="button ghost" id="closeJobDetailButton" type="button">Close</button>
+        </div>
+        <input id="detailJobId" type="hidden" />
+        <div class="form-grid two">
+          <label>Job #<input id="detailJobNumber" /></label>
+          <label>Scheduled date<input id="detailDate" type="date" /></label>
+          <label>Address<input id="detailAddress" /></label>
+          <label>Status<select id="detailStatus"></select></label>
+          <label>Assignment / type<input id="detailAssignments" /></label>
+          <label>Materials used<input id="detailMaterials" /></label>
+          <label>NID footage<input id="detailNidFootage" /></label>
+          <label>CAN footage<input id="detailCanFootage" /></label>
+        </div>
+        <label>Notes<textarea id="detailNotes" rows="4"></textarea></label>
+        <label>Participants<input id="detailParticipants" placeholder="Comma-separated user IDs" /></label>
+        <div class="detail-actions">
+          <button class="button primary" id="saveJobDetailButton" type="submit">Save detail</button>
+          <button class="button secondary" id="routeJobButton" type="button">Open route</button>
+          <button class="button secondary" id="shareJobDetailButton" type="button">Share</button>
+          <button class="button danger" id="removeJobDetailButton" type="button">Remove</button>
+        </div>
+      </form>
+    </dialog>
+
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
     <script src="config.js"></script>
     <script src="script.js"></script>
+    <script src="parity-enhancements.js"></script>
   </body>
 </html>

--- a/website/app/parity-enhancements.js
+++ b/website/app/parity-enhancements.js
@@ -1,0 +1,300 @@
+const parityBase = {
+  encodeValue,
+  hydrateUserForms,
+  renderAll,
+  jobCard,
+};
+
+encodeValue = function enhancedEncodeValue(value, key = "") {
+  if (key === "claimedAt") return { timestampValue: toTimestamp(value) };
+  return parityBase.encodeValue(value, key);
+};
+
+function hydrateStatusSelect(select, selectedStatus = "Pending") {
+  select.innerHTML = "";
+  statuses.forEach((status) => {
+    const option = document.createElement("option");
+    option.value = status;
+    option.textContent = status;
+    option.selected = status === selectedStatus;
+    select.append(option);
+  });
+}
+
+function openJobDetail(id) {
+  const job = appState.jobs.find((item) => item.id === id);
+  if (!job) return;
+
+  hydrateStatusSelect($("#detailStatus"), job.status);
+  $("#detailJobId").value = job.id;
+  $("#detailJobNumber").value = job.jobNumber || "";
+  $("#detailDate").value = job.date || selectedDate;
+  $("#detailAddress").value = job.address || "";
+  $("#detailAssignments").value = job.assignments || job.type || "";
+  $("#detailMaterials").value = job.materialsUsed || "";
+  $("#detailNidFootage").value = job.nidFootage || "";
+  $("#detailCanFootage").value = job.canFootage || "";
+  $("#detailNotes").value = job.notes || "";
+  $("#detailParticipants").value = (job.participants || []).join(", ");
+  $("#jobDetailTitle").textContent = `${job.jobNumber || "No job #"} · ${job.address || "Job detail"}`;
+
+  const dialog = $("#jobDetailDialog");
+  if (dialog.showModal) dialog.showModal();
+  else dialog.setAttribute("open", "");
+}
+
+function closeJobDetail() {
+  const dialog = $("#jobDetailDialog");
+  if (dialog.close) dialog.close();
+  else dialog.removeAttribute("open");
+}
+
+async function saveJobDetail(event) {
+  event.preventDefault();
+  const id = $("#detailJobId").value;
+  const participants = $("#detailParticipants").value
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  await updateJob(id, {
+    jobNumber: $("#detailJobNumber").value.trim(),
+    date: $("#detailDate").value,
+    address: $("#detailAddress").value.trim(),
+    status: $("#detailStatus").value,
+    assignments: $("#detailAssignments").value.trim(),
+    type: $("#detailAssignments").value.trim(),
+    materialsUsed: $("#detailMaterials").value.trim(),
+    nidFootage: $("#detailNidFootage").value.trim(),
+    canFootage: $("#detailCanFootage").value.trim(),
+    notes: $("#detailNotes").value.trim(),
+    participants,
+  });
+  closeJobDetail();
+}
+
+function currentDetailJob() {
+  return appState.jobs.find((job) => job.id === $("#detailJobId").value);
+}
+
+function openRouteForJob(job) {
+  if (!job?.address) return;
+  window.open(`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(job.address)}`, "_blank", "noopener");
+}
+
+async function removeDetailJob() {
+  const job = currentDetailJob();
+  if (!job) return;
+  await removeJob(job.id);
+  closeJobDetail();
+}
+
+async function shareDetailJob() {
+  const job = currentDetailJob();
+  if (job) await shareJob(job.id);
+}
+
+jobCard = function enhancedJobCard(job, withActions = false) {
+  const item = document.createElement("article");
+  item.className = "job-item";
+
+  const details = document.createElement("div");
+  const title = document.createElement("h3");
+  const titleButton = document.createElement("button");
+  const meta = document.createElement("div");
+
+  titleButton.type = "button";
+  titleButton.textContent = `${job.jobNumber || "No job #"} · ${job.address}`;
+  titleButton.addEventListener("click", () => openJobDetail(job.id));
+  title.append(titleButton);
+
+  meta.className = "job-meta";
+  [job.type || job.assignments || "Job", dateLabel(job.date), job.status, job.notes || "No note added"].forEach((value, index) => {
+    const span = document.createElement("span");
+    span.textContent = value;
+    span.className = index === 2 ? `badge ${statusClass(job.status)}`.trim() : index < 3 ? "badge" : "";
+    meta.append(span);
+  });
+
+  details.append(title, meta);
+  item.append(details);
+
+  if (withActions) {
+    const actions = document.createElement("div");
+    actions.className = "job-actions";
+    const select = document.createElement("select");
+    hydrateStatusSelect(select, job.status);
+    select.addEventListener("change", () => updateJob(job.id, { status: select.value }));
+
+    const share = document.createElement("button");
+    share.className = "button secondary";
+    share.type = "button";
+    share.textContent = "Share";
+    share.addEventListener("click", () => shareJob(job.id));
+
+    const remove = document.createElement("button");
+    remove.className = "button danger";
+    remove.type = "button";
+    remove.textContent = "Remove";
+    remove.addEventListener("click", () => removeJob(job.id));
+
+    actions.append(select, share, remove);
+    item.append(actions);
+  }
+
+  return item;
+};
+
+function extractShareToken(value) {
+  const raw = value.trim();
+  if (!raw) return "";
+  try {
+    const url = new URL(raw);
+    return url.searchParams.get("token") || raw;
+  } catch {
+    const match = raw.match(/[?&]token=([^&]+)/);
+    return match ? decodeURIComponent(match[1]) : raw;
+  }
+}
+
+function sharedPayloadDate(payload) {
+  return payload.date || selectedDate;
+}
+
+async function previewSharedJob(event) {
+  event?.preventDefault();
+  const token = extractShareToken($("#shareTokenInput").value);
+  const preview = $("#shareImportPreview");
+  preview.innerHTML = "";
+
+  if (!token) {
+    preview.innerHTML = `<p class="empty-state">Paste a shared job token or deep link first.</p>`;
+    return;
+  }
+
+  try {
+    const payload = await getDoc("sharedJobs", token);
+    if (!payload) {
+      preview.innerHTML = `<p class="empty-state">Shared job link not found or expired.</p>`;
+      return;
+    }
+    if (payload.claimedBy) {
+      preview.innerHTML = `<p class="empty-state">This shared job link has already been used.</p>`;
+      return;
+    }
+    if (payload.expiresAt && payload.expiresAt < toInputDate(new Date())) {
+      preview.innerHTML = `<p class="empty-state">This shared job link has expired.</p>`;
+      return;
+    }
+
+    const item = document.createElement("article");
+    item.className = "compact-item";
+
+    const details = document.createElement("div");
+    const title = document.createElement("h3");
+    const meta = document.createElement("span");
+    title.textContent = `${payload.jobNumber || "No job #"} · ${payload.address}`;
+    meta.textContent = `${payload.status || "Pending"} • ${dateLabel(sharedPayloadDate(payload))} • From ${payload.fromUserName || payload.fromUserId || "Unknown"}`;
+    details.append(title, meta);
+
+    const actions = document.createElement("div");
+    actions.className = "job-actions";
+    const importButton = document.createElement("button");
+    importButton.className = "button primary";
+    importButton.type = "button";
+    importButton.textContent = "Import job";
+    importButton.addEventListener("click", () => importSharedJob(token, payload));
+    actions.append(importButton);
+
+    item.append(details, actions);
+    preview.append(item);
+  } catch (error) {
+    preview.innerHTML = `<p class="empty-state">${error.message}</p>`;
+  }
+}
+
+async function importSharedJob(token, payload) {
+  const job = normalizeJob({
+    id: createId(),
+    jobNumber: payload.jobNumber || "",
+    address: payload.address,
+    date: sharedPayloadDate(payload),
+    status: payload.status || "Pending",
+    assignments: payload.senderIsCan ? payload.assignment || "" : "",
+    type: payload.senderIsCan ? payload.assignment || "Shared" : "Shared",
+    notes: `Imported shared job${payload.fromUserName ? ` from ${payload.fromUserName}` : ""}.`,
+    participants: [currentUser.id, payload.fromUserId].filter(Boolean),
+  });
+
+  await setDoc("jobs", job.id, job);
+  await setDoc("sharedJobs", token, { ...payload, claimedBy: currentUser.id, claimedAt: new Date().toISOString() });
+  selectedDate = job.date;
+  $("#scheduledDateInput").value = selectedDate;
+  $("#shareImportPreview").innerHTML = "";
+  $("#shareTokenInput").value = "";
+  await loadAppData();
+  renderAll();
+  navigate("dashboard");
+  showToast("Shared job imported.");
+}
+
+function hydrateShareTokenFromUrl() {
+  const params = new URLSearchParams(window.location?.search || "");
+  const hashParams = new URLSearchParams((window.location?.hash || "").replace(/^#?\??/, ""));
+  const token = params.get("token") || hashParams.get("token");
+  if (token) $("#shareTokenInput").value = token;
+}
+
+function renderProfileShortcuts() {
+  const container = $("#profileShortcuts");
+  if (!container) return;
+
+  const timesheets = Object.values(appState.timesheets).filter((sheet) => sheet.savedAt);
+  const yellowSheets = Object.values(appState.yellowSheets).filter((sheet) => sheet.savedAt);
+  const latestTimesheet = [...timesheets].sort((a, b) => b.weekStart.localeCompare(a.weekStart))[0];
+  const latestYellow = [...yellowSheets].sort((a, b) => b.date.localeCompare(a.date))[0];
+
+  container.innerHTML = "";
+  [
+    { label: "Past Timesheets", count: timesheets.length, detail: latestTimesheet ? `Latest week of ${dateLabel(latestTimesheet.weekStart)}` : "No saved weeks yet", route: "timesheets" },
+    { label: "Past Yellow Sheets", count: yellowSheets.length, detail: latestYellow ? `Latest ${dateLabel(latestYellow.date)}` : "No saved sheets yet", route: "yellowSheets" },
+  ].forEach((shortcut) => {
+    const button = document.createElement("button");
+    const label = document.createElement("span");
+    const count = document.createElement("strong");
+    const detail = document.createElement("small");
+
+    button.className = "shortcut-card";
+    button.type = "button";
+    label.textContent = shortcut.label;
+    count.textContent = shortcut.count;
+    detail.textContent = shortcut.detail;
+    button.append(label, count, detail);
+    button.addEventListener("click", () => navigate(shortcut.route));
+    container.append(button);
+  });
+}
+
+hydrateUserForms = function enhancedHydrateUserForms() {
+  parityBase.hydrateUserForms();
+  renderProfileShortcuts();
+};
+
+renderAll = function enhancedRenderAll() {
+  parityBase.renderAll();
+  renderProfileShortcuts();
+};
+
+function bindParityEnhancementEvents() {
+  hydrateStatusSelect($("#detailStatus"));
+  hydrateShareTokenFromUrl();
+  $("#jobDetailForm").addEventListener("submit", (event) => saveJobDetail(event).catch((error) => showToast(error.message)));
+  $("#closeJobDetailButton").addEventListener("click", closeJobDetail);
+  $("#routeJobButton").addEventListener("click", () => openRouteForJob(currentDetailJob()));
+  $("#shareJobDetailButton").addEventListener("click", () => shareDetailJob().catch((error) => showToast(error.message)));
+  $("#removeJobDetailButton").addEventListener("click", () => removeDetailJob().catch((error) => showToast(error.message)));
+  $("#shareImportForm").addEventListener("submit", (event) => previewSharedJob(event).catch((error) => showToast(error.message)));
+}
+
+bindParityEnhancementEvents();
+if (currentUser) renderAll();

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -1,11 +1,12 @@
-const config = window.JOB_TRACKER_FIREBASE_CONFIG;
+const config = window.JOB_TRACKER_FIREBASE_CONFIG || {};
 const authBase = "https://identitytoolkit.googleapis.com/v1";
 const tokenBase = "https://securetoken.googleapis.com/v1/token";
-const firestoreBase = `https://firestore.googleapis.com/v1/projects/${config.projectId}/databases/(default)/documents`;
+const firestoreBase = config.projectId ? `https://firestore.googleapis.com/v1/projects/${config.projectId}/databases/(default)/documents` : "";
 const sessionKey = "job-tracker-web-firebase-session";
 const statuses = ["Pending", "In Progress", "Needs Ariel", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick"];
 const weekDays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 const shortDays = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+const shareTokenAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789";
 
 let currentUser = null;
 let authSession = readSession();
@@ -13,11 +14,26 @@ let selectedDate = workdayForToday();
 let appState = { jobs: [], users: [], timesheets: {}, yellowSheets: {}, partnerRequests: [] };
 let currentMoreTab = "profile";
 
+const authCopy = {
+  login: { headline: "Welcome Back", lead: "Sign in with the credentials you use across the Job Tracker apps." },
+  signup: { headline: "Create Your Account", lead: "Fill in your crew details below so we can personalize your dashboard." },
+  reset: { headline: "Need a Reset?", lead: "Enter the email tied to your Job Tracker account and we'll send a reset link." },
+};
+
 const $ = (selector) => document.querySelector(selector);
 const $$ = (selector) => [...document.querySelectorAll(selector)];
 
 function createId() {
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function randomToken(length = 24) {
+  const bytes = new Uint8Array(length);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => shareTokenAlphabet[byte % shareTokenAlphabet.length]).join("");
+  }
+  return Array.from({ length }, () => shareTokenAlphabet[Math.floor(Math.random() * shareTokenAlphabet.length)]).join("");
 }
 
 function readSession() {
@@ -88,6 +104,7 @@ function showSync(message = "All server changes synced.") {
 }
 
 async function authRequest(path, payload) {
+  if (!config.apiKey) throw new Error("Firebase config is missing. Update website/app/config.js before signing in.");
   const response = await fetch(`${authBase}/${path}?key=${config.apiKey}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -133,7 +150,7 @@ async function apiFetch(url, options = {}) {
 
 function encodeValue(value, key = "") {
   if (value === null || value === undefined) return { nullValue: null };
-  if (["date", "weekStart", "createdAt", "savedAt"].includes(key)) return { timestampValue: toTimestamp(value) };
+  if (["date", "weekStart", "createdAt", "savedAt", "expiresAt"].includes(key)) return { timestampValue: toTimestamp(value) };
   if (Array.isArray(value)) return { arrayValue: { values: value.map((item) => encodeValue(item)) } };
   if (typeof value === "boolean") return { booleanValue: value };
   if (typeof value === "number") return Number.isInteger(value) ? { integerValue: value } : { doubleValue: value };
@@ -279,18 +296,52 @@ async function enterApp() {
 }
 
 function setAuthMode(mode) {
-  $("#loginForm").classList.toggle("hidden", mode !== "login");
-  $("#signupForm").classList.toggle("hidden", mode !== "signup");
-  $("#loginTab").classList.toggle("active", mode === "login");
-  $("#signupTab").classList.toggle("active", mode === "signup");
+  const selectedMode = authCopy[mode] ? mode : "login";
+  $("#loginForm").classList.toggle("hidden", selectedMode !== "login");
+  $("#signupForm").classList.toggle("hidden", selectedMode !== "signup");
+  $("#resetForm").classList.toggle("hidden", selectedMode !== "reset");
+  $$('[data-auth-mode]').forEach((button) => {
+    const isActive = button.dataset.authMode === selectedMode && button.classList.contains("segment");
+    button.classList.toggle("active", isActive);
+    if (button.classList.contains("segment")) button.setAttribute("aria-selected", String(isActive));
+  });
+  $("#authHeadline").textContent = authCopy[selectedMode].headline;
+  $("#authLead").textContent = authCopy[selectedMode].lead;
+  if (selectedMode === "reset" && !$("#resetEmail").value) $("#resetEmail").value = $("#loginEmail").value.trim();
   setMessage("");
+}
+
+function emailError(email) {
+  if (!email) return "Email is required.";
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? "" : "Enter a valid email address.";
+}
+
+function requiredError(value, label) {
+  return value.trim() ? "" : `Please enter your ${label}.`;
+}
+
+function passwordError(password, minimum = 8) {
+  if (!password) return "Password is required.";
+  return password.length >= minimum ? "" : `Password must be at least ${minimum} characters.`;
+}
+
+function requireValid(errors) {
+  const message = errors.find(Boolean);
+  if (message) {
+    setMessage(message);
+    return false;
+  }
+  return true;
 }
 
 async function handleLogin(event) {
   event.preventDefault();
+  const email = $("#loginEmail").value.trim();
+  const password = $("#loginPassword").value;
+  if (!requireValid([emailError(email), passwordError(password, 1)])) return;
   try {
     setMessage("Signing in…");
-    await signIn($("#loginEmail").value.trim(), $("#loginPassword").value);
+    await signIn(email, password);
     setMessage("");
     await enterApp();
     showToast(`Welcome back, ${currentUser.firstName}.`);
@@ -299,21 +350,25 @@ async function handleLogin(event) {
 
 async function handleSignup(event) {
   event.preventDefault();
+  const payload = { firstName: $("#signupFirstName").value.trim(), lastName: $("#signupLastName").value.trim(), email: $("#signupEmail").value.trim(), position: $("#signupPosition").value, password: $("#signupPassword").value };
+  if (!requireValid([requiredError(payload.firstName, "first name"), requiredError(payload.lastName, "last name"), emailError(payload.email), passwordError(payload.password)])) return;
   try {
     setMessage("Creating account…");
-    await signUp({ firstName: $("#signupFirstName").value.trim(), lastName: $("#signupLastName").value.trim(), email: $("#signupEmail").value.trim(), position: $("#signupPosition").value, password: $("#signupPassword").value });
+    await signUp(payload);
     setMessage("");
     await enterApp();
     showToast("Account created and synced.");
   } catch (error) { setMessage(error.message); }
 }
 
-async function resetPassword() {
-  const email = $("#loginEmail").value.trim();
-  if (!email) { setMessage("Enter your email first, then request a reset."); return; }
+async function resetPassword(event) {
+  event?.preventDefault();
+  const email = $("#resetEmail").value.trim() || $("#loginEmail").value.trim();
+  if (!requireValid([emailError(email)])) return;
   try {
+    setMessage("Sending reset link…");
     await authRequest("accounts:sendOobCode", { requestType: "PASSWORD_RESET", email });
-    setMessage(`Password reset instructions were sent to ${email}.`);
+    setMessage(`Check ${email} for reset instructions.`);
   } catch (error) { setMessage(error.message); }
 }
 
@@ -410,9 +465,11 @@ function jobCard(job, withActions = false) {
       option.value = status; option.textContent = status; option.selected = status === job.status; select.append(option);
     });
     select.addEventListener("change", () => updateJob(job.id, { status: select.value }));
+    const share = document.createElement("button");
+    share.className = "button secondary"; share.type = "button"; share.textContent = "Share"; share.addEventListener("click", () => shareJob(job.id));
     const remove = document.createElement("button");
     remove.className = "button danger"; remove.type = "button"; remove.textContent = "Remove"; remove.addEventListener("click", () => removeJob(job.id));
-    actions.append(select, remove); item.append(actions);
+    actions.append(select, share, remove); item.append(actions);
   }
   return item;
 }
@@ -435,6 +492,31 @@ async function removeJob(id) {
   await loadAppData();
   renderAll();
   showToast("Job removed.");
+}
+
+async function shareJob(id) {
+  const job = appState.jobs.find((item) => item.id === id);
+  if (!job) return;
+  try {
+    const token = randomToken();
+    const senderName = `${currentUser.firstName || ""} ${currentUser.lastName || ""}`.trim() || currentUser.email || currentUser.id;
+    const senderIsCan = (currentUser.position || "").toLowerCase() === "can";
+    await setDoc("sharedJobs", token, {
+      v: 2,
+      createdAt: new Date().toISOString(),
+      expiresAt: addDays(toInputDate(new Date()), 7),
+      fromUserId: currentUser.id,
+      fromUserName: senderName,
+      address: job.address,
+      date: job.date,
+      status: job.status,
+      jobNumber: job.jobNumber || "",
+      assignment: senderIsCan ? job.assignments || "" : "",
+      senderIsCan,
+    });
+    await copyText(`jobtracker://importJob?token=${token}`, `shared-job-${job.jobNumber || token}.txt`);
+    showToast("Share link copied. It expires in 7 days.");
+  } catch (error) { showToast(error.message); }
 }
 
 async function handleJobSubmit(event) {
@@ -585,7 +667,7 @@ function hydrateUserForms() {
   $("#signedInRole").textContent = currentUser.position || "Technician";
   $("#profileFirstName").value = currentUser.firstName || "";
   $("#profileLastName").value = currentUser.lastName || "";
-  $("#profilePosition").value = currentUser.position || "Technician";
+  $("#profilePosition").value = currentUser.position || "Aerial";
   $("#profileEmail").value = currentUser.email || authSession.email || "";
   $("#profilePhone").value = currentUser.phone || "";
   $("#profileYard").value = currentUser.yard || "";
@@ -695,7 +777,7 @@ function bindEvents() {
   $$('[data-auth-mode]').forEach((button) => button.addEventListener("click", () => setAuthMode(button.dataset.authMode)));
   $("#loginForm").addEventListener("submit", handleLogin);
   $("#signupForm").addEventListener("submit", handleSignup);
-  $("#resetPasswordButton").addEventListener("click", resetPassword);
+  $("#resetForm").addEventListener("submit", resetPassword);
   $("#signOutButton").addEventListener("click", logout);
   $$('[data-route]').forEach((button) => button.addEventListener("click", (event) => { event.preventDefault(); navigate(button.dataset.route); }));
   $$('[data-focus-job-form]').forEach((button) => button.addEventListener("click", () => $("#jobNumberInput").focus()));
@@ -725,7 +807,7 @@ function initializeInputs() {
 async function bootstrap() {
   bindEvents();
   initializeInputs();
-  if (!config?.apiKey || !config?.projectId) { setMessage("Firebase config is missing. Update website/config.js before signing in."); return; }
+  if (!config?.apiKey || !config?.projectId) { setMessage("Firebase config is missing. Update website/app/config.js before signing in."); return; }
   if (!authSession?.refreshToken) return;
   try { await refreshTokenIfNeeded(); await loadCurrentUser(); await enterApp(); }
   catch (error) { clearSession(); showAuth(); setMessage(error.message); }

--- a/website/app/styles.css
+++ b/website/app/styles.css
@@ -52,11 +52,15 @@ a { color: inherit; }
   box-shadow: var(--shadow);
 }
 .auth-copy, .auth-panel { padding: clamp(1.5rem, 5vw, 3rem); }
-.auth-copy { background: linear-gradient(135deg, rgba(98, 213, 255, 0.18), transparent); }
+.auth-copy { display: grid; align-content: center; background: linear-gradient(135deg, rgba(98, 213, 255, 0.18), transparent); }
+.auth-panel { align-self: center; }
 .auth-copy h1, .page-heading h1, .hero h1 { margin: 0.4rem 0 1rem; letter-spacing: -0.06em; line-height: 0.95; }
 .auth-copy h1 { font-size: clamp(2.8rem, 7vw, 5rem); }
 .auth-copy p, .page-heading p, .hero p, .feature-card p, .workspace-card p, .compact-item span { color: var(--muted); line-height: 1.65; }
 .auth-form { display: grid; gap: 0.9rem; margin-top: 1.2rem; }
+.auth-segmented { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); width: 100%; border-radius: 1.2rem; }
+.helper-text { margin: -0.2rem 0 0; color: var(--muted); font-size: 0.9rem; }
+.position-picker select { margin-top: 0.15rem; }
 
 .app-shell {
   display: grid;
@@ -152,6 +156,7 @@ a { color: inherit; }
 .button.danger { background: rgba(255, 122, 144, 0.18); color: var(--danger); border: 1px solid rgba(255, 122, 144, 0.35); }
 .full-width { width: 100%; }
 .link-button { border: 0; background: transparent; color: var(--accent); font-weight: 800; text-align: left; }
+.link-button:hover, .link-button:focus-visible { color: var(--text); text-decoration: underline; }
 .hero-panel { display: grid; align-content: center; gap: 1.2rem; padding: 1.5rem; background: var(--card-strong); }
 .hero-panel strong { font-size: 4rem; letter-spacing: -0.07em; }
 .progress-track { height: 0.8rem; overflow: hidden; border-radius: 999px; background: rgba(255, 255, 255, 0.12); }
@@ -254,4 +259,20 @@ input:focus, select:focus, textarea:focus { border-color: var(--accent); box-sha
   .job-item, .compact-item { grid-template-columns: 1fr; }
   .job-actions { justify-content: flex-start; }
   .more-tabs, .segmented { width: 100%; display: grid; grid-template-columns: 1fr; border-radius: 1.2rem; }
+}
+
+.share-import-form { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.8rem; align-items: end; }
+.profile-shortcuts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin-top: 1rem; }
+.shortcut-card { display: grid; gap: 0.35rem; padding: 1rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,0.05); text-align: left; color: var(--text); }
+.shortcut-card strong { font-size: 1.5rem; }
+.job-detail-dialog { width: min(94vw, 920px); border: 1px solid var(--line); border-radius: 1.5rem; padding: 0; background: transparent; color: var(--text); }
+.job-detail-dialog::backdrop { background: rgba(3, 8, 16, 0.72); backdrop-filter: blur(8px); }
+.job-detail-panel { display: grid; gap: 1rem; padding: clamp(1rem, 4vw, 1.5rem); background: var(--card-strong); box-shadow: var(--shadow); }
+.detail-actions { display: flex; flex-wrap: wrap; gap: 0.7rem; justify-content: flex-end; }
+.job-item h3 button { border: 0; padding: 0; background: transparent; color: inherit; font: inherit; text-align: left; cursor: pointer; }
+.job-item h3 button:hover, .job-item h3 button:focus-visible { color: var(--accent); text-decoration: underline; }
+
+@media (max-width: 760px) {
+  .share-import-form, .profile-shortcuts { grid-template-columns: 1fr; }
+  .detail-actions { justify-content: flex-start; }
 }


### PR DESCRIPTION
### Motivation

- Bring the Firebase-backed web UI closer to the native iOS flow by aligning authentication UX, adding a first-class job detail editor, expanding sharing/import flows, and surfacing profile shortcuts.
- Document the parity plan and follow-up implementation notes so this follow-up PR can merge cleanly over the already-merged baseline plan.

### Description

- Add `PARITY_PLAN.md` and `PARITY_IMPLEMENTATION_NOTES.md` to document the parity audit, completed follow-ups, and remaining work.
- Update `index.html` to replace the auth copy and controls with a three-way segmented auth UI (Sign In / Sign Up / Reset), add a shared-job import preview card, a profile shortcuts container, and a modal `dialog` for detailed job editing/route/share/remove actions, and include new `parity-enhancements.js` script.
- Add `parity-enhancements.js` which extends existing client behavior: job-detail open/edit/save/remove, status hydration, shared-job preview/import/claiming, URL token hydration, profile shortcuts rendering, and event bindings to integrate these features with the existing app state and Firebase back-end flows.
- Modify `script.js` to harden config checks, add client-side validation and improved auth flows, implement share token generation and `shareJob` creation that writes `sharedJobs` payloads and copies `jobtracker://importJob?token=...`, extend Firestore encoding for extra timestamp keys, add UI plumbing (auth state handling, profile defaults), and wire share buttons on job cards.
- Update `styles.css` with new UI styles for segmented controls, share-import form, profile shortcuts, job-detail dialog, and other visual tweaks to match the native glass-card / compact layout approach.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce41822e0832da1f9b1cd594970f8)