### PR TITLE
Replace web sidebar with bottom tab navigation

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -68,32 +68,6 @@
     </div>
 
     <div id="appShell" class="app-shell hidden">
-      <aside class="sidebar" aria-label="Primary">
-        <a class="brand" href="#dashboard" data-route="dashboard" aria-label="Job Tracker dashboard">
-          <span class="brand-mark">JT</span>
-          <span>
-            <strong>Job Tracker</strong>
-            <small id="signedInRole">Web workspace</small>
-          </span>
-        </a>
-
-        <nav class="nav-links" aria-label="Workspace sections">
-          <button class="nav-link active" type="button" data-route="dashboard">Dashboard</button>
-          <button class="nav-link" type="button" data-route="timesheets">Timesheets</button>
-          <button class="nav-link" type="button" data-route="yellowSheets">Yellow Sheets</button>
-          <button class="nav-link" type="button" data-route="search">Job Search</button>
-          <button class="nav-link" type="button" data-route="more">More</button>
-        </nav>
-
-        <div class="sidebar-card">
-          <small>Today</small>
-          <strong id="sidebarDate">Loading...</strong>
-          <span id="sidebarSummary">0 jobs scheduled</span>
-        </div>
-
-        <button class="button ghost full-width" id="signOutButton" type="button">Sign out</button>
-      </aside>
-
       <main class="content">
         <section class="view active" id="dashboardView" data-view="dashboard">
           <header class="hero">
@@ -244,7 +218,13 @@
           </section>
 
           <section class="workspace-card more-panel active" id="profilePanel" data-more-panel="profile">
-            <div class="section-heading"><div><p class="eyebrow">Profile</p><h2>Account details</h2></div><button class="button secondary" id="saveProfileButton" type="button">Save profile</button></div>
+            <div class="section-heading">
+              <div><p class="eyebrow">Profile</p><h2>Account details</h2></div>
+              <div class="detail-actions">
+                <button class="button secondary" id="saveProfileButton" type="button">Save profile</button>
+                <button class="button ghost" id="signOutButton" type="button">Sign out</button>
+              </div>
+            </div>
             <div class="form-grid three">
               <label>First name<input id="profileFirstName" /></label>
               <label>Last name<input id="profileLastName" /></label>
@@ -281,6 +261,29 @@
           </section>
         </section>
       </main>
+
+      <nav class="bottom-tab-bar" aria-label="Primary">
+        <button class="tab-button active" type="button" data-route="dashboard" aria-label="Dashboard" data-symbol="rectangle.grid.2x2">
+          <span class="tab-symbol" aria-hidden="true">▦</span>
+          <span class="tab-label">Dashboard</span>
+        </button>
+        <button class="tab-button" type="button" data-route="timesheets" aria-label="Timesheets" data-symbol="clock">
+          <span class="tab-symbol" aria-hidden="true">◷</span>
+          <span class="tab-label">Timesheets</span>
+        </button>
+        <button class="tab-button" type="button" data-route="yellowSheets" aria-label="Yellow Sheet" data-symbol="doc.text">
+          <span class="tab-symbol" aria-hidden="true">▤</span>
+          <span class="tab-label">Yellow Sheet</span>
+        </button>
+        <button class="tab-button" type="button" data-route="search" aria-label="Job Search" data-symbol="magnifyingglass">
+          <span class="tab-symbol" aria-hidden="true">⌕</span>
+          <span class="tab-label">Job Search</span>
+        </button>
+        <button class="tab-button" type="button" data-route="more" aria-label="More" data-symbol="ellipsis.circle">
+          <span class="tab-symbol" aria-hidden="true">⋯</span>
+          <span class="tab-label">More</span>
+        </button>
+      </nav>
     </div>
 
     <dialog class="job-detail-dialog" id="jobDetailDialog" aria-labelledby="jobDetailTitle">

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -380,10 +380,6 @@ function logout() {
   showToast("Signed out.");
 }
 
-function renderDate() {
-  $("#sidebarDate").textContent = dateLabel(toInputDate(new Date()), { weekday: "long", month: "short", day: "numeric" });
-}
-
 function selectedJobs() {
   return appState.jobs.filter((job) => job.date === selectedDate);
 }
