### PR TITLE
Add native-aligned Dashboard Create Job panel

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -105,7 +105,7 @@
                 smart routing hints, sync status, quick job actions, and shareable summaries.
               </p>
               <div class="hero-actions">
-                <button class="button primary" type="button" data-focus-job-form>Add job</button>
+                <button class="button primary" id="openCreateJobButton" type="button" data-open-create-job>+ Create Job</button>
                 <button class="button secondary" id="shareDailySummaryButton" type="button">Share day summary</button>
                 <button class="button secondary" id="downloadDailySummaryButton" type="button">Download summary</button>
               </div>
@@ -138,26 +138,13 @@
             <article class="feature-card"><span class="icon">👥</span><h2 id="partnerStatus">No partner</h2><p>Current partner request or active crew pairing.</p></article>
           </section>
 
-          <section class="workspace-card">
+          <section class="workspace-card create-job-launcher">
             <div class="section-heading">
               <div><p class="eyebrow">Create job</p><h2>Daily job entry</h2></div>
               <button class="button secondary" id="refreshJobsButton" type="button">Refresh jobs</button>
             </div>
-            <form class="job-form" id="jobForm">
-              <label>Job #<input id="jobNumberInput" name="jobNumber" placeholder="JT-1042" required /></label>
-              <label>Address<input id="addressInput" name="address" placeholder="123 Fiber Rd" required /></label>
-              <label>Scheduled date<input id="scheduledDateInput" name="scheduledDate" type="date" required /></label>
-              <label>
-                Type
-                <select id="typeInput" name="type"><option>Install</option><option>Repair</option><option>Survey</option><option>Maintenance</option><option>Splice</option></select>
-              </label>
-              <label>
-                Status
-                <select id="statusInput" name="status"><option>Pending</option><option>In Progress</option><option>Needs Ariel</option><option>Needs Underground</option><option>Needs Nid</option><option>Needs Can</option><option>Done</option><option>Talk to Rick</option></select>
-              </label>
-              <label>Crew note<input id="noteInput" name="note" placeholder="Gate code, splice count, material needs" /></label>
-              <button class="button primary" type="submit">Save job</button>
-            </form>
+            <p>Open the native-aligned Create Job panel to add addresses, date, status, assignments, materials, and notes.</p>
+            <button class="button primary" type="button" data-open-create-job>+ Create Job</button>
           </section>
 
           <section class="two-column">
@@ -282,6 +269,73 @@
         </section>
       </main>
     </div>
+
+
+    <section class="create-job-modal hidden" id="createJobModal" role="dialog" aria-modal="true" aria-labelledby="createJobTitle">
+      <div class="create-job-panel">
+        <form class="create-job-form" id="createJobForm">
+          <div class="create-job-topbar">
+            <button class="link-button" type="button" id="closeCreateJobButton">Close</button>
+            <h2 id="createJobTitle">Create Job</h2>
+            <button class="link-button" type="submit">Save</button>
+          </div>
+
+          <div class="create-job-content">
+            <section class="create-section-card" aria-labelledby="createAddressTitle">
+              <h3 id="createAddressTitle">Address</h3>
+              <div class="address-stack" id="createAddressList">
+                <label class="sr-only" for="createAddressInput0">Address</label>
+                <input id="createAddressInput0" name="address" placeholder="Enter address" autocomplete="street-address" required />
+              </div>
+              <button class="link-button add-address-button" id="addCreateAddressButton" type="button">+ Add Another Address</button>
+            </section>
+
+            <section class="create-section-card" aria-labelledby="createDateTitle">
+              <h3 id="createDateTitle">Date</h3>
+              <div class="date-picker-row">
+                <label>Select Date<input id="createDateInput" name="scheduledDate" type="date" required /></label>
+                <span class="date-chip" id="createDateChip">Selected date</span>
+              </div>
+            </section>
+
+            <section class="create-section-card status-card" aria-labelledby="createStatusTitle">
+              <h3 id="createStatusTitle">Status</h3>
+              <div class="segmented status-picker" role="radiogroup" aria-label="Job status">
+                <label class="segment"><input type="radio" name="status" value="Pending" checked />Pending</label>
+                <label class="segment"><input type="radio" name="status" value="Done" />Done</label>
+              </div>
+            </section>
+
+            <section class="create-section-card" aria-labelledby="createJobNumberTitle">
+              <h3 id="createJobNumberTitle">Job Number *</h3>
+              <label class="sr-only" for="createJobNumberInput">Job Number</label>
+              <input id="createJobNumberInput" name="jobNumber" placeholder="Required" autocomplete="off" required />
+            </section>
+
+            <section class="create-section-card" aria-labelledby="createAssignmentsTitle">
+              <h3 id="createAssignmentsTitle">Assignments</h3>
+              <label class="sr-only" for="createAssignmentsInput">Assignments</label>
+              <input id="createAssignmentsInput" name="assignments" inputmode="decimal" placeholder="e.g. 12.3.2" autocomplete="off" />
+              <p class="helper-text">Digits and dots only • examples: 12.3.2, 123.2.4</p>
+            </section>
+
+            <section class="create-section-card" aria-labelledby="createMaterialsTitle">
+              <h3 id="createMaterialsTitle">Materials Used</h3>
+              <label class="sr-only" for="createMaterialsInput">Materials Used</label>
+              <input id="createMaterialsInput" name="materialsUsed" placeholder="Enter materials info…" />
+            </section>
+
+            <section class="create-section-card" aria-labelledby="createNotesTitle">
+              <h3 id="createNotesTitle">Notes</h3>
+              <label class="sr-only" for="createNotesInput">Notes</label>
+              <textarea id="createNotesInput" name="notes" rows="5"></textarea>
+            </section>
+
+            <button class="button primary create-save-button" type="submit">✓ Save Job</button>
+          </div>
+        </form>
+      </div>
+    </section>
 
     <dialog class="job-detail-dialog" id="jobDetailDialog" aria-labelledby="jobDetailTitle">
       <form class="job-detail-panel" id="jobDetailForm" method="dialog">

