### PR TITLE
Align web app bottom-tab navigation

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -133,7 +133,7 @@
           </section>
         </section>
 
-        <section class="view" id="timesheetsView" data-view="timesheets">
+        <section class="view" id="timesheetsView" data-view="timesheets" hidden>
           <div class="page-heading"><p class="eyebrow">Timesheets</p><h1>Weekly timesheet</h1><p>Log Gibson, Cable South, and total hours by day, attach job notes, save the week, and export a supervisor-ready summary.</p></div>
           <section class="workspace-card">
             <div class="timesheet-toolbar">
@@ -154,7 +154,7 @@
           <section class="workspace-card"><p class="eyebrow">History</p><h2>Past timesheets</h2><div class="compact-list" id="pastTimesheetsList"></div></section>
         </section>
 
-        <section class="view" id="yellowSheetsView" data-view="yellowSheets">
+        <section class="view" id="yellowSheetsView" data-view="yellowSheets" hidden>
           <div class="page-heading"><p class="eyebrow">Yellow Sheets</p><h1>Daily compliance sheet</h1><p>Capture safety checks, material usage, job notes, and technician signature for the selected date.</p></div>
           <section class="workspace-card yellow-form">
             <div class="form-grid three">
@@ -177,7 +177,7 @@
           <section class="workspace-card"><p class="eyebrow">History</p><h2>Past yellow sheets</h2><div class="compact-list" id="pastYellowSheetsList"></div></section>
         </section>
 
-        <section class="view" id="searchView" data-view="search">
+        <section class="view" id="searchView" data-view="search" hidden>
           <div class="page-heading"><p class="eyebrow">Job Search</p><h1>Job Search</h1><p>Look up any job across Cable South in seconds.</p></div>
           <section class="workspace-card search-workspace">
             <label class="search-box">Search jobs<input id="jobSearchInput" placeholder="Address, job #, status, or teammate" /></label>
@@ -186,12 +186,18 @@
           </section>
         </section>
 
-        <section class="view" id="moreView" data-view="more">
-          <div class="page-heading"><p class="eyebrow">More</p><h1>Profile, settings, and partner tools</h1><p>The required More sections are available here with Firebase-backed persistence.</p></div>
-          <section class="more-tabs" role="tablist" aria-label="More sections">
-            <button class="segment active" type="button" data-more-tab="profile">Profile</button>
-            <button class="segment" type="button" data-more-tab="settings">Settings</button>
-            <button class="segment" type="button" data-more-tab="partner">Find a partner</button>
+        <section class="view" id="moreView" data-view="more" hidden>
+          <div class="page-heading"><p class="eyebrow">More</p><h1>More</h1><p>Choose one of the same secondary sections that live under the iOS app's More tab.</p></div>
+          <section class="more-menu" aria-label="More sections">
+            <div class="more-menu-section">
+              <h2>Account</h2>
+              <button class="more-menu-item active" type="button" data-more-tab="profile"><span aria-hidden="true">👤</span><strong>Profile</strong></button>
+              <button class="more-menu-item" type="button" data-more-tab="settings"><span aria-hidden="true">⚙️</span><strong>Settings</strong></button>
+            </div>
+            <div class="more-menu-section">
+              <h2>Team</h2>
+              <button class="more-menu-item" type="button" data-more-tab="partner"><span aria-hidden="true">👥</span><strong>Find a Partner</strong></button>
+            </div>
           </section>
 
           <section class="workspace-card more-panel active" id="profilePanel" data-more-panel="profile">
@@ -240,7 +246,7 @@
       </main>
 
       <nav class="bottom-tab-bar" aria-label="Primary">
-        <button class="tab-button active" type="button" data-route="dashboard" aria-label="Dashboard" data-symbol="rectangle.grid.2x2">
+        <button class="tab-button active" type="button" data-route="dashboard" aria-label="Dashboard" aria-current="page" data-symbol="rectangle.grid.2x2">
           <span class="tab-symbol" aria-hidden="true">▦</span>
           <span class="tab-label">Dashboard</span>
         </button>

