### PR TITLE
Refactor website into iOS-style bottom tabs

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,12 +1,12 @@
 # Job Tracker Website
 
-This folder contains a standalone browser version of the Job Tracker workspace. It is intentionally dependency-free so the website can be opened directly from `index.html`, served by any static host, or used as a prototype before wiring it to the same Firebase services as the iOS app.
+This folder contains a standalone, dependency-free browser version of the Job Tracker iOS app shell. The top-level website now follows the native app's five primary tabs instead of placing every workflow on one long page.
 
 ## Files
 
-- `index.html` – semantic page structure for the responsive dashboard, job board, team coordination, compliance checklist, and splice assist prototype.
-- `styles.css` – dark glassmorphism design system inspired by the native app's field-operations interface.
-- `script.js` – localStorage-backed interactivity for demo job creation, deletion, daily progress metrics, and splice troubleshooting checklist generation.
+- `index.html` – semantic tabbed structure for Dashboard, Timesheets, Yellow Sheet, Job Search, and More.
+- `styles.css` – dark glassmorphism design system with a fixed bottom tab bar that mirrors the iOS navigation model.
+- `script.js` – localStorage-backed demo interactivity for jobs, weekly timesheets, yellow sheets, search, and tab routing.
 
 ## Run locally
 
@@ -18,9 +18,9 @@ python3 -m http.server 8000 --directory website
 
 Then open <http://localhost:8000> in a browser.
 
-## Next integration steps
+## Parity notes
 
-1. Replace the demo `localStorage` job data in `script.js` with Firestore reads and writes that mirror `FirebaseService` in the iOS target.
-2. Add authentication so technicians, supervisors, and admins see role-appropriate sections.
-3. Connect document exports to the existing timesheet and yellow sheet PDF generation workflows.
-4. Route the splice assist form to the same AI-backed troubleshooting service used by the native app.
+- The primary navigation matches the iOS app: Dashboard, Timesheets, Yellow Sheet, Job Search, and More.
+- Dashboard content is limited to the selected day's job workflow.
+- Timesheet and Yellow Sheet content are separated into their own tabs.
+- Additional native sections such as Profile, Settings, Find a Partner, Recent Crew Jobs, Route Mapper, Splice Assist, and Help Center are grouped under More instead of appearing on the Dashboard.

--- a/website/index.html
+++ b/website/index.html
@@ -5,189 +5,212 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="A responsive web dashboard for Job Tracker technicians and supervisors."
+      content="A browser version of the Job Tracker iOS app with Dashboard, Timesheets, Yellow Sheet, Job Search, and More tabs."
     />
     <title>Job Tracker Web</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <div class="app-shell">
-      <aside class="sidebar" aria-label="Primary">
-        <a class="brand" href="#top" aria-label="Job Tracker home">
+      <header class="app-header">
+        <a class="brand" href="#dashboard" data-tab-link="dashboard" aria-label="Job Tracker dashboard">
           <span class="brand-mark">JT</span>
           <span>
             <strong>Job Tracker</strong>
-            <small>Web workspace</small>
+            <small id="currentDate">Loading today…</small>
           </span>
         </a>
+        <span class="sync-pill"><span class="pulse"></span>Local demo data saved</span>
+      </header>
 
-        <nav class="nav-links" aria-label="Workspace sections">
-          <a href="#dashboard">Dashboard</a>
-          <a href="#jobs">Jobs</a>
-          <a href="#team">Team</a>
-          <a href="#documents">Docs</a>
-          <a href="#assist">Assist</a>
-        </nav>
-
-        <div class="sidebar-card">
-          <small>Today</small>
-          <strong id="sidebarDate">Loading...</strong>
-          <span id="sidebarSummary">0 jobs scheduled</span>
-        </div>
-      </aside>
-
-      <main id="top" class="content">
-        <header class="hero" id="dashboard">
-          <div class="hero-copy">
-            <p class="eyebrow">Fiber field operations</p>
-            <h1>Plan routes, track job status, and finish paperwork from any browser.</h1>
-            <p>
-              This web version brings the core Job Tracker workflow to desktop and tablet teams:
-              daily dashboards, job creation, crew collaboration, document checklists, and splice support.
-            </p>
-            <div class="hero-actions">
-              <a class="button primary" href="#jobs">Add a job</a>
-              <a class="button secondary" href="#documents">Review paperwork</a>
+      <main class="content" id="appContent">
+        <section class="tab-view active" id="dashboardView" data-tab="dashboard" aria-labelledby="dashboardTitle">
+          <header class="page-hero">
+            <div>
+              <p class="eyebrow">Dashboard</p>
+              <h1 id="dashboardTitle">Jobs</h1>
+              <p class="lede">Review the selected day, create jobs, update statuses, and keep the daily list focused just like the app.</p>
             </div>
-          </div>
+            <button class="button primary" type="button" id="focusCreateJobButton">Create Job</button>
+          </header>
 
-          <section class="hero-panel" aria-label="Daily progress summary">
+          <section class="summary-card" aria-label="Selected day summary">
             <div>
               <span class="metric-label">Completion</span>
               <strong id="completionRate">0%</strong>
             </div>
-            <div class="progress-track" aria-hidden="true">
-              <span id="completionBar"></span>
-            </div>
+            <div class="progress-track" aria-hidden="true"><span id="completionBar"></span></div>
             <dl class="metric-grid">
-              <div>
-                <dt>Pending</dt>
-                <dd id="pendingCount">0</dd>
-              </div>
-              <div>
-                <dt>In progress</dt>
-                <dd id="activeCount">0</dd>
-              </div>
-              <div>
-                <dt>Done</dt>
-                <dd id="doneCount">0</dd>
-              </div>
+              <div><dt>Total</dt><dd id="totalCount">0</dd></div>
+              <div><dt>Pending</dt><dd id="pendingCount">0</dd></div>
+              <div><dt>Done</dt><dd id="doneCount">0</dd></div>
             </dl>
           </section>
-        </header>
 
-        <section class="section-grid" aria-label="Workspace overview">
-          <article class="feature-card">
-            <span class="icon">📍</span>
-            <h2>Smart routing</h2>
-            <p>Keep addresses, arrival windows, and status notes visible before the next dispatch.</p>
-          </article>
-          <article class="feature-card">
-            <span class="icon">🧾</span>
-            <h2>Paperwork hub</h2>
-            <p>Track weekly timesheets and yellow sheet readiness without leaving the dashboard.</p>
-          </article>
-          <article class="feature-card">
-            <span class="icon">💬</span>
-            <h2>Crew updates</h2>
-            <p>Coordinate partner requests, quick notes, and supervisor escalations in one place.</p>
-          </article>
-        </section>
+          <div class="weekday-picker" id="weekdayPicker" aria-label="Weekday picker"></div>
 
