### PR TITLE
Add Gibson portal support (portalID parsing, UI fields, and open-portal actions)

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -84,6 +84,8 @@ private struct DashboardJobSectionHeader: View {
 }
 
 struct JobCard: View {
+    @Environment(\.openURL) private var openURL
+
     let job: Job
     let isHere: Bool
     let statusOptions: [String]
@@ -139,6 +141,9 @@ struct JobCard: View {
         }
         .contextMenu {
             Button("Directions", systemImage: "map.fill", action: onMapTap)
+            if job.portalURL != nil {
+                Button("Open Portal", systemImage: "safari", action: openPortal)
+            }
             Button("Share", systemImage: "square.and.arrow.up", action: onShare)
             Button("Delete", role: .destructive, action: onDelete)
         }
@@ -264,6 +269,19 @@ struct JobCard: View {
 
             Spacer()
 
+            if job.portalURL != nil {
+                Button(action: openPortal) {
+                    Label("Open Portal", systemImage: "safari")
+                        .font(JTTypography.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(JTColors.textPrimary)
+                        .padding(.horizontal, JTSpacing.sm)
+                        .padding(.vertical, JTSpacing.xs)
+                        .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                }
+                .accessibilityLabel("Open Gibson portal")
+            }
+
             Button(action: onMapTap) {
                 Image(systemName: "map")
                     .imageScale(.medium)
@@ -294,6 +312,11 @@ struct JobCard: View {
                     .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
             }
         }
+    }
+
+    private func openPortal() {
+        guard let url = job.portalURL else { return }
+        openURL(url)
     }
 
     private func statusBackground(for status: String) -> Color {
@@ -349,6 +372,7 @@ private struct DashboardJobSectionsPreviewContainer: View {
             date: today,
             status: "Pending",
             notes: "Call ahead",
+            portalID: "97087",
             assignments: "12.3.2",
             materialsUsed: "Coax, Splitter"
         )

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -176,6 +176,7 @@ struct CreateJobView: View {
     @State private var notes = ""
     @State private var materialsUsed = ""
     @State private var jobNumber = ""
+    @State private var portalID = ""
     @State private var customStatusText = ""
     @State private var assignmentsText: String = ""
     @FocusState private var isAssignmentsFocused: Bool
@@ -261,6 +262,29 @@ struct CreateJobView: View {
                                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                                         .stroke(Color.gray.opacity(0.15), lineWidth: 1)
                                 )
+                        }
+
+                        // Portal ID
+                        SectionCard(title: "Portal ID") {
+                            VStack(alignment: .leading, spacing: 6) {
+                                TextField("Optional, e.g. 97087", text: $portalID)
+                                    .keyboardType(.numberPad)
+                                    .textInputAutocapitalization(.never)
+                                    .disableAutocorrection(true)
+                                    .padding(12)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                            .fill(Color(.systemBackground).opacity(0.9))
+                                    )
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                            .stroke(Color.gray.opacity(0.15), lineWidth: 1)
+                                    )
+
+                                Text("Enter the Gibson portal edit ID, or paste the full portal link and the app will store the ID.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
 
                         // Assignments (role-based)
@@ -414,6 +438,12 @@ struct CreateJobView: View {
             return
         }
 
+        if !portalID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           Job.normalizedPortalID(from: portalID) == nil {
+            alertMessage = "Please enter a valid numeric Portal ID or paste a Gibson portal edit link."
+            return
+        }
+
         saveJobs(addressesToSave: trimmedAddresses)
     }
 
@@ -428,6 +458,7 @@ struct CreateJobView: View {
 
         let sanitizedAssign = sanitizeAssignment(assignmentsText)
         let assignmentsValue = sanitizedAssign.isEmpty || !isValidAssignment(sanitizedAssign) ? nil : sanitizedAssign
+        let portalIDValue = Job.normalizedPortalID(from: portalID)
 
         let geocoder = CLGeocoder()
 
@@ -449,6 +480,7 @@ struct CreateJobView: View {
                     createdBy: userID,
                     notes: notes,
                     jobNumber: jobNumber.isEmpty ? nil : jobNumber,
+                    portalID: portalIDValue,
                     assignments: assignmentsValue,
                     materialsUsed: materialsUsed,
                     latitude: coord?.latitude,

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -46,6 +46,7 @@ struct JobDetailView: View {
     @State private var customStatusText = ""
     @State private var editedNotes = ""
     @State private var editedJobNumber = ""
+    @State private var editedPortalID = ""
     @State private var selectedMaterialAriel = "None"
     @State private var selectedMaterialNid = ""
     @State private var preformCount = 0
@@ -125,6 +126,11 @@ private let jobPlacementChoices = ["OH", "UG"]
     // Locale-aware decimal separator used by the keyboard toolbar
     private var decimalSeparator: String { Locale.current.decimalSeparator ?? "." }
 
+    private var isPortalIDInvalid: Bool {
+        let trimmed = editedPortalID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && Job.normalizedPortalID(from: trimmed) == nil
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -161,6 +167,18 @@ private let jobPlacementChoices = ["OH", "UG"]
                         TextField("Job #", text: $editedJobNumber)
                             .glassCard()
                             .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                        TextField("Portal ID", text: $editedPortalID)
+                            .keyboardType(.numberPad)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                            .glassCard()
+                            .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                        if isPortalIDInvalid {
+                            Text("Enter a numeric Portal ID or paste a Gibson portal edit link.")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 8, trailing: 12))
+                        }
                         Picker("Status", selection: $editedStatus) {
                             ForEach(statusOptions, id: \.self) { Text($0) }
                         }
@@ -313,6 +331,7 @@ private let jobPlacementChoices = ["OH", "UG"]
                                 (authViewModel.currentUser?.position == "Can"
                                  && !assignmentsText.isEmpty
                                  && !isValidAssignment(assignmentsText))
+                                || isPortalIDInvalid
                                 || showSavingPopup
                             )
                     }
@@ -446,6 +465,7 @@ private let jobPlacementChoices = ["OH", "UG"]
                 }
                 editedNotes      = job.notes ?? ""
                 editedJobNumber  = job.jobNumber ?? ""
+                editedPortalID   = job.portalID ?? ""
                 selectedMaterialAriel = "None"
                 selectedMaterialNid   = nidMaterials.first ?? ""
                 canFootage       = job.canFootage ?? ""
@@ -926,6 +946,7 @@ extension JobDetailView {
         job.status    = finalStatus
         job.notes     = editedNotes.isEmpty ? nil : editedNotes
         job.jobNumber = editedJobNumber.isEmpty ? nil : editedJobNumber
+        job.portalID = Job.normalizedPortalID(from: editedPortalID)
         job.jobPlacement = normalizedPlacement(jobPlacement)
 
         // Assignments (validate & sanitize) — use strict sanitizer on save

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -613,6 +613,7 @@ struct SupervisorCreateJobView: View {
     @State private var notes = ""
     @State private var materialsUsed = ""
     @State private var jobNumber = ""
+    @State private var portalID = ""
     @State private var assignmentsText: String = ""
     @State private var selectedUserID: String? = nil
     @State private var showUserPicker = false
@@ -627,6 +628,11 @@ struct SupervisorCreateJobView: View {
     @State private var showAlert = false
 
     // No statusOptions needed; status always Pending
+
+    private var isPortalIDInvalid: Bool {
+        let trimmed = portalID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && Job.normalizedPortalID(from: trimmed) == nil
+    }
 
     private var selectedUserName: String {
         guard let id = selectedUserID, let u = usersViewModel.user(id: id) else { return "Unassigned" }
@@ -753,6 +759,21 @@ struct SupervisorCreateJobView: View {
                         TextField("Required", text: $jobNumber)
                     }
 
+                    Section(header: Text("Portal ID")) {
+                        TextField("Optional, e.g. 97087", text: $portalID)
+                            .keyboardType(.numberPad)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        Text("Enter the Gibson portal edit ID, or paste the full portal link and the app will store the ID.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        if isPortalIDInvalid {
+                            Text("Enter a numeric Portal ID or paste a Gibson portal edit link.")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
+                    }
+
                     Section(header: Text("Materials Used")) {
                         TextField("Enter materials info…", text: $materialsUsed)
                     }
@@ -772,7 +793,7 @@ struct SupervisorCreateJobView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Save") { saveJob() }
-                        .disabled(jobNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .disabled(jobNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isPortalIDInvalid)
                 }
             }
             .sheet(isPresented: $showUserPicker) {
@@ -821,6 +842,7 @@ struct SupervisorCreateJobView: View {
                 createdBy: supervisorID,
                 notes: notes,
                 jobNumber: jobNumber.isEmpty ? nil : jobNumber,
+                portalID: Job.normalizedPortalID(from: portalID),
                 assignments: assignmentsText.isEmpty ? nil : assignmentsText,
                 materialsUsed: materialsUsed,
                 latitude: coord?.latitude,

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -66,6 +66,10 @@ struct JobSearchDetailView: View {
             items.append(.init(title: "Assigned to", value: assigned, systemImage: "person.crop.circle"))
         }
 
+        if let portalID = displayValue(job.portalID) {
+            items.append(.init(title: "Portal ID", value: portalID, systemImage: "safari"))
+        }
+
         if let assignments = displayValue(job.assignments) {
             items.append(.init(title: "Assignment", value: assignments, systemImage: "list.number"))
         }
@@ -220,11 +224,22 @@ struct JobSearchDetailView: View {
                 openInMaps(job: job)
             }
 
+            if job.portalURL != nil {
+                QuickActionButton(title: "Open Portal", systemImage: "safari") {
+                    openPortal(job: job)
+                }
+            }
+
             QuickActionButton(title: "Share", systemImage: "square.and.arrow.up", isLoading: isGeneratingShareLink) {
                 share(job: job)
             }
             .disabled(isGeneratingShareLink)
         }
+    }
+
+    private func openPortal(job: Job) {
+        guard let url = job.portalURL else { return }
+        UIApplication.shared.open(url)
     }
 
     private func openInMaps(job: Job) {

--- a/Job Tracker/Features/Search/JobSearchViewModel.swift
+++ b/Job Tracker/Features/Search/JobSearchViewModel.swift
@@ -286,6 +286,7 @@ final class JobSearchViewModel: ObservableObject {
 
     private nonisolated static func snippet(for entry: JobSearchIndexEntry, tokens: [String]) -> Result.DetailSnippet? {
         let candidates: [(String, String?)] = [
+            ("Portal ID", entry.portalID),
             ("Notes", entry.notes),
             ("Materials", entry.materialsUsed),
             ("Assignments", entry.assignments),
@@ -317,6 +318,9 @@ final class JobSearchViewModel: ObservableObject {
             haystackParts.append(normalized)
         }
         if let normalized = normalizedNonEmpty(job.jobNumber) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.portalID) {
             haystackParts.append(normalized)
         }
         if let normalized = normalizedNonEmpty(job.status) {

--- a/Job Tracker/Features/Timesheets/JobEditView.swift
+++ b/Job Tracker/Features/Timesheets/JobEditView.swift
@@ -7,6 +7,7 @@ struct JobEditView: View {
 
     // Local state for editing.
     @State private var jobNumber: String = ""
+    @State private var portalID: String = ""
     @State private var address: String = ""
     @State private var hours: String = ""
 
@@ -20,6 +21,10 @@ struct JobEditView: View {
                 Form {
                     Section(header: Text("Job Details")) {
                         TextField("Job Number", text: $jobNumber)
+                        TextField("Portal ID", text: $portalID)
+                            .keyboardType(.numberPad)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
                         TextField("Address", text: $address)
                         TextField("Hours", text: $hours)
                             .keyboardType(.decimalPad)
@@ -37,6 +42,7 @@ struct JobEditView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
                         job.jobNumber = jobNumber.isEmpty ? nil : jobNumber
+                        job.portalID = Job.normalizedPortalID(from: portalID)
                         job.address = address
                         job.hours = Double(hours) ?? 0.0
                         jobsViewModel.updateJob(job)
@@ -46,6 +52,7 @@ struct JobEditView: View {
             }
             .onAppear {
                 self.jobNumber = job.jobNumber ?? ""
+                self.portalID = job.portalID ?? ""
                 self.address = job.address
                 self.hours = String(format: "%.1f", job.hours)
             }

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -9,6 +9,7 @@ struct Job: Identifiable, Codable {
     var createdBy: String?          // userID of whoever created the job
     var notes: String?              // Additional text notes
     var jobNumber: String?          // A job number for timesheet or reference
+    var portalID: String?           // Gibson portal edit ID used to deep-link into the external portal
     var assignments: String?        // e.g. "12.3.2" or "123.2.4" – free-form dotted assignment code
     var materialsUsed: String?      // e.g. "Preforms, Weatherhead, Rams Head, 1 Nid Box and 1 Jumper", etc.
     var photos: [String]            // Array of image URLs
@@ -36,6 +37,7 @@ struct Job: Identifiable, Codable {
         createdBy: String? = nil,
         notes: String = "",
         jobNumber: String? = nil,
+        portalID: String? = nil,
         assignments: String? = nil,
         materialsUsed: String? = nil,
         photos: [String] = [],
@@ -58,6 +60,7 @@ struct Job: Identifiable, Codable {
         self.createdBy = createdBy
         self.notes = notes
         self.jobNumber = jobNumber
+        self.portalID = Self.normalizedPortalID(from: portalID)
         self.assignments = assignments
         self.materialsUsed = materialsUsed
         self.photos = photos
@@ -102,12 +105,45 @@ extension Job {
     }
 }
 
+// MARK: - Gibson portal support
+
+extension Job {
+    static let portalBaseURLString = "https://portal.gibsonemc.com/edit"
+
+    /// Accepts either a plain portal ID (for example, "97087") or a full Gibson portal URL
+    /// and returns the numeric edit ID that should be stored on the job.
+    static func normalizedPortalID(from rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed),
+           let editIndex = url.pathComponents.firstIndex(of: "edit"),
+           url.pathComponents.indices.contains(editIndex + 1) {
+            let candidate = url.pathComponents[editIndex + 1]
+            return candidate.allSatisfy(\.isNumber) ? candidate : nil
+        }
+
+        return trimmed.allSatisfy(\.isNumber) ? trimmed : nil
+    }
+
+    var normalizedPortalID: String? {
+        Self.normalizedPortalID(from: portalID)
+    }
+
+    var portalURL: URL? {
+        guard let normalizedPortalID else { return nil }
+        return URL(string: "\(Self.portalBaseURLString)/\(normalizedPortalID)")
+    }
+}
+
 // MARK: - Search index support
 
 protocol JobSearchMatchable {
     var id: String { get }
     var address: String { get }
     var jobNumber: String? { get }
+    var portalID: String? { get }
     var status: String { get }
     var createdBy: String? { get }
     var date: Date { get }
@@ -125,6 +161,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
     var id: String
     var address: String
     var jobNumber: String?
+    var portalID: String?
     var status: String
     var createdBy: String?
     var date: Date
@@ -139,6 +176,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         id: String,
         address: String,
         jobNumber: String? = nil,
+        portalID: String? = nil,
         status: String,
         createdBy: String? = nil,
         date: Date,
@@ -152,6 +190,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         self.id = id
         self.address = address
         self.jobNumber = jobNumber
+        self.portalID = Job.normalizedPortalID(from: portalID)
         self.status = status
         self.createdBy = createdBy
         self.date = date
@@ -168,6 +207,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             id: job.id,
             address: job.address,
             jobNumber: job.jobNumber,
+            portalID: job.portalID,
             status: job.status,
             createdBy: job.createdBy,
             date: job.date,
@@ -189,6 +229,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             createdBy: createdBy,
             notes: notes ?? "",
             jobNumber: jobNumber,
+            portalID: portalID,
             assignments: assignments,
             materialsUsed: materialsUsed,
             photos: [],
@@ -205,6 +246,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         job.canFootage = canFootage
         job.jobPlacement = jobPlacement
         job.jobNumber = jobNumber
+        job.portalID = Job.normalizedPortalID(from: portalID)
         job.createdBy = createdBy
         return job
     }


### PR DESCRIPTION
### Motivation
- Provide first-class support for storing and opening Gibson portal edit links by capturing a compact `portalID` on jobs and surfacing it across the app.
- Allow users to paste either a numeric portal ID or a full Gibson portal edit URL and validate/normalize the value before saving.
- Surface portal information in search/indexing and quick actions so users can open the portal directly from job cards and details.

### Description
- Added a new optional `portalID` property to `Job`, persisted via constructors and normalized on input using `Job.normalizedPortalID(from:)` and exposed as `job.portalID` and `job.normalizedPortalID`.
- Added `portalURL` computed property on `Job` that constructs a deep-link using `portalBaseURLString` and the normalized ID.
- Updated models/indexing to include `portalID` in `JobSearchIndexEntry`, `JobSearchMatchable`, and search snippet/matching logic so portal IDs are searchable and surfaced in snippets.
- Updated UI to capture and validate portal IDs in `CreateJobView`, `SupervisorCreateJobView`, `JobDetailView`, and `JobEditView`, including inline validation and disabling save when the portal input is invalid, and storing normalized IDs on save.
- Added quick actions to open the Gibson portal: an `Open Portal` button in `JobCard` (with context menu and inline button), and a quick action in `JobSearchDetailView`; implemented `openPortal` handlers using the normalized `portalURL`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186ea55054832db0126c8095bc3436)