### PR TITLE
Set MARKETING_VERSION to 2.1.9 for WatchKit Companion target

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 2.1.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -321,7 +321,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 2.1.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;


### PR DESCRIPTION
### Motivation
- Update the watch companion app marketing/version number to match the intended release version.

### Description
- Change `MARKETING_VERSION` from `3.0` to `2.1.9` in the WatchKit Companion app `XCBuildConfiguration` entries for both `Debug` and `Release` in `project.pbxproj`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18445ea9e0832d9b9e42deeb2e358a)