--- a/website/app/parity-enhancements.js
+++ b/website/app/parity-enhancements.js
@@ -11,8 +11,10 @@ encodeValue = function enhancedEncodeValue(value, key = "") {
 };
 
 function hydrateStatusSelect(select, selectedStatus = "Pending") {
+  if (!select) return;
   select.innerHTML = "";
-  statuses.forEach((status) => {
+  const optionValues = statuses.includes(selectedStatus) ? statuses : [selectedStatus, ...statuses];
+  optionValues.forEach((status) => {
     const option = document.createElement("option");
     option.value = status;
     option.textContent = status;
@@ -288,12 +290,12 @@ renderAll = function enhancedRenderAll() {
 function bindParityEnhancementEvents() {
   hydrateStatusSelect($("#detailStatus"));
   hydrateShareTokenFromUrl();
-  $("#jobDetailForm").addEventListener("submit", (event) => saveJobDetail(event).catch((error) => showToast(error.message)));
-  $("#closeJobDetailButton").addEventListener("click", closeJobDetail);
-  $("#routeJobButton").addEventListener("click", () => openRouteForJob(currentDetailJob()));
-  $("#shareJobDetailButton").addEventListener("click", () => shareDetailJob().catch((error) => showToast(error.message)));
-  $("#removeJobDetailButton").addEventListener("click", () => removeDetailJob().catch((error) => showToast(error.message)));
-  $("#shareImportForm").addEventListener("submit", (event) => previewSharedJob(event).catch((error) => showToast(error.message)));
+  $("#jobDetailForm")?.addEventListener("submit", (event) => saveJobDetail(event).catch((error) => showToast(error.message)));
+  $("#closeJobDetailButton")?.addEventListener("click", closeJobDetail);
+  $("#routeJobButton")?.addEventListener("click", () => openRouteForJob(currentDetailJob()));
+  $("#shareJobDetailButton")?.addEventListener("click", () => shareDetailJob().catch((error) => showToast(error.message)));
+  $("#removeJobDetailButton")?.addEventListener("click", () => removeDetailJob().catch((error) => showToast(error.message)));
+  $("#shareImportForm")?.addEventListener("submit", (event) => previewSharedJob(event).catch((error) => showToast(error.message)));
 }
 
 bindParityEnhancementEvents();

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -3,7 +3,7 @@ const authBase = "https://identitytoolkit.googleapis.com/v1";
 const tokenBase = "https://securetoken.googleapis.com/v1/token";
 const firestoreBase = config.projectId ? `https://firestore.googleapis.com/v1/projects/${config.projectId}/databases/(default)/documents` : "";
 const sessionKey = "job-tracker-web-firebase-session";
-const statuses = ["Pending", "In Progress", "Needs Ariel", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick"];
+const statuses = ["Pending", "Aerial", "UG", "Nid", "Can", "Done", "Talk to Rick", "Custom"];
 const weekDays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 const shortDays = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 const shareTokenAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789";
@@ -1006,7 +1006,15 @@ async function saveSettings() {
   showToast("Settings saved to Firebase.");
 }
 
-function setMoreTab(tab) { currentMoreTab = tab; $$('[data-more-tab]').forEach((button) => button.classList.toggle("active", button.dataset.moreTab === tab)); $$('[data-more-panel]').forEach((panel) => panel.classList.toggle("active", panel.dataset.morePanel === tab)); }
+function setMoreTab(tab) {
+  currentMoreTab = tab;
+  $$('[data-more-tab]').forEach((button) => {
+    const isActive = button.dataset.moreTab === tab;
+    button.classList.toggle("active", isActive);
+    button.toggleAttribute("aria-current", isActive);
+  });
+  $$('[data-more-panel]').forEach((panel) => panel.classList.toggle("active", panel.dataset.morePanel === tab));
+}
 function userName(uid) { const user = appState.users.find((item) => item.id === uid); return user ? `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.email : uid; }
 function partnerName(request) { return request.fromUid === currentUser.id ? userName(request.toUid) : userName(request.fromUid); }
 
@@ -1061,13 +1069,30 @@ async function updatePartnerRequest(id, status) {
   showToast(`Request ${status}.`);
 }
 
-function navigate(route) {
-  $$('[data-view]').forEach((view) => view.classList.toggle("active", view.dataset.view === route));
-  $$('[data-route]').forEach((button) => button.classList.toggle("active", button.dataset.route === route));
-  if (route === "timesheets") renderTimesheet();
-  if (route === "yellowSheets") renderYellowSheet();
-  if (route === "search") renderSearch();
-  if (route === "more") setMoreTab(currentMoreTab);
+function normalizeRoute(route) {
+  const aliases = { yellowSheet: "yellowSheets", jobSearch: "search" };
+  const requestedRoute = aliases[route] || route;
+  return $(`[data-view="${requestedRoute}"]`) ? requestedRoute : "dashboard";
+}
+
+function navigate(route, options = {}) {
+  const nextRoute = normalizeRoute(route);
+  $$('[data-view]').forEach((view) => {
+    const isActive = view.dataset.view === nextRoute;
+    view.classList.toggle("active", isActive);
+    view.hidden = !isActive;
+  });
+  $$('[data-route]').forEach((button) => {
+    const isActive = button.dataset.route === nextRoute;
+    button.classList.toggle("active", isActive);
+    button.toggleAttribute("aria-current", isActive);
+  });
+  if (currentUser && nextRoute === "timesheets") renderTimesheet();
+  if (currentUser && nextRoute === "yellowSheets") renderYellowSheet();
+  if (currentUser && nextRoute === "search") renderSearch();
+  if (nextRoute === "more") setMoreTab(currentMoreTab);
+  if (!options.skipHash) history.replaceState(null, "", `#${nextRoute}`);
+  if (!options.skipScroll) $("#appShell")?.scrollIntoView({ block: "start" });
 }
 
 function renderAll() {
@@ -1122,6 +1147,8 @@ function initializeInputs() {
 async function bootstrap() {
   bindEvents();
   initializeInputs();
+  navigate((window.location.hash || "#dashboard").slice(1), { skipHash: true, skipScroll: true });
+  window.addEventListener("hashchange", () => navigate((window.location.hash || "#dashboard").slice(1), { skipHash: true }));
   if (!config?.apiKey || !config?.projectId) { setMessage("Firebase config is missing. Update website/app/config.js before signing in."); return; }
   if (!authSession?.refreshToken) return;
   try { await refreshTokenIfNeeded(); await loadCurrentUser(); await enterApp(); }

--- a/website/app/styles.css
+++ b/website/app/styles.css
@@ -464,3 +464,43 @@ body.modal-open { overflow: hidden; }
   .date-picker-row { grid-template-columns: 1fr; }
   .date-chip { justify-content: center; }
 }
+
+.more-menu {
+  display: grid;
+  gap: 1rem;
+}
+.more-menu-section {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+.more-menu-section h2 {
+  margin: 0 0 0.25rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.more-menu-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 3.25rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  text-align: left;
+}
+.more-menu-item.active,
+.more-menu-item:focus-visible,
+.more-menu-item:hover {
+  border-color: rgba(98, 213, 255, 0.65);
+  background: rgba(98, 213, 255, 0.13);
+  outline: none;
+}


### PR DESCRIPTION
### Motivation
- Make the web shell mirror the iOS app navigation by splitting the one long page into five bottom-tab screens (Dashboard, Timesheets, Yellow Sheet, Job Search, More).
- Remove UI surface bleed where non-relevant workflows appeared on the Dashboard and ensure each tab only shows its relevant content.
- Keep the web parity with the native app for status options and More-tab structure so users get the expected experience.

### Description
- Marked non-active primary panels as hidden in `website/app/index.html` and converted the More section into an iOS-style menu that launches the existing More subpanels instead of a segmented control.
- Reworked routing in `website/app/script.js` by adding `normalizeRoute()` and an improved `navigate()` that toggles `hidden`, `active`, and `aria-current`, supports URL hash deep links, and defers rendering of authenticated tab content until `currentUser` is present.
- Aligned job status options with the iOS create-job list by updating `statuses` and made status select hydration robust to custom or unknown statuses in `website/app/parity-enhancements.js`.
- Guarded optional parity enhancement event bindings to avoid errors when optional DOM elements are absent and added menu styles in `website/app/styles.css`.

### Testing
- Performed static checks with `node --check website/app/script.js` and `node --check website/app/parity-enhancements.js` which succeeded.
- Verified HTML parsing for `website/app/index.html` and `website/index.html` with a `python3` `HTMLParser` pass which succeeded.
- Started a local static server via `python3 -m http.server 8000 --directory website/app` and confirmed the site responded with `curl -I http://127.0.0.1:8000/` and served the page.
- Ran `git diff --check` to ensure no whitespace or merge problems; no issues were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020c2dead4832dbf4e899be3fdb35f)