--- a/website/app/parity-enhancements.js
+++ b/website/app/parity-enhancements.js
@@ -229,7 +229,7 @@ async function importSharedJob(token, payload) {
   await setDoc("jobs", job.id, job);
   await setDoc("sharedJobs", token, { ...payload, claimedBy: currentUser.id, claimedAt: new Date().toISOString() });
   selectedDate = job.date;
-  $("#scheduledDateInput").value = selectedDate;
+  updateCreateDateInput(selectedDate);
   $("#shareImportPreview").innerHTML = "";
   $("#shareTokenInput").value = "";
   await loadAppData();

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -13,6 +13,7 @@ let authSession = readSession();
 let selectedDate = workdayForToday();
 let appState = { jobs: [], users: [], timesheets: {}, yellowSheets: {}, partnerRequests: [] };
 let currentMoreTab = "profile";
+let createAddressCount = 1;
 
 const authCopy = {
   login: { headline: "Welcome Back", lead: "Sign in with the credentials you use across the Job Tracker apps." },
@@ -402,7 +403,7 @@ function renderWeekdayPicker() {
     button.className = `day-button ${date === selectedDate ? "active" : ""}`.trim();
     button.type = "button";
     button.innerHTML = `<strong>${shortDays[index]}</strong><span>${dateLabel(date, { month: "short", day: "numeric" })}</span><small>${jobs.length} jobs</small>`;
-    button.addEventListener("click", () => { selectedDate = date; $("#scheduledDateInput").value = selectedDate; renderAll(); });
+    button.addEventListener("click", () => { selectedDate = date; updateCreateDateInput(selectedDate); renderAll(); });
     picker.append(button);
   });
 }
@@ -519,26 +520,124 @@ async function shareJob(id) {
   } catch (error) { showToast(error.message); }
 }
 
