### PR TITLE
Bump App Store version to 2.1.10

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -283,7 +283,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Job Tracker Companion";
@@ -293,7 +293,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -311,7 +311,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Job Tracker Companion";
@@ -321,7 +321,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -464,7 +464,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Job Tracker/Job Tracker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_ASSET_PATHS = "\"Job Tracker/Preview Content\"";
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				ENABLE_PREVIEWS = YES;
@@ -484,7 +484,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -506,7 +506,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Job Tracker/Job Tracker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_ASSET_PATHS = "\"Job Tracker/Preview Content\"";
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				ENABLE_PREVIEWS = YES;
@@ -526,7 +526,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.7</string>
+	<string>2.1.10</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
### Motivation
- Fix App Store submission failures caused by the closed train and duplicate version: the submission reported the previously approved version `2.1.9` and the train `2.1.9` is closed, so a higher valid version is required.  
- `CFBundleShortVersionString` must be a higher three-period-separated version than the approved release, so `2.1.9.1` was not used because Apple requires the standard three-component version format.  

### Description
- Updated the checked-in short version in `Job-Tracker-Info.plist` from `2.1.7` to `2.1.10`.  
- Replaced `MARKETING_VERSION` values in `Job Tracker.xcodeproj/project.pbxproj` from `2.1.9` to `2.1.10` for app and watch targets in both Debug and Release configurations.  
- Incremented `CURRENT_PROJECT_VERSION` from `15` to `16` in the project file for all relevant build configurations.  
- Committed the changes with a commit message `Bump App Store version to 2.1.10`.

### Testing
- Ran `rg -n "2\.1\.9|2\.1\.10|CURRENT_PROJECT_VERSION =" 'Job Tracker.xcodeproj/project.pbxproj' 'Job-Tracker-Info.plist'` and confirmed the updated occurrences for `2.1.10` and `CURRENT_PROJECT_VERSION = 16` (succeeded).  
- Ran `plutil -- 'Job-Tracker-Info.plist'` which reported `Job-Tracker-Info.plist: OK` (succeeded).  
- Ran `git diff --check` and `git status --short` to ensure there are no whitespace or diff errors and that the two files were staged and committed (succeeded).  
- Attempted `xcodebuild -version` but `xcodebuild` is not available in this environment, so Xcode build verification could not be executed here (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189f0ba17c832dbffd24bffee8ce2c)