### PR TITLE
Separate House/NID/CAN photo slots into individual cards

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -534,29 +534,39 @@ extension JobDetailView {
         }
     }
     private var jobPhotoSlotsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            jobPhotoSlotRow(title: "House Picture", urlString: job.housePhotoURL, image: housePhotoImage, slot: .house)
-            jobPhotoSlotRow(title: "NID Picture", urlString: job.nidPhotoURL, image: nidPhotoImage, slot: .nid)
-            jobPhotoSlotRow(title: "CAN Picture", urlString: job.canPhotoURL, image: canPhotoImage, slot: .can)
+        VStack(alignment: .leading, spacing: 14) {
+            jobPhotoSlotCard(title: "House Picture", urlString: job.housePhotoURL, image: housePhotoImage, slot: .house)
+            jobPhotoSlotCard(title: "NID Picture", urlString: job.nidPhotoURL, image: nidPhotoImage, slot: .nid)
+            jobPhotoSlotCard(title: "CAN Picture", urlString: job.canPhotoURL, image: canPhotoImage, slot: .can)
 
             if !job.photos.isEmpty {
-                Divider()
-                Text("Other Job Photos")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                legacyPhotosSection
+            }
+        }
+        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+    }
 
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 10) {
-                        ForEach(job.photos, id: \.self) { urlString in
-                            legacyPhotoThumbnail(urlString: urlString)
-                        }
+    private func jobPhotoSlotCard(title: String, urlString: String?, image: UIImage?, slot: JobPhotoSlot) -> some View {
+        jobPhotoSlotRow(title: title, urlString: urlString, image: image, slot: slot)
+            .glassCard()
+    }
+
+    private var legacyPhotosSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Other Job Photos")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(job.photos, id: \.self) { urlString in
+                        legacyPhotoThumbnail(urlString: urlString)
                     }
-                    .padding(.vertical, 4)
                 }
+                .padding(.vertical, 4)
             }
         }
         .glassCard()
-        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
     }
 
     private func jobPhotoSlotRow(title: String, urlString: String?, image: UIImage?, slot: JobPhotoSlot) -> some View {
@@ -615,6 +625,7 @@ extension JobDetailView {
                 showImagePicker = true
             }
             .font(.subheadline)
+            .buttonStyle(.borderless)
         }
     }
 


### PR DESCRIPTION
### Motivation
- The House, NID, and CAN photo controls were grouped inside a single shared card which caused hit-test/button scoping issues in the form and could result in the wrong photo slot receiving an image. 

### Description
- Split the three primary photo rows into separate glass-card slots by adding `jobPhotoSlotCard(title:urlString:image:slot:)` and replacing the combined row with `jobPhotoSlotCard` calls in `Job Tracker/Features/Jobs/Editor/JobDetailView.swift`.
- Moved the legacy gallery into its own card implemented as `legacyPhotosSection` placed below the primary slots.
- Scoped the Add/Replace button taps to the correct slot by applying `.buttonStyle(.borderless)` to the photo buttons and adjusted `VStack` spacing and `listRowInsets` for layout and spacing.

### Testing
- Ran `git diff --check` to validate the working tree had no obvious diff-check issues and it passed. 
- Attempted to run `xcodebuild` to build the `Job Tracker` scheme, but the environment does not have `xcodebuild` installed so a device/simulator build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1885d7f004832d8aa909c95bd1b40b)