-        <section class="workspace-card" id="jobs">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">Daily job board</p>
-              <h2>Create and update jobs</h2>
+          <section class="workspace-card" aria-labelledby="createJobTitle">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Create Job</p>
+                <h2 id="createJobTitle">Add a dashboard job</h2>
+              </div>
+              <button class="button secondary" id="resetJobsButton" type="button">Reset demo jobs</button>
             </div>
-            <button class="button secondary" id="resetJobsButton" type="button">Reset demo data</button>
-          </div>
 
-          <form class="job-form" id="jobForm">
-            <label>
-              Job address
-              <input id="addressInput" name="address" placeholder="123 Fiber Rd" required />
-            </label>
-            <label>
-              Job type
-              <select id="typeInput" name="type">
-                <option>Install</option>
-                <option>Repair</option>
-                <option>Survey</option>
-                <option>Maintenance</option>
-              </select>
-            </label>
-            <label>
-              Status
-              <select id="statusInput" name="status">
-                <option>Pending</option>
-                <option>In Progress</option>
-                <option>Needs Ariel</option>
-                <option>Needs Underground</option>
-                <option>Done</option>
-              </select>
-            </label>
-            <label>
-              Crew note
-              <input id="noteInput" name="note" placeholder="Gate code, splice count, material needs" />
-            </label>
-            <button class="button primary" type="submit">Save job</button>
-          </form>
+            <form class="job-form" id="jobForm">
+              <label>Address<input id="addressInput" name="address" placeholder="123 Fiber Rd" required /></label>
+              <label>Job #<input id="jobNumberInput" name="jobNumber" placeholder="1024" /></label>
+              <label>Status
+                <select id="statusInput" name="status">
+                  <option>Pending</option>
+                  <option>Needs Ariel</option>
+                  <option>Needs Underground</option>
+                  <option>Done</option>
+                </select>
+              </label>
+              <label>Notes<input id="noteInput" name="notes" placeholder="Materials, gate code, or job note" /></label>
+              <button class="button primary" type="submit">Save Job</button>
+            </form>
+          </section>
 
-          <div class="job-list" id="jobList" aria-live="polite"></div>
-        </section>
-
-        <section class="two-column">
-          <article class="workspace-card" id="team">
-            <p class="eyebrow">Crew room</p>
-            <h2>Team coordination</h2>
-            <ul class="timeline">
-              <li>
-                <strong>Partner finder</strong>
-                <span>Post help requests for long pulls, aerial work, and late-day callbacks.</span>
-              </li>
-              <li>
-                <strong>Supervisor view</strong>
-                <span>Review stuck jobs, imports, and status exceptions from the same web surface.</span>
-              </li>
-              <li>
-                <strong>Recent crew jobs</strong>
-                <span>Reuse notes from recent nearby jobs to speed up troubleshooting.</span>
-              </li>
-            </ul>
-          </article>
-
-          <article class="workspace-card" id="documents">
-            <p class="eyebrow">Compliance</p>
-            <h2>Paperwork checklist</h2>
-            <div class="checklist">
-              <label><input type="checkbox" /> Weekly timesheet reviewed</label>
-              <label><input type="checkbox" /> Yellow sheet photos attached</label>
-              <label><input type="checkbox" /> Extra work notes submitted</label>
-              <label><input type="checkbox" /> PDF export ready for supervisor</label>
+          <section class="workspace-card" aria-labelledby="dailyJobsTitle">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Selected day</p>
+                <h2 id="dailyJobsTitle">Daily jobs</h2>
+              </div>
+              <span class="muted" id="selectedDayLabel"></span>
             </div>
-          </article>
+            <div class="job-list" id="jobList" aria-live="polite"></div>
+          </section>
         </section>
 
-        <section class="workspace-card assist-card" id="assist">
-          <div>
-            <p class="eyebrow">Splice assist</p>
-            <h2>Bring troubleshooting prompts to the web.</h2>
-            <p>
-              The website shell leaves room for the same AI-assisted splice workflow as the iOS app:
-              upload a splice map, summarize CAN issues, and capture recommended next steps.
-            </p>
-          </div>
-          <form class="assist-form" id="assistForm">
-            <label>
-              Describe the issue
-              <textarea id="assistInput" rows="4" placeholder="Example: customer light is low after 288-count enclosure swap"></textarea>
-            </label>
-            <button class="button secondary" type="submit">Generate checklist</button>
-            <output id="assistOutput" aria-live="polite"></output>
-          </form>
+        <section class="tab-view" id="timesheetsView" data-tab="timesheets" aria-labelledby="timesheetsTitle" hidden>
+          <header class="page-heading">
+            <p class="eyebrow">Timesheets</p>
+            <h1 id="timesheetsTitle">Weekly timesheet</h1>
+            <p class="lede">Track supervisor, partner, Gibson hours, Cable South hours, and daily totals for the current week.</p>
+          </header>
+
+          <section class="workspace-card">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Week</p>
+                <h2 id="weekRangeLabel">This week</h2>
+              </div>
+              <button class="button secondary" id="saveTimesheetButton" type="button">Save Timesheet</button>
+            </div>
+            <form class="timesheet-form" id="timesheetForm">
+              <label>Supervisor<input id="supervisorInput" name="supervisor" placeholder="Supervisor name" /></label>
+              <label>Name 1<input id="nameOneInput" name="name1" placeholder="Technician" /></label>
+              <label>Name 2<input id="nameTwoInput" name="name2" placeholder="Partner" /></label>
+              <label>Gibson Hours<input id="gibsonHoursInput" name="gibsonHours" type="number" min="0" step="0.25" value="0" /></label>
+              <label>Cable South Hours<input id="cableSouthHoursInput" name="cableSouthHours" type="number" min="0" step="0.25" value="0" /></label>
+              <label>Total Hours<input id="totalHoursInput" name="totalHours" type="number" min="0" step="0.25" value="0" readonly /></label>
+            </form>
+            <div class="daily-hours" id="dailyHoursGrid" aria-label="Daily total hours"></div>
+          </section>
+
+          <section class="workspace-card">
+            <p class="eyebrow">History</p>
+            <h2>Past Timesheets</h2>
+            <div class="compact-list" id="pastTimesheetsList"></div>
+          </section>
+        </section>
+
+        <section class="tab-view" id="yellowSheetView" data-tab="yellowSheet" aria-labelledby="yellowSheetTitle" hidden>
+          <header class="page-heading">
+            <p class="eyebrow">Yellow Sheet</p>
+            <h1 id="yellowSheetTitle">Weekly yellow sheet</h1>
+            <p class="lede">Save the week-starting date and total job count for the same yellow sheet record the iOS app stores.</p>
+          </header>
+
+          <section class="workspace-card">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Current week</p>
+                <h2>Yellow Sheet summary</h2>
+              </div>
+              <button class="button primary" id="saveYellowSheetButton" type="button">Save Yellow Sheet</button>
+            </div>
+            <div class="yellow-summary">
+              <article>
+                <span>Week starting</span>
+                <strong id="yellowWeekStartLabel">—</strong>
+              </article>
+              <article>
+                <span>Total jobs</span>
+                <strong id="yellowTotalJobs">0</strong>
+              </article>
+            </div>
+            <div class="job-list compact" id="yellowJobList"></div>
+          </section>
+
+          <section class="workspace-card">
+            <p class="eyebrow">History</p>
+            <h2>Past Yellow Sheets</h2>
+            <div class="compact-list" id="pastYellowSheetsList"></div>
+          </section>
+        </section>
+
+        <section class="tab-view" id="jobSearchView" data-tab="jobSearch" aria-labelledby="jobSearchTitle" hidden>
+          <header class="page-heading">
+            <p class="eyebrow">Job Search</p>
+            <h1 id="jobSearchTitle">Job Search</h1>
+            <p class="lede">Look up jobs by address, job number, status, assignment, materials, or notes.</p>
+          </header>
+
+          <section class="workspace-card">
+            <label class="search-field">Search jobs<input id="searchInput" type="search" placeholder="Address, job #, status, or note" /></label>
+            <div class="quick-filters" aria-label="Quick filters">
+              <button class="chip" type="button" data-search-filter="Pending">Pending</button>
+              <button class="chip" type="button" data-search-filter="Needs Ariel">Needs Ariel</button>
+              <button class="chip" type="button" data-search-filter="Needs Underground">Needs Underground</button>
+              <button class="chip" type="button" data-search-filter="Done">Done</button>
+            </div>
+            <div class="job-list" id="searchResults" aria-live="polite"></div>
+          </section>
+        </section>
+
+        <section class="tab-view" id="moreView" data-tab="more" aria-labelledby="moreTitle" hidden>
+          <header class="page-heading">
+            <p class="eyebrow">More</p>
+            <h1 id="moreTitle">More</h1>
+            <p class="lede">Additional app sections live here instead of being mixed into the Dashboard.</p>
+          </header>
+
+          <nav class="more-list" aria-label="More sections">
+            <section>
+              <h2>Account</h2>
+              <a href="#more">👤 Profile</a>
+              <a href="#more">⚙️ Settings</a>
+            </section>
+            <section>
+              <h2>Team</h2>
+              <a href="#more">👥 Find a Partner</a>
+            </section>
+            <section>
+              <h2>Jobs</h2>
+              <a href="#more">🕘 Recent Crew Jobs</a>
+            </section>
+            <section>
+              <h2>Resources</h2>
+              <a href="#more">🗺️ Route Mapper</a>
+              <a href="#more">✨ Splice Assist</a>
+              <a href="#more">❓ Help Center</a>
+            </section>
+          </nav>
         </section>
       </main>