@@ -419,7 +415,6 @@ function renderDashboard() {
   const partner = appState.partnerRequests.find((request) => request.status === "accepted");
 
   $("#dashboardGreeting").textContent = `Hi ${currentUser.firstName}, here is ${dateLabel(selectedDate)}. Updates save to Firebase and stay aligned with the native app collections.`;
-  $("#sidebarSummary").textContent = `${jobs.length} jobs on selected day`;
   $("#totalCount").textContent = jobs.length;
   $("#pendingCount").textContent = pending.length;
   $("#doneCount").textContent = done.length;
@@ -664,7 +659,6 @@ function renderSearch() {
 }
 
 function hydrateUserForms() {
-  $("#signedInRole").textContent = currentUser.position || "Technician";
   $("#profileFirstName").value = currentUser.firstName || "";
   $("#profileLastName").value = currentUser.lastName || "";
   $("#profilePosition").value = currentUser.position || "Aerial";
@@ -764,7 +758,6 @@ function navigate(route) {
 
 function renderAll() {
   if (!currentUser) return;
-  renderDate();
   renderWeekdayPicker();
   renderDashboard();
   renderTimesheet();

--- a/website/app/styles.css
+++ b/website/app/styles.css
@@ -64,22 +64,9 @@ a { color: inherit; }
 
 .app-shell {
   display: grid;
-  grid-template-columns: 18rem minmax(0, 1fr);
   min-height: 100vh;
+  padding-bottom: calc(5.75rem + env(safe-area-inset-bottom));
 }
-.sidebar {
-  position: sticky;
-  top: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  height: 100vh;
-  padding: 2rem;
-  border-right: 1px solid var(--line);
-  background: rgba(8, 17, 31, 0.8);
-  backdrop-filter: blur(20px);
-}
-.brand { display: flex; align-items: center; gap: 0.85rem; text-decoration: none; }
 .brand-mark {
   display: grid;
   width: 3rem;
@@ -91,7 +78,7 @@ a { color: inherit; }
   color: #04111f;
   font-weight: 900;
 }
-.brand small, .sidebar-card small, .metric-label, .eyebrow {
+.metric-label, .eyebrow {
   display: block;
   color: var(--muted);
   font-size: 0.78rem;
@@ -99,30 +86,53 @@ a { color: inherit; }
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-.nav-links { display: grid; gap: 0.55rem; }
-.nav-link {
-  width: 100%;
-  padding: 0.85rem 1rem;
-  border: 1px solid transparent;
-  border-radius: 1rem;
-  background: transparent;
-  color: var(--muted);
-  text-align: left;
-}
-.nav-link:hover, .nav-link:focus-visible, .nav-link.active {
-  border-color: var(--line);
-  background: rgba(255, 255, 255, 0.07);
-  color: var(--text);
-}
-.sidebar-card, .workspace-card, .feature-card, .hero-panel, .sync-banner, .weekday-picker {
+.workspace-card, .feature-card, .hero-panel, .sync-banner, .weekday-picker {
   border: 1px solid var(--line);
   border-radius: 1.5rem;
   background: var(--card);
   box-shadow: var(--shadow);
 }
-.sidebar-card { display: grid; gap: 0.35rem; padding: 1rem; margin-top: auto; }
 .content { display: grid; gap: 1.5rem; width: min(100%, 1220px); margin: 0 auto; padding: 2rem; }
+.view:not(.active) { display: none !important; }
+.view.active { display: grid !important; }
 .view { gap: 1.5rem; }
+
+.bottom-tab-bar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.25rem;
+  padding: 0.5rem max(0.75rem, env(safe-area-inset-left)) calc(0.5rem + env(safe-area-inset-bottom)) max(0.75rem, env(safe-area-inset-right));
+  border-top: 1px solid var(--line);
+  background: rgba(8, 17, 31, 0.9);
+  box-shadow: 0 -16px 40px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(20px);
+}
+.tab-button {
+  display: grid;
+  justify-items: center;
+  gap: 0.2rem;
+  min-width: 0;
+  min-height: 3.8rem;
+  padding: 0.4rem 0.2rem;
+  border: 0;
+  border-radius: 1rem;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 800;
+}
+.tab-button:hover, .tab-button:focus-visible, .tab-button.active {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+.tab-button.active .tab-symbol { color: var(--accent); }
+.tab-symbol { font-size: 1.35rem; line-height: 1; }
+.tab-label { overflow: hidden; max-width: 100%; text-overflow: ellipsis; white-space: nowrap; font-size: 0.72rem; }
 
 .hero {
   display: grid;
@@ -240,25 +250,23 @@ input:focus, select:focus, textarea:focus { border-color: var(--accent); box-sha
 .segment { border: 0; border-radius: 999px; padding: 0.65rem 1rem; background: transparent; color: var(--muted); font-weight: 850; }
 .segment.active { background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #04111f; }
 .form-message { min-height: 1.4rem; color: var(--warning); }
-.toast { position: fixed; right: 1rem; bottom: 1rem; z-index: 5; transform: translateY(140%); max-width: 28rem; padding: 0.9rem 1rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--card-strong); box-shadow: var(--shadow); color: var(--text); transition: transform 180ms ease; }
+.toast { position: fixed; right: 1rem; bottom: calc(6.25rem + env(safe-area-inset-bottom)); z-index: 11; transform: translateY(140%); max-width: 28rem; padding: 0.9rem 1rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--card-strong); box-shadow: var(--shadow); color: var(--text); transition: transform 180ms ease; }
 .toast.show { transform: translateY(0); }
 
 @media (max-width: 1120px) {
-  .app-shell, .hero, .section-grid, .section-grid.four, .two-column, .job-form, .partner-form, .settings-grid { grid-template-columns: 1fr; }
-  .sidebar { position: static; height: auto; border-right: 0; border-bottom: 1px solid var(--line); }
-  .nav-links { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-  .nav-link { text-align: center; }
+  .hero, .section-grid, .section-grid.four, .two-column, .job-form, .partner-form, .settings-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 760px) {
   .auth-card, .form-grid.two, .form-grid.three, .checklist, .weekday-picker { grid-template-columns: 1fr; }
-  .content, .sidebar, .auth-screen { padding: 1rem; }
+  .content, .auth-screen { padding: 1rem; }
   .hero { min-height: auto; padding: 1.3rem; }
   .hero h1 { font-size: 2.8rem; }
   .hero-panel strong { font-size: 3rem; }
-  .metric-grid, .nav-links { grid-template-columns: 1fr; }
+  .metric-grid { grid-template-columns: 1fr; }
   .job-item, .compact-item { grid-template-columns: 1fr; }
   .job-actions { justify-content: flex-start; }
   .more-tabs, .segmented { width: 100%; display: grid; grid-template-columns: 1fr; border-radius: 1.2rem; }
+  .tab-label { font-size: 0.65rem; }
 }
 
 .share-import-form { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.8rem; align-items: end; }


### PR DESCRIPTION
### Motivation
- Move the authenticated shell from a desktop-focused sidebar to a mobile-friendly bottom tab bar that matches the native app's primary destinations and SF Symbol semantics.
- Remove sidebar-only UI pieces (workspace brand/role, `sidebarDate`, `sidebarSummary`, and sign-out placement) from the primary layout so the main content and navigation are consistent across form factors.

### Description
- Removed the `<aside class="sidebar">` block from `website/app/index.html` and added a fixed `<nav class="bottom-tab-bar">` with five tab buttons using `data-route` values `dashboard`, `timesheets`, `yellowSheets`, `search`, and `more` and SF Symbol equivalents via `data-symbol` attributes. 
- Moved the sign-out button into the More/Profile panel header in `website/app/index.html` and updated the profile header markup to include the sign-out control alongside the profile save button.
- Cleaned up `website/app/script.js` to stop updating removed sidebar elements by removing `renderDate`, `#sidebarSummary` and `#signedInRole` DOM updates and removing `renderDate()` from `renderAll()`, while keeping the existing `navigate(route)` routing and `data-route` bindings intact.
- Updated `website/app/styles.css` to hide inactive `.view` sections (`.view:not(.active) { display: none !important; }`), add styles for a fixed `.bottom-tab-bar` with safe-area padding, style `.tab-button` states and symbols, and move the toast position above the tab bar; also removed sidebar-specific layout CSS.

### Testing
- Ran `node --check website/app/script.js` and it completed with no syntax errors.
- Executed an HTML parser assertion script that verified the sidebar was removed, the bottom tab bar contains the five expected `data-route`/`data-symbol` pairs, and that `sidebarDate`, `sidebarSummary`, and `signedInRole` are no longer present; the assertions passed (`Navigation markup assertions passed`).
- Ran `git diff --check` to ensure no whitespace/merge issues; it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd93a9260832dacf2d0804127f4e7)