### PR TITLE
Add Gibson location number support

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -141,8 +141,8 @@ struct JobCard: View {
         }
         .contextMenu {
             Button("Directions", systemImage: "map.fill", action: onMapTap)
-            if job.portalURL != nil {
-                Button("Open Portal", systemImage: "safari", action: openPortal)
+            if job.gibsonPortalURL != nil {
+                Button(job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari", action: openPortal)
             }
             Button("Share", systemImage: "square.and.arrow.up", action: onShare)
             Button("Delete", role: .destructive, action: onDelete)
@@ -200,6 +200,12 @@ struct JobCard: View {
                 Spacer()
             }
 
+            if let portalID = job.portalID?.trimmedNonEmpty {
+                KeyValueRow(key: "Portal ID:", value: portalID)
+            }
+            if let locationNumber = job.locationNumber?.trimmedNonEmpty {
+                KeyValueRow(key: "Location Number:", value: locationNumber)
+            }
             if let assignments = job.assignments?.trimmedNonEmpty {
                 KeyValueRow(key: "Assignment:", value: assignments)
             }
@@ -269,9 +275,9 @@ struct JobCard: View {
 
             Spacer()
 
-            if job.portalURL != nil {
+            if job.gibsonPortalURL != nil {
                 Button(action: openPortal) {
-                    Label("Open Portal", systemImage: "safari")
+                    Label(job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari")
                         .font(JTTypography.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(JTColors.textPrimary)
@@ -279,7 +285,7 @@ struct JobCard: View {
                         .padding(.vertical, JTSpacing.xs)
                         .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
                 }
-                .accessibilityLabel("Open Gibson portal")
+                .accessibilityLabel(job.portalURL == nil ? "Open Gibson location search" : "Open Gibson portal")
             }
 
             Button(action: onMapTap) {
@@ -315,7 +321,7 @@ struct JobCard: View {
     }
 
     private func openPortal() {
-        guard let url = job.portalURL else { return }
+        guard let url = job.gibsonPortalURL else { return }
         openURL(url)
     }
 

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -177,6 +177,7 @@ struct CreateJobView: View {
     @State private var materialsUsed = ""
     @State private var jobNumber = ""
     @State private var portalID = ""
+    @State private var locationNumber = ""
     @State private var customStatusText = ""
     @State private var assignmentsText: String = ""
     @FocusState private var isAssignmentsFocused: Bool
@@ -282,6 +283,29 @@ struct CreateJobView: View {
                                     )
 
                                 Text("Enter the Gibson portal edit ID, or paste the full portal link and the app will store the ID.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        // Location Number
+                        SectionCard(title: "Location Number") {
+                            VStack(alignment: .leading, spacing: 6) {
+                                TextField("Optional, e.g. 833167", text: $locationNumber)
+                                    .keyboardType(.numberPad)
+                                    .textInputAutocapitalization(.never)
+                                    .disableAutocorrection(true)
+                                    .padding(12)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                            .fill(Color(.systemBackground).opacity(0.9))
+                                    )
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                            .stroke(Color.gray.opacity(0.15), lineWidth: 1)
+                                    )
+
+                                Text("Use this when the job does not have a portal ID. You can enter the location number or paste a Gibson consumer search link.")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
@@ -444,6 +468,12 @@ struct CreateJobView: View {
             return
         }
 
+        if !locationNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           Job.normalizedLocationNumber(from: locationNumber) == nil {
+            alertMessage = "Please enter a valid numeric location number or paste a Gibson consumer search link."
+            return
+        }
+
         saveJobs(addressesToSave: trimmedAddresses)
     }
 
@@ -459,6 +489,7 @@ struct CreateJobView: View {
         let sanitizedAssign = sanitizeAssignment(assignmentsText)
         let assignmentsValue = sanitizedAssign.isEmpty || !isValidAssignment(sanitizedAssign) ? nil : sanitizedAssign
         let portalIDValue = Job.normalizedPortalID(from: portalID)
+        let locationNumberValue = Job.normalizedLocationNumber(from: locationNumber)
 
         let geocoder = CLGeocoder()
 
@@ -481,6 +512,7 @@ struct CreateJobView: View {
                     notes: notes,
                     jobNumber: jobNumber.isEmpty ? nil : jobNumber,
                     portalID: portalIDValue,
+                    locationNumber: locationNumberValue,
                     assignments: assignmentsValue,
                     materialsUsed: materialsUsed,
                     latitude: coord?.latitude,

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -47,6 +47,7 @@ struct JobDetailView: View {
     @State private var editedNotes = ""
     @State private var editedJobNumber = ""
     @State private var editedPortalID = ""
+    @State private var editedLocationNumber = ""
     @State private var selectedMaterialAriel = "None"
     @State private var selectedMaterialNid = ""
     @State private var preformCount = 0
@@ -126,6 +127,11 @@ private let jobPlacementChoices = ["OH", "UG"]
         return !trimmed.isEmpty && Job.normalizedPortalID(from: trimmed) == nil
     }
 
+    private var isLocationNumberInvalid: Bool {
+        let trimmed = editedLocationNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && Job.normalizedLocationNumber(from: trimmed) == nil
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -170,6 +176,22 @@ private let jobPlacementChoices = ["OH", "UG"]
                             .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
                         if isPortalIDInvalid {
                             Text("Enter a numeric Portal ID or paste a Gibson portal edit link.")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 8, trailing: 12))
+                        }
+                        TextField("Location Number", text: $editedLocationNumber)
+                            .keyboardType(.numberPad)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                            .glassCard()
+                            .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                        Text("Use this when there is no Portal ID. Enter the location number or paste a Gibson consumer search link.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 4, trailing: 12))
+                        if isLocationNumberInvalid {
+                            Text("Enter a numeric location number or paste a Gibson consumer search link.")
                                 .font(.caption)
                                 .foregroundColor(.red)
                                 .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 8, trailing: 12))
@@ -325,6 +347,7 @@ private let jobPlacementChoices = ["OH", "UG"]
                                  && !assignmentsText.isEmpty
                                  && !isValidAssignment(assignmentsText))
                                 || isPortalIDInvalid
+                                || isLocationNumberInvalid
                                 || showSavingPopup
                             )
                     }
@@ -451,6 +474,7 @@ private let jobPlacementChoices = ["OH", "UG"]
                 editedNotes      = job.notes ?? ""
                 editedJobNumber  = job.jobNumber ?? ""
                 editedPortalID   = job.portalID ?? ""
+                editedLocationNumber = job.locationNumber ?? ""
                 selectedMaterialAriel = "None"
                 selectedMaterialNid   = nidMaterials.first ?? ""
                 canFootage       = job.canFootage ?? ""
@@ -837,6 +861,7 @@ extension JobDetailView {
         job.notes     = editedNotes.isEmpty ? nil : editedNotes
         job.jobNumber = editedJobNumber.isEmpty ? nil : editedJobNumber
         job.portalID = Job.normalizedPortalID(from: editedPortalID)
+        job.locationNumber = Job.normalizedLocationNumber(from: editedLocationNumber)
         job.jobPlacement = normalizedPlacement(jobPlacement)
 
         // Assignments (validate & sanitize) — use strict sanitizer on save

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -614,6 +614,7 @@ struct SupervisorCreateJobView: View {
     @State private var materialsUsed = ""
     @State private var jobNumber = ""
     @State private var portalID = ""
+    @State private var locationNumber = ""
     @State private var assignmentsText: String = ""
     @State private var selectedUserID: String? = nil
     @State private var showUserPicker = false
@@ -632,6 +633,11 @@ struct SupervisorCreateJobView: View {
     private var isPortalIDInvalid: Bool {
         let trimmed = portalID.trimmingCharacters(in: .whitespacesAndNewlines)
         return !trimmed.isEmpty && Job.normalizedPortalID(from: trimmed) == nil
+    }
+
+    private var isLocationNumberInvalid: Bool {
+        let trimmed = locationNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && Job.normalizedLocationNumber(from: trimmed) == nil
     }
 
     private var selectedUserName: String {
@@ -774,6 +780,21 @@ struct SupervisorCreateJobView: View {
                         }
                     }
 
+                    Section(header: Text("Location Number")) {
+                        TextField("Optional, e.g. 833167", text: $locationNumber)
+                            .keyboardType(.numberPad)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        Text("Use this when there is no Portal ID. Enter the location number or paste a Gibson consumer search link.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        if isLocationNumberInvalid {
+                            Text("Enter a numeric location number or paste a Gibson consumer search link.")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
+                    }
+
                     Section(header: Text("Materials Used")) {
                         TextField("Enter materials info…", text: $materialsUsed)
                     }
@@ -793,7 +814,7 @@ struct SupervisorCreateJobView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Save") { saveJob() }
-                        .disabled(jobNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isPortalIDInvalid)
+                        .disabled(jobNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isPortalIDInvalid || isLocationNumberInvalid)
                 }
             }
             .sheet(isPresented: $showUserPicker) {
@@ -843,6 +864,7 @@ struct SupervisorCreateJobView: View {
                 notes: notes,
                 jobNumber: jobNumber.isEmpty ? nil : jobNumber,
                 portalID: Job.normalizedPortalID(from: portalID),
+                locationNumber: Job.normalizedLocationNumber(from: locationNumber),
                 assignments: assignmentsText.isEmpty ? nil : assignmentsText,
                 materialsUsed: materialsUsed,
                 latitude: coord?.latitude,

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -70,6 +70,10 @@ struct JobSearchDetailView: View {
             items.append(.init(title: "Portal ID", value: portalID, systemImage: "safari"))
         }
 
+        if let locationNumber = displayValue(job.locationNumber) {
+            items.append(.init(title: "Location Number", value: locationNumber, systemImage: "mappin.and.ellipse"))
+        }
+
         if let assignments = displayValue(job.assignments) {
             items.append(.init(title: "Assignment", value: assignments, systemImage: "list.number"))
         }
@@ -225,8 +229,8 @@ struct JobSearchDetailView: View {
                 openInMaps(job: job)
             }
 
-            if job.portalURL != nil {
-                QuickActionButton(title: "Open Portal", systemImage: "safari") {
+            if job.gibsonPortalURL != nil {
+                QuickActionButton(title: job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari") {
                     openPortal(job: job)
                 }
             }
@@ -239,7 +243,7 @@ struct JobSearchDetailView: View {
     }
 
     private func openPortal(job: Job) {
-        guard let url = job.portalURL else { return }
+        guard let url = job.gibsonPortalURL else { return }
         UIApplication.shared.open(url)
     }
 

--- a/Job Tracker/Features/Search/JobSearchViewModel.swift
+++ b/Job Tracker/Features/Search/JobSearchViewModel.swift
@@ -287,6 +287,7 @@ final class JobSearchViewModel: ObservableObject {
     private nonisolated static func snippet(for entry: JobSearchIndexEntry, tokens: [String]) -> Result.DetailSnippet? {
         let candidates: [(String, String?)] = [
             ("Portal ID", entry.portalID),
+            ("Location Number", entry.locationNumber),
             ("Notes", entry.notes),
             ("Materials", entry.materialsUsed),
             ("Assignments", entry.assignments),
@@ -321,6 +322,9 @@ final class JobSearchViewModel: ObservableObject {
             haystackParts.append(normalized)
         }
         if let normalized = normalizedNonEmpty(job.portalID) {
+            haystackParts.append(normalized)
+        }
+        if let normalized = normalizedNonEmpty(job.locationNumber) {
             haystackParts.append(normalized)
         }
         if let normalized = normalizedNonEmpty(job.status) {

--- a/Job Tracker/Features/Timesheets/JobEditView.swift
+++ b/Job Tracker/Features/Timesheets/JobEditView.swift
@@ -8,6 +8,7 @@ struct JobEditView: View {
     // Local state for editing.
     @State private var jobNumber: String = ""
     @State private var portalID: String = ""
+    @State private var locationNumber: String = ""
     @State private var address: String = ""
     @State private var hours: String = ""
 
@@ -22,6 +23,10 @@ struct JobEditView: View {
                     Section(header: Text("Job Details")) {
                         TextField("Job Number", text: $jobNumber)
                         TextField("Portal ID", text: $portalID)
+                            .keyboardType(.numberPad)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        TextField("Location Number", text: $locationNumber)
                             .keyboardType(.numberPad)
                             .textInputAutocapitalization(.never)
                             .disableAutocorrection(true)
@@ -43,6 +48,7 @@ struct JobEditView: View {
                     Button("Save") {
                         job.jobNumber = jobNumber.isEmpty ? nil : jobNumber
                         job.portalID = Job.normalizedPortalID(from: portalID)
+                        job.locationNumber = Job.normalizedLocationNumber(from: locationNumber)
                         job.address = address
                         job.hours = Double(hours) ?? 0.0
                         jobsViewModel.updateJob(job)
@@ -53,6 +59,7 @@ struct JobEditView: View {
             .onAppear {
                 self.jobNumber = job.jobNumber ?? ""
                 self.portalID = job.portalID ?? ""
+                self.locationNumber = job.locationNumber ?? ""
                 self.address = job.address
                 self.hours = String(format: "%.1f", job.hours)
             }

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -10,6 +10,7 @@ struct Job: Identifiable, Codable {
     var notes: String?              // Additional text notes
     var jobNumber: String?          // A job number for timesheet or reference
     var portalID: String?           // Gibson portal edit ID used to deep-link into the external portal
+    var locationNumber: String?     // Gibson consumer location number used to search the external portal
     var assignments: String?        // e.g. "12.3.2" or "123.2.4" – free-form dotted assignment code
     var materialsUsed: String?      // e.g. "Preforms, Weatherhead, Rams Head, 1 Nid Box and 1 Jumper", etc.
     var photos: [String]            // Array of image URLs
@@ -38,6 +39,7 @@ struct Job: Identifiable, Codable {
         notes: String = "",
         jobNumber: String? = nil,
         portalID: String? = nil,
+        locationNumber: String? = nil,
         assignments: String? = nil,
         materialsUsed: String? = nil,
         photos: [String] = [],
@@ -61,6 +63,7 @@ struct Job: Identifiable, Codable {
         self.notes = notes
         self.jobNumber = jobNumber
         self.portalID = Self.normalizedPortalID(from: portalID)
+        self.locationNumber = Self.normalizedLocationNumber(from: locationNumber)
         self.assignments = assignments
         self.materialsUsed = materialsUsed
         self.photos = photos
@@ -109,6 +112,7 @@ extension Job {
 
 extension Job {
     static let portalBaseURLString = "https://portal.gibsonemc.com/edit"
+    static let locationSearchBaseURLString = "https://portal.gibsonemc.com/consumers/search/"
 
     /// Accepts either a plain portal ID (for example, "97087") or a full Gibson portal URL
     /// and returns the numeric edit ID that should be stored on the job.
@@ -131,9 +135,46 @@ extension Job {
         Self.normalizedPortalID(from: portalID)
     }
 
+    /// Accepts either a plain location number (for example, "833167") or a full Gibson
+    /// consumer search URL and returns the numeric location number that should be stored.
+    static func normalizedLocationNumber(from rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed),
+           let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           url.path.contains("/consumers/search"),
+           let queryValue = components.queryItems?.first(where: { $0.name == "q" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !queryValue.isEmpty,
+           queryValue.allSatisfy(\.isNumber) {
+            return queryValue
+        }
+
+        return trimmed.allSatisfy(\.isNumber) ? trimmed : nil
+    }
+
+    var normalizedLocationNumber: String? {
+        Self.normalizedLocationNumber(from: locationNumber)
+    }
+
     var portalURL: URL? {
         guard let normalizedPortalID else { return nil }
         return URL(string: "\(Self.portalBaseURLString)/\(normalizedPortalID)")
+    }
+
+    var locationSearchURL: URL? {
+        guard let normalizedLocationNumber else { return nil }
+        var components = URLComponents(string: Self.locationSearchBaseURLString)
+        components?.queryItems = [
+            URLQueryItem(name: "q", value: normalizedLocationNumber),
+            URLQueryItem(name: "models", value: "consumers.consumer")
+        ]
+        return components?.url
+    }
+
+    var gibsonPortalURL: URL? {
+        portalURL ?? locationSearchURL
     }
 }
 
@@ -144,6 +185,7 @@ protocol JobSearchMatchable {
     var address: String { get }
     var jobNumber: String? { get }
     var portalID: String? { get }
+    var locationNumber: String? { get }
     var status: String { get }
     var createdBy: String? { get }
     var date: Date { get }
@@ -162,6 +204,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
     var address: String
     var jobNumber: String?
     var portalID: String?
+    var locationNumber: String?
     var status: String
     var createdBy: String?
     var date: Date
@@ -177,6 +220,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         address: String,
         jobNumber: String? = nil,
         portalID: String? = nil,
+        locationNumber: String? = nil,
         status: String,
         createdBy: String? = nil,
         date: Date,
@@ -191,6 +235,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         self.address = address
         self.jobNumber = jobNumber
         self.portalID = Job.normalizedPortalID(from: portalID)
+        self.locationNumber = Job.normalizedLocationNumber(from: locationNumber)
         self.status = status
         self.createdBy = createdBy
         self.date = date
@@ -208,6 +253,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             address: job.address,
             jobNumber: job.jobNumber,
             portalID: job.portalID,
+            locationNumber: job.locationNumber,
             status: job.status,
             createdBy: job.createdBy,
             date: job.date,
@@ -230,6 +276,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             notes: notes ?? "",
             jobNumber: jobNumber,
             portalID: portalID,
+            locationNumber: locationNumber,
             assignments: assignments,
             materialsUsed: materialsUsed,
             photos: [],
@@ -247,6 +294,7 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         job.jobPlacement = jobPlacement
         job.jobNumber = jobNumber
         job.portalID = Job.normalizedPortalID(from: portalID)
+        job.locationNumber = Job.normalizedLocationNumber(from: locationNumber)
         job.createdBy = createdBy
         return job
     }

--- a/Job TrackerTests/JobSearchMatcherTests.swift
+++ b/Job TrackerTests/JobSearchMatcherTests.swift
@@ -43,6 +43,7 @@ final class JobSearchMatcherTests: XCTestCase {
             createdBy: "user-1",
             notes: "   Needs Ladder   ",
             jobNumber: nil,
+            locationNumber: "833167",
             assignments: "  42.7.1  ",
             materialsUsed: "  Fiber Cable  ",
             nidFootage: "  150FT  ",
@@ -51,6 +52,7 @@ final class JobSearchMatcherTests: XCTestCase {
 
         XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "ladder", creator: creator))
         XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "fiber", creator: creator))
+        XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "833167", creator: creator))
         XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "42.7.1", creator: creator))
         XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "150ft", creator: creator))
         XCTAssertTrue(JobSearchMatcher.matches(job: jobWithOptionals, query: "200 ft", creator: creator))
@@ -60,5 +62,38 @@ final class JobSearchMatcherTests: XCTestCase {
         let entry = JobSearchIndexEntry(job: sampleJob)
         XCTAssertTrue(JobSearchMatcher.matches(job: entry, query: "main", creator: creator))
         XCTAssertTrue(JobSearchMatcher.matches(job: entry, query: "completed", creator: creator))
+    }
+
+    func testNormalizesLocationNumberFromConsumerSearchLink() {
+        let link = "https://portal.gibsonemc.com/consumers/search/?q=491320&models=consumers.consumer"
+        let job = Job(
+            id: "job-location-link",
+            address: "789 Pine Street",
+            date: Date(timeIntervalSince1970: 1_700_200_000),
+            status: "Pending",
+            locationNumber: link
+        )
+
+        XCTAssertEqual(job.locationNumber, "491320")
+        XCTAssertEqual(
+            job.locationSearchURL?.absoluteString,
+            "https://portal.gibsonemc.com/consumers/search/?q=491320&models=consumers.consumer"
+        )
+    }
+
+    func testGibsonPortalURLFallsBackToLocationSearchWhenPortalIDIsMissing() {
+        let job = Job(
+            id: "job-location-only",
+            address: "789 Pine Street",
+            date: Date(timeIntervalSince1970: 1_700_200_000),
+            status: "Pending",
+            locationNumber: "833167"
+        )
+
+        XCTAssertNil(job.portalURL)
+        XCTAssertEqual(
+            job.gibsonPortalURL?.absoluteString,
+            "https://portal.gibsonemc.com/consumers/search/?q=833167&models=consumers.consumer"
+        )
     }
 }


### PR DESCRIPTION
### Motivation
- Some jobs lack a Gibson portal edit ID but do have a consumer "location number" (examples: `https://portal.gibsonemc.com/consumers/search/?q=833167&models=consumers.consumer`), so the app should accept and use a location number as an alternate deep link source.
- Provide a normalized model field, UI inputs, validation, search indexing, and fallback opening behavior so users can save and open jobs by location number when a portal edit ID is unavailable.

### Description
- Added a new optional property `locationNumber` to `Job` and to the search index struct `JobSearchIndexEntry`, and implemented `normalizedLocationNumber(from:)` to accept either a plain numeric value or a Gibson consumer search URL and return the numeric location. (file: `Job Tracker/Models/Job.swift`)
- Added `locationSearchURL` and `gibsonPortalURL` accessors so the app opens the portal edit URL when present or falls back to the consumer search URL when only a location number exists. (file: `Job Tracker/Models/Job.swift`)
- Added a `Location Number` input field and validation to job creation, job detail editing, supervisor create-job flow, and the timesheet job edit sheet, and wired saving to store the normalized value on the `Job`. (files: `CreateJobView.swift`, `JobDetailView.swift`, `SupervisorDashboardView.swift`, `JobEditView.swift`)
- Updated UI actions and labels to use the fallback link: `Open Portal` becomes `Open Location` when only a location exists, and quick actions/open handlers now use `gibsonPortalURL`. (files: `DashboardJobSectionsView.swift`, `JobSearchDetailView.swift`)
- Included `locationNumber` in search snippets and matching so search queries can match on location numbers, and extended unit tests to assert normalization and fallback behavior. (files: `JobSearchViewModel.swift`, `JobSearchDetailView.swift`, `JobSearchMatcherTests.swift`)

### Testing
- Ran `git diff --check` to verify no whitespace/merge issues; it passed with no warnings.
- Executed a small `swift` script that assembles the consumer search URL and printed `https://portal.gibsonemc.com/consumers/search/?q=833167&models=consumers.consumer` to validate URL composition; the script succeeded.
- Attempted to run the Xcode unit test suite via `xcodebuild` but it could not be executed in this environment because `xcodebuild` is not available, so the new/modified unit tests (`JobSearchMatcherTests`) were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189a37cdbc832d93a0104ff01ac53c)