+
+      <nav class="bottom-tabs" aria-label="Primary tabs">
+        <button class="tab-button active" type="button" data-tab-target="dashboard" aria-label="Dashboard" aria-current="page"><span>▦</span><small>Dashboard</small></button>
+        <button class="tab-button" type="button" data-tab-target="timesheets" aria-label="Timesheets"><span>◷</span><small>Timesheets</small></button>
+        <button class="tab-button" type="button" data-tab-target="yellowSheet" aria-label="Yellow Sheet"><span>▤</span><small>Yellow Sheet</small></button>
+        <button class="tab-button" type="button" data-tab-target="jobSearch" aria-label="Job Search"><span>⌕</span><small>Job Search</small></button>
+        <button class="tab-button" type="button" data-tab-target="more" aria-label="More"><span>•••</span><small>More</small></button>
+      </nav>
     </div>
 
     <script src="script.js"></script>

--- a/website/script.js
+++ b/website/script.js
@@ -2,184 +2,467 @@ function createId() {
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+const storageKeys = {
+  jobs: "job-tracker-web-tabs-jobs",
+  timesheets: "job-tracker-web-tabs-timesheets",
+  yellowSheets: "job-tracker-web-tabs-yellow-sheets",
+};
+
+const today = new Date();
 const defaultJobs = [
   {
     id: createId(),
     address: "1410 Maple Fiber Ln",
-    type: "Install",
+    date: toDateInputValue(today),
     status: "Pending",
-    note: "Call customer 30 minutes before arrival.",
+    notes: "Call customer 30 minutes before arrival.",
+    jobNumber: "1001",
+    assignments: "12.3.2",
+    materialsUsed: "NID box, jumper",
+    hours: 2,
   },
   {
     id: createId(),
     address: "88 Ridge Cabinet Rd",
-    type: "Repair",
-    status: "In Progress",
-    note: "Low light after drop replacement.",
+    date: toDateInputValue(today),
+    status: "Needs Underground",
+    notes: "Drop needs bore crew before completion.",
+    jobNumber: "1002",
+    assignments: "14.1.7",
+    materialsUsed: "Conduit, mule tape",
+    hours: 1.5,
   },
   {
     id: createId(),
     address: "702 Splice Loop",
-    type: "Maintenance",
+    date: toDateInputValue(addDays(today, -1)),
     status: "Done",
-    note: "Yellow sheet photos attached.",
+    notes: "Footage and materials entered.",
+    jobNumber: "1003",
+    assignments: "9.4.1",
+    materialsUsed: "Preforms, weatherhead",
+    hours: 3,
   },
 ];
 
-const storageKey = "job-tracker-web-jobs";
+const appState = {
+  selectedTab: "dashboard",
+  selectedDate: toDateInputValue(today),
+  jobs: loadStoredArray(storageKeys.jobs, defaultJobs),
+  timesheets: loadStoredArray(storageKeys.timesheets, []),
+  yellowSheets: loadStoredArray(storageKeys.yellowSheets, []),
+};
+
+const formatDay = new Intl.DateTimeFormat(undefined, { weekday: "short", month: "short", day: "numeric" });
+const formatLongDay = new Intl.DateTimeFormat(undefined, { weekday: "long", month: "short", day: "numeric" });
+const formatWeekday = new Intl.DateTimeFormat(undefined, { weekday: "short" });
+const formatShortDate = new Intl.DateTimeFormat(undefined, { month: "numeric", day: "numeric" });
+
+const tabButtons = document.querySelectorAll("[data-tab-target]");
+const tabViews = document.querySelectorAll("[data-tab]");
 const jobForm = document.querySelector("#jobForm");
-const resetJobsButton = document.querySelector("#resetJobsButton");
 const jobList = document.querySelector("#jobList");
-const assistForm = document.querySelector("#assistForm");
-const assistInput = document.querySelector("#assistInput");
-const assistOutput = document.querySelector("#assistOutput");
+const resetJobsButton = document.querySelector("#resetJobsButton");
+const focusCreateJobButton = document.querySelector("#focusCreateJobButton");
+const weekdayPicker = document.querySelector("#weekdayPicker");
+const dailyHoursGrid = document.querySelector("#dailyHoursGrid");
+const timesheetForm = document.querySelector("#timesheetForm");
+const saveTimesheetButton = document.querySelector("#saveTimesheetButton");
+const saveYellowSheetButton = document.querySelector("#saveYellowSheetButton");
+const searchInput = document.querySelector("#searchInput");
 
-let jobs = loadJobs();
-
-function loadJobs() {
-  const savedJobs = localStorage.getItem(storageKey);
-
-  if (!savedJobs) {
-    return defaultJobs;
-  }
+function loadStoredArray(key, fallback) {
+  const storedValue = localStorage.getItem(key);
+  if (!storedValue) return fallback;
 
   try {
-    const parsedJobs = JSON.parse(savedJobs);
-    return Array.isArray(parsedJobs) ? parsedJobs : defaultJobs;
+    const parsedValue = JSON.parse(storedValue);
+    return Array.isArray(parsedValue) ? parsedValue : fallback;
   } catch {
-    return defaultJobs;
+    return fallback;
   }
 }
 
-function saveJobs() {
-  localStorage.setItem(storageKey, JSON.stringify(jobs));
+function saveStoredArray(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
 }
 
-function renderDate() {
-  const formatter = new Intl.DateTimeFormat(undefined, {
-    weekday: "long",
-    month: "short",
-    day: "numeric",
-  });
-
-  document.querySelector("#sidebarDate").textContent = formatter.format(new Date());
+function addDays(date, days) {
+  const nextDate = new Date(date);
+  nextDate.setDate(nextDate.getDate() + days);
+  return nextDate;
 }
 
-function renderSummary() {
-  const pending = jobs.filter((job) => job.status === "Pending").length;
-  const active = jobs.filter((job) => job.status === "In Progress").length;
-  const done = jobs.filter((job) => job.status === "Done").length;
-  const completion = jobs.length === 0 ? 0 : Math.round((done / jobs.length) * 100);
+function fromDateInputValue(value) {
+  return new Date(`${value}T12:00:00`);
+}
 
-  document.querySelector("#pendingCount").textContent = pending;
-  document.querySelector("#activeCount").textContent = active;
-  document.querySelector("#doneCount").textContent = done;
-  document.querySelector("#completionRate").textContent = `${completion}%`;
-  document.querySelector("#completionBar").style.width = `${completion}%`;
-  document.querySelector("#sidebarSummary").textContent = `${jobs.length} jobs scheduled`;
+function toDateInputValue(date) {
+  const normalizedDate = new Date(date);
+  normalizedDate.setMinutes(normalizedDate.getMinutes() - normalizedDate.getTimezoneOffset());
+  return normalizedDate.toISOString().slice(0, 10);
+}
+
+function startOfWeek(value) {
+  const date = fromDateInputValue(value);
+  date.setDate(date.getDate() - date.getDay());
+  return toDateInputValue(date);
+}
+
+function weekDays(value) {
+  const firstDay = fromDateInputValue(startOfWeek(value));
+  return Array.from({ length: 7 }, (_, index) => toDateInputValue(addDays(firstDay, index)));
+}
+
+function currentWeekJobs() {
+  const dates = new Set(weekDays(appState.selectedDate));
+  return appState.jobs.filter((job) => dates.has(job.date));
+}
+
+function selectedDayJobs() {
+  return appState.jobs.filter((job) => job.date === appState.selectedDate);
 }
 
 function statusClass(status) {
-  if (status === "Done") {
-    return "done";
-  }
-
-  if (status.startsWith("Needs")) {
-    return "warning";
-  }
-
+  if (status === "Done") return "done";
+  if (status.startsWith("Needs")) return "warning";
   return "";
 }
 
+function navigateTo(tabName) {
+  appState.selectedTab = tabName;
+
+  for (const button of tabButtons) {
+    const isActive = button.dataset.tabTarget === tabName;
+    button.classList.toggle("active", isActive);
+    button.toggleAttribute("aria-current", isActive);
+  }
+
+  for (const view of tabViews) {
+    const isActive = view.dataset.tab === tabName;
+    view.classList.toggle("active", isActive);
+    view.hidden = !isActive;
+  }
+
+  history.replaceState(null, "", `#${tabName}`);
+  document.querySelector("#appContent").scrollIntoView({ block: "start" });
+}
+
+function renderDate() {
+  document.querySelector("#currentDate").textContent = formatLongDay.format(today);
+}
+
+function renderWeekdayPicker() {
+  weekdayPicker.innerHTML = "";
+
+  for (const dateValue of weekDays(appState.selectedDate)) {
+    const date = fromDateInputValue(dateValue);
+    const button = document.createElement("button");
+    button.className = "day-button";
+    button.type = "button";
+    button.dataset.date = dateValue;
+    button.classList.toggle("active", dateValue === appState.selectedDate);
+    button.innerHTML = `<span>${formatWeekday.format(date)}</span><small>${formatShortDate.format(date)}</small>`;
+    weekdayPicker.append(button);
+  }
+}
+
+function renderDashboardSummary() {
+  const jobs = selectedDayJobs();
+  const pending = jobs.filter((job) => job.status !== "Done").length;
+  const done = jobs.filter((job) => job.status === "Done").length;
+  const completion = jobs.length === 0 ? 0 : Math.round((done / jobs.length) * 100);
+
+  document.querySelector("#totalCount").textContent = jobs.length;
+  document.querySelector("#pendingCount").textContent = pending;
+  document.querySelector("#doneCount").textContent = done;
+  document.querySelector("#completionRate").textContent = `${completion}%`;
+  document.querySelector("#completionBar").style.width = `${completion}%`;
+  document.querySelector("#selectedDayLabel").textContent = formatLongDay.format(fromDateInputValue(appState.selectedDate));
+}
+
+function makeJobItem(job, options = {}) {
+  const item = document.createElement("article");
+  const details = document.createElement("div");
+  const address = document.createElement("h3");
+  const meta = document.createElement("div");
+  const jobNumber = document.createElement("span");
+  const statusBadge = document.createElement("span");
+  const dateBadge = document.createElement("span");
+  const note = document.createElement("span");
+
+  item.className = "job-item";
+  meta.className = "job-meta";
+  jobNumber.className = "badge";
+  statusBadge.className = `badge ${statusClass(job.status)}`.trim();
+  dateBadge.className = "badge";
+
+  address.textContent = job.address;
+  jobNumber.textContent = job.jobNumber ? `Job #${job.jobNumber}` : "No job #";
+  statusBadge.textContent = job.status;
+  dateBadge.textContent = formatDay.format(fromDateInputValue(job.date));
+  note.textContent = job.notes || "No notes";
+
+  meta.append(jobNumber, statusBadge, dateBadge, note);
+  details.append(address, meta);
+  item.append(details);
+
+  if (!options.readOnly) {
+    const controls = document.createElement("div");
+    controls.className = "job-meta";
+
+    const statusSelect = document.createElement("select");
+    statusSelect.dataset.statusJob = job.id;
+    for (const status of ["Pending", "Needs Ariel", "Needs Underground", "Done"]) {
+      const option = document.createElement("option");
+      option.value = status;
+      option.textContent = status;
+      option.selected = status === job.status;
+      statusSelect.append(option);
+    }
+
+    const removeButton = document.createElement("button");
+    removeButton.className = "button secondary";
+    removeButton.type = "button";
+    removeButton.dataset.deleteJob = job.id;
+    removeButton.textContent = "Delete";
+
+    controls.append(statusSelect, removeButton);
+    item.append(controls);
+  }
+
+  return item;
+}
+
 function renderJobs() {
+  const jobs = selectedDayJobs();
   jobList.innerHTML = "";
 
   if (jobs.length === 0) {
-    jobList.innerHTML = `<p class="empty-state">No jobs yet. Add the first address above.</p>`;
+    jobList.innerHTML = `<p class="empty-state">No jobs for this day. Create one above or choose another weekday.</p>`;
     return;
   }
 
   for (const job of jobs) {
-    const item = document.createElement("article");
-    const details = document.createElement("div");
-    const address = document.createElement("h3");
-    const meta = document.createElement("div");
-    const typeBadge = document.createElement("span");
-    const statusBadge = document.createElement("span");
-    const note = document.createElement("span");
-    const removeButton = document.createElement("button");
-
-    item.className = "job-item";
-    meta.className = "job-meta";
-    typeBadge.className = "badge";
-    statusBadge.className = `badge ${statusClass(job.status)}`.trim();
-    removeButton.className = "button secondary";
-    removeButton.type = "button";
-    removeButton.dataset.deleteJob = job.id;
-
-    address.textContent = job.address;
-    typeBadge.textContent = job.type;
-    statusBadge.textContent = job.status;
-    note.textContent = job.note || "No note added";
-    removeButton.textContent = "Remove";
-
-    meta.append(typeBadge, statusBadge, note);
-    details.append(address, meta);
-    item.append(details, removeButton);
-    jobList.append(item);
+    jobList.append(makeJobItem(job));
   }
 }
 
-function render() {
-  renderSummary();
-  renderJobs();
+function renderTimesheet() {
+  const dates = weekDays(appState.selectedDate);
+  const firstDate = fromDateInputValue(dates[0]);
+  const lastDate = fromDateInputValue(dates[6]);
+  document.querySelector("#weekRangeLabel").textContent = `${formatDay.format(firstDate)} – ${formatDay.format(lastDate)}`;
+
+  dailyHoursGrid.innerHTML = "";
+  for (const dateValue of dates) {
+    const dayJobs = appState.jobs.filter((job) => job.date === dateValue);
+    const totalHours = dayJobs.reduce((sum, job) => sum + Number(job.hours || 0), 0);
+    const label = document.createElement("label");
+    label.innerHTML = `${formatWeekday.format(fromDateInputValue(dateValue))}<input data-daily-hours="${dateValue}" type="number" min="0" step="0.25" value="${totalHours}" />`;
+    dailyHoursGrid.append(label);
+  }
+
+  renderPastTimesheets();
+  updateTimesheetTotal();
 }
+
+function updateTimesheetTotal() {
+  const gibson = Number(document.querySelector("#gibsonHoursInput").value || 0);
+  const cableSouth = Number(document.querySelector("#cableSouthHoursInput").value || 0);
+  const dailyTotal = Array.from(document.querySelectorAll("[data-daily-hours]")).reduce((sum, input) => sum + Number(input.value || 0), 0);
+  document.querySelector("#totalHoursInput").value = Math.max(gibson + cableSouth, dailyTotal).toFixed(2).replace(/\.00$/, "");
+}
+
+function renderPastTimesheets() {
+  const list = document.querySelector("#pastTimesheetsList");
+  list.innerHTML = "";
+
+  if (appState.timesheets.length === 0) {
+    list.innerHTML = `<p class="empty-state">No saved timesheets yet.</p>`;
+    return;
+  }
+
+  for (const sheet of [...appState.timesheets].reverse()) {
+    const item = document.createElement("article");
+    item.className = "compact-item";
+    item.innerHTML = `<div><strong>Week of ${formatDay.format(fromDateInputValue(sheet.weekStart))}</strong><div class="muted">${sheet.totalHours || 0} total hours • Supervisor: ${sheet.supervisor || "—"}</div></div>`;
+    list.append(item);
+  }
+}
+
+function renderYellowSheet() {
+  const weekStart = startOfWeek(appState.selectedDate);
+  const jobs = currentWeekJobs();
+  document.querySelector("#yellowWeekStartLabel").textContent = formatDay.format(fromDateInputValue(weekStart));
+  document.querySelector("#yellowTotalJobs").textContent = jobs.length;
+
+  const list = document.querySelector("#yellowJobList");
+  list.innerHTML = "";
+
+  if (jobs.length === 0) {
+    list.innerHTML = `<p class="empty-state">No jobs in this week yet.</p>`;
+  } else {
+    for (const job of jobs) list.append(makeJobItem(job, { readOnly: true }));
+  }
+
+  renderPastYellowSheets();
+}
+
+function renderPastYellowSheets() {
+  const list = document.querySelector("#pastYellowSheetsList");
+  list.innerHTML = "";
+
+  if (appState.yellowSheets.length === 0) {
+    list.innerHTML = `<p class="empty-state">No saved yellow sheets yet.</p>`;
+    return;
+  }
+
+  for (const sheet of [...appState.yellowSheets].reverse()) {
+    const item = document.createElement("article");
+    item.className = "compact-item";
+    item.innerHTML = `<div><strong>Week of ${formatDay.format(fromDateInputValue(sheet.weekStart))}</strong><div class="muted">${sheet.totalJobs} jobs saved</div></div>`;
+    list.append(item);
+  }
+}
+
+function renderSearchResults() {
+  const query = searchInput.value.trim().toLowerCase();
+  const results = query
+    ? appState.jobs.filter((job) => [job.address, job.jobNumber, job.status, job.notes, job.assignments, job.materialsUsed].some((value) => String(value || "").toLowerCase().includes(query)))
+    : appState.jobs;
+
+  const searchResults = document.querySelector("#searchResults");
+  searchResults.innerHTML = "";
+
+  if (results.length === 0) {
+    searchResults.innerHTML = `<p class="empty-state">No matching jobs found.</p>`;
+    return;
+  }
+
+  for (const job of results) searchResults.append(makeJobItem(job, { readOnly: true }));
+}
+
+function render() {
+  renderWeekdayPicker();
+  renderDashboardSummary();
+  renderJobs();
+  renderTimesheet();
+  renderYellowSheet();
+  renderSearchResults();
+}
+
+for (const button of tabButtons) {
+  button.addEventListener("click", () => navigateTo(button.dataset.tabTarget));
+}
+
+document.querySelector("[data-tab-link]").addEventListener("click", (event) => {
+  event.preventDefault();
+  navigateTo("dashboard");
+});
+
+weekdayPicker.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-date]");
+  if (!button) return;
+  appState.selectedDate = button.dataset.date;
+  render();
+});
 
 jobForm.addEventListener("submit", (event) => {
   event.preventDefault();
 
   const formData = new FormData(jobForm);
-  jobs = [
+  appState.jobs = [
     {
       id: createId(),
       address: formData.get("address").trim(),
-      type: formData.get("type"),
+      date: appState.selectedDate,
       status: formData.get("status"),
-      note: formData.get("note").trim(),
+      notes: formData.get("notes").trim(),
+      jobNumber: formData.get("jobNumber").trim(),
+      assignments: "",
+      materialsUsed: "",
+      hours: 0,
     },
-    ...jobs,
+    ...appState.jobs,
   ];
 
-  saveJobs();
-  render();
+  saveStoredArray(storageKeys.jobs, appState.jobs);
   jobForm.reset();
+  render();
 });
 
 jobList.addEventListener("click", (event) => {
   const deleteButton = event.target.closest("[data-delete-job]");
+  if (!deleteButton) return;
 
-  if (!deleteButton) {
-    return;
-  }
+  appState.jobs = appState.jobs.filter((job) => job.id !== deleteButton.dataset.deleteJob);
+  saveStoredArray(storageKeys.jobs, appState.jobs);
+  render();
+});
 
-  jobs = jobs.filter((job) => job.id !== deleteButton.dataset.deleteJob);
-  saveJobs();
+jobList.addEventListener("change", (event) => {
+  const statusSelect = event.target.closest("[data-status-job]");
+  if (!statusSelect) return;
+
+  appState.jobs = appState.jobs.map((job) => job.id === statusSelect.dataset.statusJob ? { ...job, status: statusSelect.value } : job);
+  saveStoredArray(storageKeys.jobs, appState.jobs);
   render();
 });
 
 resetJobsButton.addEventListener("click", () => {
-  jobs = defaultJobs.map((job) => ({ ...job, id: createId() }));
-  saveJobs();
+  appState.jobs = defaultJobs.map((job) => ({ ...job, id: createId() }));
+  saveStoredArray(storageKeys.jobs, appState.jobs);
   render();
 });
 
-assistForm.addEventListener("submit", (event) => {
-  event.preventDefault();
+focusCreateJobButton.addEventListener("click", () => document.querySelector("#addressInput").focus());
 
-  const issue = assistInput.value.trim();
-  const prefix = issue ? `For “${issue}”: ` : "";
-  assistOutput.value = `${prefix}verify light levels, inspect connectors, compare splice records, capture photos, and escalate with cabinet or CAN details.`;
+timesheetForm.addEventListener("input", updateTimesheetTotal);
+dailyHoursGrid.addEventListener("input", updateTimesheetTotal);
+
+saveTimesheetButton.addEventListener("click", () => {
+  const formData = new FormData(timesheetForm);
+  const dailyTotalHours = Object.fromEntries(Array.from(document.querySelectorAll("[data-daily-hours]")).map((input) => [input.dataset.dailyHours, input.value || "0"]));
+  const weekStart = startOfWeek(appState.selectedDate);
+  const sheet = {
+    id: createId(),
+    weekStart,
+    supervisor: formData.get("supervisor").trim(),
+    name1: formData.get("name1").trim(),
+    name2: formData.get("name2").trim(),
+    gibsonHours: formData.get("gibsonHours"),
+    cableSouthHours: formData.get("cableSouthHours"),
+    totalHours: formData.get("totalHours"),
+    dailyTotalHours,
+  };
+
+  appState.timesheets = appState.timesheets.filter((item) => item.weekStart !== weekStart).concat(sheet);
+  saveStoredArray(storageKeys.timesheets, appState.timesheets);
+  renderPastTimesheets();
 });
+
+saveYellowSheetButton.addEventListener("click", () => {
+  const weekStart = startOfWeek(appState.selectedDate);
+  const sheet = { id: createId(), weekStart, totalJobs: currentWeekJobs().length };
+  appState.yellowSheets = appState.yellowSheets.filter((item) => item.weekStart !== weekStart).concat(sheet);
+  saveStoredArray(storageKeys.yellowSheets, appState.yellowSheets);
+  renderPastYellowSheets();
+});
+
+searchInput.addEventListener("input", renderSearchResults);
+
+document.querySelectorAll("[data-search-filter]").forEach((button) => {
+  button.addEventListener("click", () => {
+    searchInput.value = button.dataset.searchFilter;
+    renderSearchResults();
+  });
+});
+
+const initialHash = window.location.hash.replace("#", "");
+if (["dashboard", "timesheets", "yellowSheet", "jobSearch", "more"].includes(initialHash)) {
+  navigateTo(initialHash);
+}
 
 renderDate();
 render();

--- a/website/styles.css
+++ b/website/styles.css
@@ -2,7 +2,7 @@
   color-scheme: dark;
   --bg: #08111f;
   --bg-soft: #101b2d;
-  --card: rgba(18, 31, 52, 0.82);
+  --card: rgba(18, 31, 52, 0.84);
   --card-strong: rgba(20, 40, 70, 0.96);
   --line: rgba(154, 179, 219, 0.22);
   --text: #eef5ff;
@@ -17,13 +17,9 @@
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
-html {
-  scroll-behavior: smooth;
-}
+html { scroll-behavior: smooth; }
 
 body {
   min-height: 100vh;
@@ -37,31 +33,26 @@ body {
 
 button,
 input,
-select,
-textarea {
-  font: inherit;
-}
+select { font: inherit; }
 
-button {
-  cursor: pointer;
-}
-
-a {
-  color: inherit;
-}
+button { cursor: pointer; }
+a { color: inherit; }
 
 .app-shell {
-  display: grid;
-  grid-template-columns: 18rem minmax(0, 1fr);
   min-height: 100vh;
+  padding-bottom: 6.8rem;
 }
 
-.sidebar {
+.app-header {
   position: sticky;
   top: 0;
-  height: 100vh;
-  padding: 2rem;
-  border-right: 1px solid var(--line);
+  z-index: 5;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem clamp(1rem, 4vw, 2rem);
+  border-bottom: 1px solid var(--line);
   background: rgba(8, 17, 31, 0.78);
   backdrop-filter: blur(20px);
 }
@@ -86,7 +77,6 @@ a {
 }
 
 .brand small,
-.sidebar-card small,
 .metric-label,
 .eyebrow {
   display: block;
@@ -97,91 +87,92 @@ a {
   text-transform: uppercase;
 }
 
-.nav-links {
-  display: grid;
-  gap: 0.6rem;
-  margin: 3rem 0;
-}
-
-.nav-links a {
-  padding: 0.85rem 1rem;
-  border: 1px solid transparent;
-  border-radius: 1rem;
+.sync-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
   color: var(--muted);
-  text-decoration: none;
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
-.nav-links a:hover,
-.nav-links a:focus-visible {
-  border-color: var(--line);
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text);
+.pulse {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--success);
+  box-shadow: 0 0 0 0 rgba(99, 230, 169, 0.5);
+  animation: pulse 1.8s infinite;
 }
 
-.sidebar-card,
+@keyframes pulse {
+  70% { box-shadow: 0 0 0 0.45rem rgba(99, 230, 169, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(99, 230, 169, 0); }
+}
+
+.content {
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: clamp(1rem, 4vw, 2rem);
+}
+
+.tab-view {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.tab-view[hidden] { display: none; }
+
+.page-hero,
+.page-heading,
 .workspace-card,
-.feature-card,
-.hero-panel {
+.summary-card {
   border: 1px solid var(--line);
   border-radius: 1.5rem;
   background: var(--card);
   box-shadow: var(--shadow);
 }
 
-.sidebar-card {
+.page-hero {
   display: grid;
-  gap: 0.35rem;
-  padding: 1rem;
-}
-
-.content {
-  display: grid;
-  gap: 1.5rem;
-  width: min(100%, 1180px);
-  margin: 0 auto;
-  padding: 2rem;
-}
-
-.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(20rem, 0.65fr);
-  gap: 1.5rem;
-  align-items: stretch;
-  min-height: 33rem;
-  padding: clamp(2rem, 5vw, 4rem);
-  border: 1px solid var(--line);
-  border-radius: 2rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+  min-height: 18rem;
+  padding: clamp(1.35rem, 5vw, 3rem);
   background:
-    linear-gradient(135deg, rgba(18, 31, 52, 0.92), rgba(12, 21, 37, 0.72)),
-    linear-gradient(135deg, rgba(98, 213, 255, 0.2), rgba(47, 140, 255, 0.1));
-  box-shadow: var(--shadow);
+    linear-gradient(135deg, rgba(18, 31, 52, 0.94), rgba(12, 21, 37, 0.72)),
+    linear-gradient(135deg, rgba(98, 213, 255, 0.22), rgba(47, 140, 255, 0.1));
 }
 
-.hero-copy {
-  align-self: center;
+.page-heading,
+.workspace-card,
+.summary-card {
+  padding: 1.25rem;
 }
 
-.hero h1 {
-  max-width: 12ch;
-  margin: 0.5rem 0 1rem;
-  font-size: clamp(2.8rem, 8vw, 5.8rem);
+h1,
+h2,
+h3,
+p { margin-top: 0; }
+
+h1 {
+  margin-bottom: 0.7rem;
+  font-size: clamp(2.4rem, 8vw, 5rem);
   line-height: 0.9;
-  letter-spacing: -0.08em;
+  letter-spacing: -0.07em;
 }
 
-.hero p {
-  max-width: 45rem;
+h2 { margin-bottom: 0.7rem; }
+
+.lede,
+.muted {
   color: var(--muted);
-  font-size: 1.08rem;
-  line-height: 1.7;
-}
-
-.hero-actions,
-.section-heading {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.8rem;
-  align-items: center;
+  line-height: 1.6;
 }
 
 .button {
@@ -207,17 +198,26 @@ a {
   color: var(--text);
 }
 
-.hero-panel {
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.summary-card {
   display: grid;
-  align-content: center;
-  gap: 1.2rem;
-  padding: 1.5rem;
+  grid-template-columns: 12rem minmax(12rem, 1fr) 1fr;
+  gap: 1.25rem;
+  align-items: center;
   background: var(--card-strong);
 }
 
-.hero-panel strong {
-  font-size: 4rem;
-  letter-spacing: -0.07em;
+.summary-card strong {
+  font-size: 3.2rem;
+  letter-spacing: -0.06em;
 }
 
 .progress-track {
@@ -239,70 +239,79 @@ a {
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.8rem;
+  gap: 0.75rem;
   margin: 0;
 }
 
-.metric-grid div {
-  padding: 0.9rem;
+.metric-grid div,
+.yellow-summary article {
+  padding: 0.85rem;
   border: 1px solid var(--line);
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.05);
 }
 
-.metric-grid dt {
+.metric-grid dt,
+.yellow-summary span {
   color: var(--muted);
   font-size: 0.8rem;
 }
 
 .metric-grid dd {
   margin: 0.25rem 0 0;
-  font-size: 1.8rem;
+  font-size: 1.65rem;
   font-weight: 900;
 }
 
-.section-grid,
-.two-column {
+.weekday-picker,
+.quick-filters {
+  display: flex;
+  gap: 0.55rem;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
+}
+
+.day-button,
+.chip {
+  min-width: max-content;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-weight: 800;
+}
+
+.day-button {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.15rem;
+  padding: 0.7rem 0.95rem;
 }
 
-.two-column {
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+.day-button small { color: var(--muted); }
+
+.day-button.active,
+.chip:hover,
+.chip:focus-visible {
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #04111f;
 }
 
-.feature-card,
-.workspace-card {
-  padding: 1.3rem;
-}
+.day-button.active small { color: rgba(4, 17, 31, 0.72); }
 
-.feature-card .icon {
-  font-size: 2rem;
-}
+.chip { padding: 0.6rem 0.85rem; }
 
-.feature-card h2,
-.workspace-card h2 {
-  margin: 0.4rem 0;
-}
-
-.feature-card p,
-.workspace-card p,
-.timeline span {
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-.section-heading {
-  justify-content: space-between;
-  margin-bottom: 1rem;
-}
-
-.job-form {
+.job-form,
+.timesheet-form {
   display: grid;
-  grid-template-columns: 1.4fr 0.8fr 0.9fr 1.3fr auto;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) auto;
   gap: 0.8rem;
   align-items: end;
+}
+
+.timesheet-form {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 1rem;
 }
 
 label {
@@ -314,8 +323,7 @@ label {
 }
 
 input,
-select,
-textarea {
+select {
   width: 100%;
   border: 1px solid var(--line);
   border-radius: 0.9rem;
@@ -325,24 +333,22 @@ textarea {
   padding: 0.82rem 0.9rem;
 }
 
-textarea {
-  resize: vertical;
-}
-
 input:focus,
-select:focus,
-textarea:focus {
+select:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 4px rgba(98, 213, 255, 0.12);
 }
 
-.job-list {
+input[readonly] { color: var(--success); }
+
+.job-list,
+.compact-list {
   display: grid;
   gap: 0.75rem;
-  margin-top: 1rem;
 }
 
-.job-item {
+.job-item,
+.compact-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
@@ -353,9 +359,7 @@ textarea:focus {
   background: rgba(255, 255, 255, 0.05);
 }
 
-.job-item h3 {
-  margin: 0;
-}
+.job-item h3 { margin: 0; }
 
 .job-meta {
   display: flex;
@@ -374,107 +378,133 @@ textarea:focus {
   font-weight: 800;
 }
 
-.badge.done {
-  background: rgba(99, 230, 169, 0.17);
-  color: var(--success);
+.badge.done { background: rgba(99, 230, 169, 0.17); color: var(--success); }
+.badge.warning { background: rgba(255, 209, 102, 0.17); color: var(--warning); }
+
+.empty-state {
+  margin: 0;
+  padding: 1rem;
+  border: 1px dashed var(--line);
+  border-radius: 1rem;
+  color: var(--muted);
 }
 
-.badge.warning {
-  background: rgba(255, 209, 102, 0.17);
-  color: var(--warning);
-}
-
-.timeline,
-.checklist {
+.daily-hours,
+.yellow-summary {
   display: grid;
-  gap: 1rem;
-  padding: 0;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.7rem;
 }
 
-.timeline li {
-  display: grid;
-  gap: 0.25rem;
-  padding-left: 1rem;
-  border-left: 3px solid var(--accent);
-}
-
-.checklist label {
-  display: flex;
-  align-items: center;
+.daily-hours label {
   padding: 0.8rem;
   border: 1px solid var(--line);
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.05);
+}
+
+.yellow-summary {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+
+.yellow-summary strong {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1.7rem;
+}
+
+.job-list.compact .job-item { grid-template-columns: 1fr; }
+
+.search-field { margin-bottom: 0.9rem; }
+
+.more-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.more-list section {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.more-list h2 {
+  margin: 0 0 0.25rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.more-list a {
+  padding: 0.8rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.05);
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.bottom-tabs {
+  position: fixed;
+  left: 50%;
+  bottom: 1rem;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  width: min(calc(100% - 1rem), 44rem);
+  padding: 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 1.5rem;
+  background: rgba(10, 21, 38, 0.9);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(24px);
+  transform: translateX(-50%);
+}
+
+.tab-button {
+  display: grid;
+  gap: 0.2rem;
+  place-items: center;
+  min-height: 4.2rem;
+  border: 0;
+  border-radius: 1.1rem;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.tab-button span { font-size: 1.35rem; line-height: 1; }
+.tab-button small { font-size: 0.72rem; }
+
+.tab-button.active {
+  background: linear-gradient(135deg, rgba(98, 213, 255, 0.22), rgba(47, 140, 255, 0.18));
   color: var(--text);
 }
 
-.checklist input {
-  width: auto;
-  accent-color: var(--accent);
-}
-
-.assist-card {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-  gap: 1.5rem;
-  align-items: center;
-}
-
-.assist-form {
-  display: grid;
-  gap: 0.8rem;
-}
-
-output {
-  min-height: 2rem;
-  color: var(--success);
-  line-height: 1.5;
-}
-
-@media (max-width: 1020px) {
-  .app-shell,
-  .hero,
-  .section-grid,
-  .two-column,
-  .assist-card,
-  .job-form {
+@media (max-width: 900px) {
+  .page-hero,
+  .summary-card,
+  .job-form,
+  .timesheet-form,
+  .daily-hours {
     grid-template-columns: 1fr;
   }
 
-  .sidebar {
-    position: static;
-    height: auto;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .nav-links {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    margin: 1.5rem 0;
-  }
+  .metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 @media (max-width: 640px) {
-  .content,
-  .sidebar {
-    padding: 1rem;
-  }
-
-  .hero {
-    min-height: auto;
-    padding: 1.3rem;
-  }
-
-  .hero h1 {
-    font-size: 3rem;
-  }
-
-  .nav-links,
-  .metric-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .job-item {
-    grid-template-columns: 1fr;
-  }
+  .app-header { align-items: flex-start; }
+  .sync-pill { display: none; }
+  .content { padding: 1rem; }
+  .page-hero { min-height: auto; }
+  .metric-grid,
+  .yellow-summary { grid-template-columns: 1fr; }
+  .job-item,
+  .compact-item { grid-template-columns: 1fr; }
+  .tab-button small { font-size: 0.64rem; }
 }


### PR DESCRIPTION
### Motivation
- Align the web prototype with the native iOS app by implementing the same five primary tabs: Dashboard, Timesheets, Yellow Sheet, Job Search, and More. 
- Ensure each tab shows only the content relevant to that view so the Dashboard is not a single long page with unrelated workflows. 
- Group native-only or extended functionality under the `More` area instead of exposing it on the Dashboard. 

### Description
- Reworked the top-level layout in `website/index.html` to replace the long single-page UI with discrete tab views and a fixed bottom tab bar, including `dashboardView`, `timesheetsView`, `yellowSheetView`, `jobSearchView`, and `moreView`. 
- Replaced the old sidebar/hero layout with a compact header and a bottom tab bar and moved dashboard-only controls into the `dashboard` tab so other workflows live in their own views. 
- Rewrote `website/script.js` to an `appState`-driven model with tab routing, `localStorage` keys (`job-tracker-web-tabs-*`), weekday picker rendering, per-day job CRUD, weekly timesheet capture, yellow-sheet saving, and client-side search/filtering. 
- Updated `website/styles.css` to support the tabbed layout, bottom-tab styling, responsive behavior, and adjusted component styles to match the app parity plan, and updated `website/README.md` to document the parity-focused structure. 

### Testing
- Parsed the updated HTML with a small `python3` HTML parser script, which succeeded. 
- Ran `node --check website/script.js` to validate the JavaScript syntax, which succeeded. 
- Served the `website/` directory with a simple HTTP server and verified an HTTP `200` response with `curl -I`, which succeeded. 
- Attempted an automated screenshot via `playwright` install, but the environment npm registry returned `403 Forbidden`, so screenshots could not be captured in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e1ba9084832d882e15d215dfd2e7)