+function sanitizeAssignmentValue(raw = "", { allowTrailingDot = false } = {}) {
+  let value = String(raw).trim().replace(/[^0-9.]/g, "");
+  while (value.includes("..")) value = value.replaceAll("..", ".");
+  while (value.startsWith(".")) value = value.slice(1);
+  if (!allowTrailingDot) value = value.replace(/\.+$/g, "");
+  return value.slice(0, 32);
+}
+
+function isValidAssignmentValue(value) {
+  return !value || /^[0-9]+(\.[0-9]+)*$/.test(value);
+}
+
+async function saveJobsFromCreateValues({ addresses, date, status, jobNumber, assignments = "", materialsUsed = "", notes = "" }) {
+  const trimmedAddresses = addresses.map((address) => address.trim()).filter(Boolean);
+  const trimmedJobNumber = jobNumber.trim();
+  const sanitizedAssignments = sanitizeAssignmentValue(assignments);
+
+  if (!trimmedJobNumber) throw new Error("Please enter a Job Number before saving.");
+  if (trimmedAddresses.length === 0) throw new Error("Please enter at least one address before saving.");
+  if (!date) throw new Error("Please select a date before saving.");
+  if (!isValidAssignmentValue(sanitizedAssignments)) throw new Error("Assignments must use digits separated by single dots.");
+
+  const jobs = trimmedAddresses.map((address) => normalizeJob({
+    id: createId(),
+    jobNumber: trimmedJobNumber,
+    address,
+    date,
+    status,
+    assignments: sanitizedAssignments,
+    materialsUsed: materialsUsed.trim(),
+    notes: notes.trim(),
+  }));
+
+  await Promise.all(jobs.map((job) => setDoc("jobs", job.id, job)));
+  selectedDate = date;
+  await loadAppData();
+  renderAll();
+  showToast(jobs.length > 1 ? `${jobs.length} jobs created in Firebase.` : "Job created in Firebase.");
+}
+
 async function handleJobSubmit(event) {
   event.preventDefault();
   const formData = new FormData(event.currentTarget);
-  const job = normalizeJob({
-    id: createId(),
-    jobNumber: formData.get("jobNumber").trim(),
-    address: formData.get("address").trim(),
+  await saveJobsFromCreateValues({
+    addresses: formData.getAll("address"),
     date: formData.get("scheduledDate"),
-    type: formData.get("type"),
-    assignments: formData.get("type"),
     status: formData.get("status"),
-    notes: formData.get("note").trim(),
+    jobNumber: formData.get("jobNumber"),
+    assignments: formData.get("assignments"),
+    materialsUsed: formData.get("materialsUsed"),
+    notes: formData.get("notes"),
   });
-  await setDoc("jobs", job.id, job);
-  selectedDate = job.date;
-  event.currentTarget.reset();
-  $("#scheduledDateInput").value = selectedDate;
-  await loadAppData();
-  renderAll();
-  showToast("Job created in Firebase.");
+}
+
+async function saveJobFromCreatePanel(event) {
+  await handleJobSubmit(event);
+  navigate("dashboard");
+  closeCreateJobPanel();
+  resetCreateJobPanel();
+}
+
+function updateCreateDateChip() {
+  const dateInput = $("#createDateInput");
+  const chip = $("#createDateChip");
+  if (!dateInput || !chip) return;
+  chip.textContent = dateInput.value ? dateLabel(dateInput.value, { weekday: "short", month: "short", day: "numeric" }) : "Select a date";
+}
+
+function updateCreateDateInput(date = selectedDate) {
+  const input = $("#createDateInput");
+  if (!input) return;
+  input.value = date;
+  updateCreateDateChip();
+}
+
+function updateCreateStatusPicker() {
+  $$("#createJobForm .status-picker .segment").forEach((label) => {
+    const input = label.querySelector('input[type="radio"]');
+    label.classList.toggle("active", Boolean(input?.checked));
+  });
+}
+
+function openCreateJobPanel() {
+  updateCreateDateInput(selectedDate);
+  updateCreateStatusPicker();
+  $("#createJobModal").classList.remove("hidden");
+  document.body.classList.add("modal-open");
+  window.setTimeout(() => $("#createAddressInput0")?.focus(), 0);
+}
+
+function closeCreateJobPanel() {
+  $("#createJobModal").classList.add("hidden");
+  document.body.classList.remove("modal-open");
+}
+
+function resetCreateJobPanel() {
+  const form = $("#createJobForm");
+  form.reset();
+  createAddressCount = 1;
+  $("#createAddressList").innerHTML = `<label class="sr-only" for="createAddressInput0">Address</label><input id="createAddressInput0" name="address" placeholder="Enter address" autocomplete="street-address" required />`;
+  updateCreateDateInput(selectedDate);
+  updateCreateStatusPicker();
+}
+
+function addCreateAddressField() {
+  const id = `createAddressInput${createAddressCount}`;
+  const label = document.createElement("label");
+  label.className = "sr-only";
+  label.htmlFor = id;
+  label.textContent = `Address ${createAddressCount + 1}`;
+  const input = document.createElement("input");
+  input.id = id;
+  input.name = "address";
+  input.placeholder = "Enter address";
+  input.autocomplete = "street-address";
+  $("#createAddressList").append(label, input);
+  createAddressCount += 1;
+  input.focus();
 }
 
 function getTimesheet(weekStart) {
@@ -780,8 +879,15 @@ function bindEvents() {
   $("#resetForm").addEventListener("submit", resetPassword);
   $("#signOutButton").addEventListener("click", logout);
   $$('[data-route]').forEach((button) => button.addEventListener("click", (event) => { event.preventDefault(); navigate(button.dataset.route); }));
-  $$('[data-focus-job-form]').forEach((button) => button.addEventListener("click", () => $("#jobNumberInput").focus()));
-  $("#jobForm").addEventListener("submit", (event) => handleJobSubmit(event).catch((error) => showToast(error.message)));
+  $$('[data-open-create-job]').forEach((button) => button.addEventListener("click", openCreateJobPanel));
+  $("#closeCreateJobButton").addEventListener("click", closeCreateJobPanel);
+  $("#addCreateAddressButton").addEventListener("click", addCreateAddressField);
+  $("#createJobForm").addEventListener("submit", (event) => saveJobFromCreatePanel(event).catch((error) => showToast(error.message)));
+  $("#createDateInput").addEventListener("change", updateCreateDateChip);
+  $("#createAssignmentsInput").addEventListener("input", (event) => { event.target.value = sanitizeAssignmentValue(event.target.value, { allowTrailingDot: true }); });
+  $$("#createJobForm .status-picker input").forEach((input) => input.addEventListener("change", updateCreateStatusPicker));
+  $("#createJobModal").addEventListener("click", (event) => { if (event.target.id === "createJobModal") closeCreateJobPanel(); });
+  document.addEventListener("keydown", (event) => { if (event.key === "Escape" && !$("#createJobModal").classList.contains("hidden")) closeCreateJobPanel(); });
   $("#refreshJobsButton").addEventListener("click", () => loadAppData().then(renderAll).then(() => showToast("Jobs refreshed from Firebase.")));
   $("#shareDailySummaryButton").addEventListener("click", () => copyText(dailySummaryText(), `job-tracker-${selectedDate}.txt`));
   $("#downloadDailySummaryButton").addEventListener("click", () => downloadText(`job-tracker-${selectedDate}.txt`, dailySummaryText()));
@@ -799,7 +905,8 @@ function bindEvents() {
 }
 
 function initializeInputs() {
-  $("#scheduledDateInput").value = selectedDate;
+  updateCreateDateInput(selectedDate);
+  updateCreateStatusPicker();
   $("#timesheetWeekInput").value = mondayFor(selectedDate);
   $("#yellowDateInput").value = selectedDate;
 }

--- a/website/app/styles.css
+++ b/website/app/styles.css
@@ -276,3 +276,133 @@ input:focus, select:focus, textarea:focus { border-color: var(--accent); box-sha
   .share-import-form, .profile-shortcuts { grid-template-columns: 1fr; }
   .detail-actions { justify-content: flex-start; }
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+body.modal-open { overflow: hidden; }
+.create-job-launcher { display: grid; gap: 1rem; }
+.create-job-launcher .section-heading { margin-bottom: 0; }
+.create-job-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  background:
+    radial-gradient(circle at 24% 12%, rgba(98, 213, 255, 0.18), transparent 28rem),
+    rgba(3, 8, 16, 0.86);
+  backdrop-filter: blur(20px);
+  overflow-y: auto;
+}
+.create-job-panel {
+  width: min(100%, 760px);
+  min-height: 100vh;
+  margin: 0 auto;
+  background:
+    linear-gradient(135deg, rgba(8, 12, 18, 0.94), rgba(18, 31, 52, 0.9)),
+    radial-gradient(circle at bottom right, rgba(98, 213, 255, 0.16), transparent 24rem);
+  border-inline: 1px solid var(--line);
+  box-shadow: var(--shadow);
+}
+.create-job-form { min-height: 100vh; }
+.create-job-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  padding: max(1rem, env(safe-area-inset-top)) 1.1rem 1rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(8, 17, 31, 0.82);
+  backdrop-filter: blur(18px);
+}
+.create-job-topbar h2 {
+  margin: 0;
+  font-size: 1.08rem;
+  letter-spacing: -0.02em;
+  text-align: center;
+}
+.create-job-topbar .link-button:last-child { justify-self: end; }
+.create-job-content {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem 1rem max(1.5rem, env(safe-area-inset-bottom));
+}
+.create-section-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.2);
+}
+.create-section-card h3 {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.address-stack { display: grid; gap: 0.7rem; }
+.add-address-button { width: fit-content; padding: 0; }
+.date-picker-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 0.8rem;
+}
+.date-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  padding: 0 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(98, 213, 255, 0.12);
+  color: var(--text);
+  font-weight: 850;
+  white-space: nowrap;
+}
+.status-card {
+  justify-self: center;
+  width: min(100%, 24rem);
+  text-align: center;
+}
+.status-picker {
+  justify-self: center;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: min(100%, 18rem);
+}
+.status-picker .segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+.status-picker .segment input { position: absolute; opacity: 0; pointer-events: none; }
+.status-picker .segment.active { background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #04111f; }
+.create-save-button {
+  width: 100%;
+  min-height: 3.3rem;
+  border-radius: 1rem;
+  font-size: 1rem;
+}
+@media (max-width: 760px) {
+  .create-job-panel { width: 100%; border-inline: 0; }
+  .create-job-topbar { padding-inline: 0.9rem; }
+  .date-picker-row { grid-template-columns: 1fr; }
+  .date-chip { justify-content: center; }
+}


### PR DESCRIPTION
### Motivation
- Replace the cramped inline Dashboard `#jobForm` with a native-aligned Create Job panel so web UX matches the iOS `CreateJobView` layout and flow.
- Support multi-address job creation and reuse the existing save/write path so created jobs remain compatible with the Firestore-native data model.
- Make the create flow modal, focused, and route back to the Dashboard after save while refreshing the selected day’s job list.

### Description
- Removed the inline dashboard creation form and launcher the inline action to `+ Create Job` in `website/app/index.html`, and added a compact launcher card. (`create-job-launcher`)
- Added a full-screen modal in `website/app/index.html` with id `createJobModal` and form `createJobForm` containing the requested structure: top bar (`Close`, centered `Create Job`, `Save`), `ADDRESS` card with `Add Another Address`, `DATE` card with a date chip, centered `STATUS` picker (Pending/Done), required `JOB NUMBER *`, `ASSIGNMENTS` with digits/dots helper text, `MATERIALS USED`, `NOTES`, and bottom `Save Job` button.
- Implemented create-panel behavior in `website/app/script.js`, including `saveJobsFromCreateValues()` (shared multi-address save path), `saveJobFromCreatePanel()`, `openCreateJobPanel()`, `closeCreateJobPanel()`, `resetCreateJobPanel()`, `addCreateAddressField()`, `updateCreateDateInput()`/`updateCreateDateChip()`, `updateCreateStatusPicker()`, and assignment sanitization helpers (`sanitizeAssignmentValue`, `isValidAssignmentValue`).
- Wired modal open/close/add-address/date/status/save interactions into the existing `bindEvents()` flow and updated date initialization to use the new create-panel helpers; updated shared import path in `website/app/parity-enhancements.js` to call `updateCreateDateInput()`.
- Added responsive styles and accessibility helpers in `website/app/styles.css` (sr-only, modal layout, top bar, section cards, date chip, centered status picker, bottom save button).
- Kept the existing Firestore `setDoc("jobs", ...)` usage and `loadAppData()`/`renderAll()` calls so the Dashboard refreshes the selected day after saving and navigates back to the dashboard view.

### Testing
- Ran `node --check website/app/script.js` and `node --check website/app/parity-enhancements.js` to validate JS syntax; both checks passed.
- Ensured the old inline selectors/form are removed by verifying `rg -n "jobForm|jobNumberInput|scheduledDateInput|addressInput|statusInput|typeInput|noteInput|data-focus-job-form"` across the modified files; verification passed.
- Started a simple static server and fetched the app HTML with `python3 -m http.server 8000 --directory website` and `curl -fsS http://127.0.0.1:8000/app/` to confirm the new modal markup is served; the page contained `createJobModal`, `+ Create Job`, and `createJobForm` as expected.
- Attempted automated screenshot capture, but no local browser/screenshot binary (Chromium/Chrome/Playwright/wkhtmltoimage) is available in this environment, so screenshot verification was not performed (not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd93cced8832d9855ea504b3e6959)