### PR TITLE
Align web Job Search with native iOS flow

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -217,21 +217,11 @@
         </section>
 
         <section class="view" id="searchView" data-view="search">
-          <div class="page-heading"><p class="eyebrow">Job Search</p><h1>Address-aware job index</h1><p>Search by job number, address, type, status, date, or crew note, then inspect and update matching jobs.</p></div>
-          <section class="workspace-card">
-            <label class="search-box">Search jobs<input id="jobSearchInput" placeholder="Try: Maple, JT-1001, pending, splice, 2026-05-07" /></label>
-            <div class="job-list" id="searchResults"></div>
-          </section>
-
-          <section class="workspace-card">
-            <div class="section-heading">
-              <div><p class="eyebrow">Shared jobs</p><h2>Import shared job link</h2></div>
-            </div>
-            <form class="share-import-form" id="shareImportForm">
-              <label>Token or link<input id="shareTokenInput" placeholder="jobtracker://importJob?token=..." /></label>
-              <button class="button primary" type="submit">Preview import</button>
-            </form>
-            <div class="compact-list" id="shareImportPreview"></div>
+          <div class="page-heading"><p class="eyebrow">Job Search</p><h1>Job Search</h1><p>Look up any job across Cable South in seconds.</p></div>
+          <section class="workspace-card search-workspace">
+            <label class="search-box">Search jobs<input id="jobSearchInput" placeholder="Address, job #, status, or teammate" /></label>
+            <div class="quick-filters" id="searchQuickFilters" aria-label="Quick filters"></div>
+            <div class="job-list search-results" id="searchResults"></div>
           </section>
         </section>
 

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -657,10 +657,225 @@ function dailySummaryText() { const lines = [`Job Tracker Daily Summary`, `Date:
 function timesheetText() { const sheet = captureTimesheet(); return [`Job Tracker Timesheet`, `Week: ${sheet.weekStart}`, `Technician: ${sheet.name1}`, `Supervisor: ${sheet.supervisor || "Not set"}`, `Partner: ${sheet.name2 || "None"}`, "", ...sheet.days.map((day) => `${day.name}: ${sumDay(day).toFixed(2)} hrs - ${day.notes || "No notes"}`), `Total: ${sheet.totalHours} hrs`].join("\n"); }
 function yellowSheetText() { const sheet = captureYellowSheet(); const checks = Object.entries(sheet.checks).map(([key, value]) => `${key}: ${value ? "yes" : "no"}`).join("\n"); return [`Job Tracker Yellow Sheet`, `Date: ${sheet.date}`, `Technician: ${currentUser.firstName} ${currentUser.lastName}`, `Signature: ${sheet.signature || "Missing"}`, "", checks, "", `Materials: ${sheet.materials || "None"}`, `Notes: ${sheet.notes || "None"}`].join("\n"); }
 
+function displayUserName(user) {
+  if (!user) return "";
+  return `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.email || user.id || "";
+}
+
+function userById(uid) {
+  return appState.users.find((user) => user.id === uid);
+}
+
+function searchTokens(query) {
+  return query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function compactDateLabel(value) {
+  if (!value) return "No date";
+  const date = new Date(/^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T12:00:00` : value);
+  if (Number.isNaN(date.valueOf())) return value;
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(date);
+}
+
+function splitSearchAddress(address = "") {
+  const parts = address.split(",").map((part) => part.trim()).filter(Boolean);
+  return { primary: parts[0] || address || "No address", secondary: parts.slice(1).join(", ") };
+}
+
+function creatorLine(job) {
+  const creator = userById(job.createdBy);
+  if (creator) {
+    const role = (creator.position || creator.normalizedPosition || "").trim();
+    return role ? `Added by ${displayUserName(creator)} · ${role}` : `Added by ${displayUserName(creator)}`;
+  }
+  const crew = userById(job.assignedTo);
+  return crew ? `Crew: ${displayUserName(crew)}` : "Crew not assigned";
+}
+
+function searchSnippet(job, tokens) {
+  const candidates = [
+    ["Notes", job.notes],
+    ["Materials", job.materialsUsed],
+    ["Assignments", job.assignments],
+    ["NID Footage", job.nidFootage],
+    ["CAN Footage", job.canFootage],
+  ];
+  for (const [title, rawValue] of candidates) {
+    const value = String(rawValue || "").trim();
+    if (!value) continue;
+    if (!tokens.length || tokens.some((token) => value.toLowerCase().includes(token))) return { title, value };
+  }
+  return null;
+}
+
+function searchHaystack(job) {
+  const creator = userById(job.createdBy);
+  const creatorName = displayUserName(creator);
+  return [
+    job.address,
+    job.jobNumber,
+    job.status,
+    job.notes,
+    job.assignments,
+    job.materialsUsed,
+    job.nidFootage,
+    job.canFootage,
+    compactDateLabel(job.date),
+    job.date,
+    creatorName,
+    creator?.position,
+    creator?.normalizedPosition,
+  ].filter(Boolean).join(" ").toLowerCase();
+}
+
+function compareSearchJobs(a, b) {
+  const dateOrder = String(b.date || "").localeCompare(String(a.date || ""));
+  if (dateOrder !== 0) return dateOrder;
+  return String(a.address || "").localeCompare(String(b.address || ""), undefined, { sensitivity: "base" });
+}
+
+function buildQuickFilters() {
+  const countBy = (valueFor) => {
+    const counts = new Map();
+    appState.jobs.forEach((job) => {
+      const value = String(valueFor(job) || "").trim();
+      if (!value) return;
+      const key = value.toLowerCase();
+      const existing = counts.get(key) || { display: value, count: 0 };
+      existing.count += 1;
+      counts.set(key, existing);
+    });
+    return [...counts.values()].sort((a, b) => b.count - a.count || a.display.localeCompare(b.display, undefined, { sensitivity: "base" }));
+  };
+  const statuses = countBy((job) => job.status).slice(0, 4).map((item) => ({ ...item, kind: "status" }));
+  const creators = countBy((job) => displayUserName(userById(job.createdBy))).slice(0, 4).map((item) => ({ ...item, kind: "creator" }));
+  return [...statuses, ...creators].slice(0, 8);
+}
+
+function renderQuickFilters() {
+  const container = $("#searchQuickFilters");
+  if (!container) return;
+  const filters = buildQuickFilters();
+  container.innerHTML = "";
+  if (!filters.length) return;
+  const heading = document.createElement("p");
+  heading.className = "quick-filter-title";
+  heading.textContent = "Quick filters";
+  const row = document.createElement("div");
+  row.className = "quick-filter-row";
+  filters.forEach((filter) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "quick-filter-pill";
+    const label = document.createElement("span");
+    label.textContent = `${filter.kind === "creator" ? "👥" : "🏷️"} ${filter.display}`;
+    const count = document.createElement("small");
+    count.textContent = `${filter.count} job${filter.count === 1 ? "" : "s"}`;
+    button.append(label, count);
+    button.addEventListener("click", () => {
+      $("#jobSearchInput").value = filter.display;
+      renderSearch();
+    });
+    row.append(button);
+  });
+  container.append(heading, row);
+}
+
+function renderSearchResultCard(job, tokens) {
+  const item = document.createElement("article");
+  item.className = "job-item search-result-card";
+  const { primary, secondary } = splitSearchAddress(job.address);
+  const snippet = searchSnippet(job, tokens);
+
+  const header = document.createElement("div");
+  header.className = "search-result-header";
+
+  const addressBlock = document.createElement("div");
+  addressBlock.className = "search-result-address";
+  const title = document.createElement("h3");
+  title.textContent = primary;
+  addressBlock.append(title);
+  if (secondary) {
+    const line = document.createElement("p");
+    line.textContent = secondary;
+    addressBlock.append(line);
+  }
+
+  const jobNumber = document.createElement("span");
+  jobNumber.className = "badge job-number-badge";
+  jobNumber.textContent = job.jobNumber ? `#${job.jobNumber}` : "No job #";
+  header.append(addressBlock, jobNumber);
+
+  const meta = document.createElement("div");
+  meta.className = "job-meta search-result-meta";
+  const status = document.createElement("span");
+  status.className = `badge ${statusClass(job.status)}`.trim();
+  status.textContent = job.status || "No status";
+  const date = document.createElement("span");
+  date.textContent = compactDateLabel(job.date);
+  const creator = document.createElement("span");
+  creator.className = "search-result-creator";
+  creator.textContent = creatorLine(job);
+  meta.append(status, date, creator);
+
+  item.append(header, meta);
+  if (snippet) {
+    const snippetBlock = document.createElement("div");
+    snippetBlock.className = "search-result-snippet";
+    const snippetTitle = document.createElement("span");
+    snippetTitle.textContent = snippet.title.toUpperCase();
+    const snippetValue = document.createElement("p");
+    snippetValue.textContent = snippet.value;
+    snippetBlock.append(snippetTitle, snippetValue);
+    item.append(snippetBlock);
+  }
+  if ([job.createdBy, job.assignedTo].includes(currentUser.id) || (job.participants || []).includes(currentUser.id)) {
+    const owned = document.createElement("span");
+    owned.className = "search-owned-label";
+    owned.textContent = "✓ In your job list";
+    item.append(owned);
+  }
+  return item;
+}
+
 function renderSearch() {
-  const query = $("#jobSearchInput").value.trim().toLowerCase();
-  const filtered = query ? appState.jobs.filter((job) => [job.jobNumber, job.address, job.type, job.status, job.notes, job.date, job.assignments, job.materialsUsed].join(" ").toLowerCase().includes(query)) : appState.jobs;
-  renderJobList($("#searchResults"), filtered, true);
+  const input = $("#jobSearchInput");
+  const results = $("#searchResults");
+  const query = input.value.trim();
+  const tokens = searchTokens(query);
+  const sortedJobs = [...appState.jobs].sort(compareSearchJobs);
+  const matches = tokens.length ? sortedJobs.filter((job) => {
+    const haystack = searchHaystack(job);
+    return tokens.every((token) => haystack.includes(token));
+  }) : sortedJobs.slice(0, 12);
+
+  renderQuickFilters();
+  results.innerHTML = "";
+
+  if (!tokens.length) {
+    const idle = document.createElement("article");
+    idle.className = "search-idle-card";
+    idle.innerHTML = `<div class="search-idle-icon">⌕</div><h3>Search the entire company</h3><p>Type part of an address, job number, status, or teammate to explore every job in Job Tracker.</p>`;
+    results.append(idle);
+    if (!matches.length) return;
+    const heading = document.createElement("div");
+    heading.className = "search-list-heading";
+    heading.innerHTML = `<h3>Recent activity</h3><p>Jump back into the latest jobs from across your team.</p>`;
+    results.append(heading);
+  } else if (!matches.length) {
+    const empty = document.createElement("article");
+    empty.className = "empty-state search-empty-state";
+    empty.innerHTML = `<strong>No jobs found for “${query.replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;" }[char]))}”</strong><span>Try fewer keywords or search by street, city, job number, status, or teammate name.</span>`;
+    results.append(empty);
+    return;
+  } else {
+    const heading = document.createElement("div");
+    heading.className = "search-list-heading";
+    heading.innerHTML = `<h3>Results</h3><p>${matches.length} match${matches.length === 1 ? "" : "es"}</p>`;
+    results.append(heading);
+  }
+
+  matches.forEach((job) => results.append(renderSearchResultCard(job, tokens)));
 }
 
 function hydrateUserForms() {

--- a/website/app/styles.css
+++ b/website/app/styles.css
@@ -204,6 +204,56 @@ textarea { resize: vertical; }
 input:focus, select:focus, textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(98, 213, 255, 0.12); }
 .search-box input { font-size: 1.2rem; padding: 1rem; }
 
+.search-workspace { display: grid; gap: 1rem; }
+.quick-filters { display: grid; gap: 0.55rem; }
+.quick-filter-title, .search-list-heading p, .search-result-address p, .search-result-snippet p { margin: 0; }
+.quick-filter-title { color: var(--muted); font-size: 0.9rem; font-weight: 800; }
+.quick-filter-row { display: flex; gap: 0.65rem; overflow-x: auto; padding: 0.1rem 0 0.25rem; }
+.quick-filter-pill {
+  display: grid;
+  gap: 0.15rem;
+  flex: 0 0 auto;
+  min-width: 8.5rem;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text);
+  padding: 0.55rem 0.85rem;
+  cursor: pointer;
+}
+.quick-filter-pill span { font-size: 0.82rem; font-weight: 850; }
+.quick-filter-pill small { color: var(--muted); font-weight: 750; }
+.job-list.search-results { gap: 1rem; margin-top: 0; }
+.search-idle-card {
+  display: grid;
+  justify-items: center;
+  gap: 0.7rem;
+  padding: 2rem 1.5rem;
+  border: 1px solid var(--line);
+  border-radius: 1.4rem;
+  background: rgba(255, 255, 255, 0.05);
+  text-align: center;
+}
+.search-idle-icon { color: var(--muted); font-size: 2.5rem; font-weight: 900; }
+.search-idle-card h3, .search-list-heading h3 { margin: 0; }
+.search-idle-card p, .search-list-heading p { color: var(--muted); line-height: 1.55; }
+.search-list-heading { display: grid; gap: 0.2rem; margin-top: 0.35rem; }
+.job-item.search-result-card { display: grid; grid-template-columns: 1fr; align-items: stretch; gap: 0.85rem; }
+.search-result-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+.search-result-address { display: grid; gap: 0.25rem; min-width: 0; }
+.search-result-address h3 { line-height: 1.25; }
+.search-result-address p { color: var(--muted); font-size: 0.9rem; }
+.job-number-badge { white-space: nowrap; }
+.search-result-meta { margin-top: 0; align-items: center; }
+.search-result-creator { color: var(--muted); }
+.search-result-snippet { display: grid; gap: 0.25rem; }
+.search-result-snippet span { color: var(--muted); font-size: 0.75rem; font-weight: 900; letter-spacing: 0.08em; }
+.search-result-snippet p { color: var(--text); line-height: 1.45; }
+.search-owned-label { color: var(--success); font-size: 0.85rem; font-weight: 850; }
+.search-empty-state { display: grid; gap: 0.35rem; }
+.search-empty-state span { color: var(--muted); }
+
 .job-list, .compact-list { display: grid; gap: 0.75rem; margin-top: 1rem; }
 .job-item, .compact-item {
   display: grid;


### PR DESCRIPTION
### Motivation
- Make the web Job Search tab match the native iOS Job Search experience including title, subtitle, placeholder copy, quick filters, recent activity, and result card hierarchy.
- Remove the shared import/deep-link preview from the default search tab so the default flow mirrors the native app.

### Description
- Update `website/app/index.html` to set the page heading to `Job Search`, subtitle to `Look up any job across Cable South in seconds.`, change the search placeholder to `Address, job #, status, or teammate`, add a quick-filters container, and remove the shared-import preview UI.
- Replace the simple filter in `renderSearch()` with a native-like search implementation in `website/app/script.js` that adds tokenization (`searchTokens`), AND-token matching (`searchHaystack`), newest-first sorting (`compareSearchJobs`), a recent/idle view when query is empty, and empty-state handling.
- Implement dedicated rendering helpers in `website/app/script.js` including `renderQuickFilters`, `renderSearchResultCard`, `splitSearchAddress`, `creatorLine`, and `searchSnippet` so result cards show primary address, secondary line, job number badge, status badge, date, creator/crew line, snippet, and owned-job label in the requested visual hierarchy.
- Add CSS rules in `website/app/styles.css` to style the search workspace, quick filter pills, idle/recent sections, and search result cards so the web UI visually matches the native design.

### Testing
- Ran `node --check website/app/script.js` to validate the updated script and it completed successfully.
- Used `rg` checks to confirm the old shared-import/default heading and placeholder were removed and the new `Job Search` heading, `Address, job #, status, or teammate` placeholder, `renderSearchResultCard`, and `renderQuickFilters` implementations exist, and those searches returned expected matches.
- Performed a smoke static check of the updated files; no runtime errors were reported during the static checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd942e5dc832d81664b30ad9ff70d)