### PR TITLE
Add background job photo upload queue with sync-state reporting

### DIFF
--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -195,6 +195,7 @@ struct DashboardView: View {
             .onAppear {
                 viewModel.configureIfNeeded(jobsViewModel: jobsViewModel)
                 viewModel.updateNearestJob(with: jobsViewModel.jobs, currentLocation: locationService.current)
+                JobPhotoUploadQueue.shared.publishCurrentSyncState()
             }
             .onReceive(locationService.$current) { location in
                 viewModel.updateNearestJob(with: jobsViewModel.jobs, currentLocation: location)
@@ -222,6 +223,13 @@ struct DashboardView: View {
                 let done = (info["uploaded"] as? Int) ?? (info["done"] as? Int) ?? 0
                 let inFlight = (info["inFlight"] as? Int) ?? 0
                 viewModel.handleSyncStateChange(total: total, done: done, inFlight: inFlight)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .jobPhotoUploadsSyncStateDidChange)) { note in
+                let info = note.userInfo ?? [:]
+                let total = (info["total"] as? Int) ?? 0
+                let done = (info["uploaded"] as? Int) ?? (info["done"] as? Int) ?? 0
+                let inFlight = (info["inFlight"] as? Int) ?? 0
+                viewModel.handlePhotoUploadSyncStateChange(total: total, done: done, inFlight: inFlight)
             }
             .onChange(of: viewModel.showSyncBanner) { visible in
                 if visible {

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -51,6 +51,13 @@ final class DashboardViewModel: ObservableObject {
     @Published var syncDone: Int = 0
     @Published var syncInFlight: Int = 0
     @Published var wavePhase: CGFloat = 0
+
+    private var jobSyncTotal: Int = 0
+    private var jobSyncDone: Int = 0
+    private var jobSyncInFlight: Int = 0
+    private var photoSyncTotal: Int = 0
+    private var photoSyncDone: Int = 0
+    private var photoSyncInFlight: Int = 0
     @Published var nearestJobID: String?
     @Published var selectedJob: Job?
 
@@ -428,16 +435,33 @@ final class DashboardViewModel: ObservableObject {
     }
 
     func handleSyncStateChange(total: Int, done: Int, inFlight: Int) {
-        syncTotal = max(total, 0)
-        syncDone = max(min(done, total), 0)
-        syncInFlight = max(inFlight, 0)
+        jobSyncTotal = max(total, 0)
+        jobSyncDone = max(min(done, total), 0)
+        jobSyncInFlight = max(inFlight, 0)
+        updateCombinedSyncState()
+    }
+
+    func handlePhotoUploadSyncStateChange(total: Int, done: Int, inFlight: Int) {
+        photoSyncTotal = max(total, 0)
+        photoSyncDone = max(min(done, total), 0)
+        photoSyncInFlight = max(inFlight, 0)
+        updateCombinedSyncState()
+    }
+
+    private func updateCombinedSyncState() {
+        syncTotal = jobSyncTotal + photoSyncTotal
+        syncDone = jobSyncDone + photoSyncDone
+        syncInFlight = jobSyncInFlight + photoSyncInFlight
+
         withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
             showSyncBanner = (syncTotal > 0) && (syncDone < syncTotal)
         }
         if syncTotal > 0 && syncDone >= syncTotal {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                guard let self else { return }
+                guard self.syncTotal > 0, self.syncDone >= self.syncTotal else { return }
                 withAnimation(.easeInOut(duration: 0.25)) {
-                    self?.showSyncBanner = false
+                    self.showSyncBanner = false
                 }
             }
         }

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -113,12 +113,6 @@ private let jobPlacementChoices = ["OH", "UG"]
     // State for delete confirmation alert.
     @State private var showDeleteConfirmation = false
 
-    private enum JobPhotoSlot {
-        case house
-        case nid
-        case can
-    }
-
     // Locale-aware decimal separator used by the keyboard toolbar
     private var decimalSeparator: String { Locale.current.decimalSeparator ?? "." }
 
@@ -944,17 +938,22 @@ extension JobDetailView {
             job.latitude  = coord?.latitude
             job.longitude = coord?.longitude
 
-            uploadPendingPhotosThenSave()
+            enqueuePendingPhotosIfNeeded()
+            finalizeJobSave()
         }
     }
 
-    private func uploadPendingPhotosThenSave() {
-        savingProgress = 0.30
-        savingStatus = "Uploading job photos"
+    private func enqueuePendingPhotosIfNeeded() {
+        let pending: [(slot: JobPhotoSlot, image: UIImage)] = [
+            housePhotoImage.map { (.house, $0) },
+            nidPhotoImage.map { (.nid, $0) },
+            canPhotoImage.map { (.can, $0) }
+        ].compactMap { $0 }
 
-        uploadDedicatedPhotoImages {
-            finalizeJobSave()
-        }
+        guard !pending.isEmpty else { return }
+        savingProgress = 0.42
+        savingStatus = "Queueing job photos"
+        JobPhotoUploadQueue.shared.enqueue(pending, for: job.id)
     }
 
     private func finalizeJobSave() {
@@ -968,52 +967,6 @@ extension JobDetailView {
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.success)
             dismiss()
-        }
-    }
-
-    private func uploadDedicatedPhotoImages(completion: @escaping () -> Void) {
-        let pending: [(JobPhotoSlot, UIImage)] = [
-            housePhotoImage.map { (.house, $0) },
-            nidPhotoImage.map { (.nid, $0) },
-            canPhotoImage.map { (.can, $0) }
-        ].compactMap { $0 }
-
-        guard !pending.isEmpty else {
-            completion()
-            return
-        }
-
-        let group = DispatchGroup()
-        var completed = 0
-
-        for (slot, image) in pending {
-            group.enter()
-            FirebaseService.shared.uploadImage(image, for: job.id) { result in
-                defer {
-                    completed += 1
-                    savingProgress = 0.30 + (0.15 * Double(completed) / Double(pending.count))
-                    savingStatus = "Uploading job photos (\(completed)/\(pending.count))"
-                    group.leave()
-                }
-
-                switch result {
-                case .success(let url):
-                    switch slot {
-                    case .house:
-                        job.housePhotoURL = url
-                    case .nid:
-                        job.nidPhotoURL = url
-                    case .can:
-                        job.canPhotoURL = url
-                    }
-                case .failure(let error):
-                    print("Upload error:", error.localizedDescription)
-                }
-            }
-        }
-
-        group.notify(queue: .main) {
-            completion()
         }
     }
 

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -771,12 +771,16 @@ class FirebaseService {
             completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid image"])))
             return
         }
+        uploadImageData(data, for: jobID, completion: completion)
+    }
+
+    func uploadImageData(_ data: Data, for jobID: String, completion: @escaping (Result<String, Error>) -> Void) {
         let fileName = UUID().uuidString + ".jpg"
         let ref = storage.reference().child("jobPhotos/\(jobID)/\(fileName)")
-        
+
         let metadata = StorageMetadata()
         metadata.contentType = "image/jpeg"
-        
+
         ref.putData(data, metadata: metadata) { _, error in
             if let error = error {
                 completion(.failure(error))

--- a/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
+++ b/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Combine
+import FirebaseFirestore
+import UIKit
+
+/// Dedicated photo slots on a job document.
+enum JobPhotoSlot: String, Codable, CaseIterable {
+    case house
+    case nid
+    case can
+
+    var firestoreField: String {
+        switch self {
+        case .house:
+            return "housePhotoURL"
+        case .nid:
+            return "nidPhotoURL"
+        case .can:
+            return "canPhotoURL"
+        }
+    }
+}
+
+private struct PendingJobPhotoUpload: Identifiable, Codable, Equatable {
+    let id: String
+    let jobID: String
+    let slot: JobPhotoSlot
+    let fileName: String
+    let createdAt: Date
+    var attempts: Int
+    var lastErrorDescription: String?
+}
+
+/// Persists selected job photos locally, uploads them outside of the detail save flow,
+/// and patches the job document with the Firebase Storage URL once each upload finishes.
+///
+/// Firestore queues document writes offline, but Firebase Storage does not provide the
+/// same durable offline write queue. This service gives photo uploads the same user
+/// experience as job saves by keeping local image files and retrying uploads while the
+/// app is running.
+@MainActor
+final class JobPhotoUploadQueue: ObservableObject {
+    static let shared = JobPhotoUploadQueue()
+
+    @Published private(set) var pendingCount: Int = 0
+    @Published private(set) var inFlightCount: Int = 0
+    @Published private(set) var completedCount: Int = 0
+
+    private let fileManager: FileManager
+    private let queueDirectory: URL
+    private let manifestURL: URL
+    private let db = Firestore.firestore()
+
+    private var items: [PendingJobPhotoUpload] = []
+    private var activeUploadID: String?
+    private var retryTask: Task<Void, Never>?
+    private var cycleTotalCount: Int = 0
+    private var cycleDoneCount: Int = 0
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        let applicationSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        self.queueDirectory = applicationSupport.appendingPathComponent("PendingJobPhotoUploads", isDirectory: true)
+        self.manifestURL = queueDirectory.appendingPathComponent("manifest.json")
+
+        try? fileManager.createDirectory(at: queueDirectory, withIntermediateDirectories: true)
+        loadManifest()
+        cycleTotalCount = items.count
+        pendingCount = items.count
+        publishSyncState()
+        processQueue()
+    }
+
+    deinit {
+        retryTask?.cancel()
+    }
+
+    func enqueue(_ photos: [(slot: JobPhotoSlot, image: UIImage)], for jobID: String) {
+        guard !photos.isEmpty else { return }
+
+        var addedItems: [PendingJobPhotoUpload] = []
+        for photo in photos {
+            guard let data = photo.image.jpegData(compressionQuality: 0.82) else { continue }
+            let id = UUID().uuidString
+            let fileName = "\(id).jpg"
+            let fileURL = queueDirectory.appendingPathComponent(fileName)
+
+            do {
+                try data.write(to: fileURL, options: [.atomic])
+                addedItems.append(
+                    PendingJobPhotoUpload(
+                        id: id,
+                        jobID: jobID,
+                        slot: photo.slot,
+                        fileName: fileName,
+                        createdAt: Date(),
+                        attempts: 0,
+                        lastErrorDescription: nil
+                    )
+                )
+            } catch {
+                #if DEBUG
+                print("[JobPhotoUploadQueue] Failed to persist pending photo: \(error.localizedDescription)")
+                #endif
+            }
+        }
+
+        guard !addedItems.isEmpty else { return }
+        items.append(contentsOf: addedItems)
+        cycleTotalCount += addedItems.count
+        pendingCount = items.count
+        saveManifest()
+        publishSyncState()
+        scheduleRetry(after: 1.0)
+    }
+
+    func retryPendingUploads() {
+        retryTask?.cancel()
+        retryTask = nil
+        processQueue()
+    }
+
+    func publishCurrentSyncState() {
+        publishSyncState()
+    }
+
+    private func processQueue() {
+        guard activeUploadID == nil else { return }
+        guard let next = items.first else {
+            resetCycleIfFinished()
+            return
+        }
+
+        activeUploadID = next.id
+        inFlightCount = 1
+        publishSyncState()
+
+        let fileURL = queueDirectory.appendingPathComponent(next.fileName)
+        guard let data = try? Data(contentsOf: fileURL) else {
+            finish(next, removingLocalFile: true)
+            return
+        }
+
+        FirebaseService.shared.uploadImageData(data, for: next.jobID) { [weak self] result in
+            Task { @MainActor in
+                guard let self else { return }
+                switch result {
+                case .success(let urlString):
+                    self.patchJob(next, photoURL: urlString)
+                case .failure(let error):
+                    self.handleFailure(for: next, error: error)
+                }
+            }
+        }
+    }
+
+    private func patchJob(_ item: PendingJobPhotoUpload, photoURL: String) {
+        db.collection("jobs").document(item.jobID).updateData([item.slot.firestoreField: photoURL]) { [weak self] error in
+            Task { @MainActor in
+                guard let self else { return }
+                if let error {
+                    self.handleFailure(for: item, error: error)
+                } else {
+                    self.finish(item, removingLocalFile: true)
+                }
+            }
+        }
+    }
+
+    private func handleFailure(for item: PendingJobPhotoUpload, error: Error) {
+        guard activeUploadID == item.id else { return }
+
+        if isFirestoreNotFound(error) {
+            finish(item, removingLocalFile: true)
+            return
+        }
+
+        activeUploadID = nil
+        inFlightCount = 0
+
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index].attempts += 1
+            items[index].lastErrorDescription = error.localizedDescription
+        }
+
+        pendingCount = items.count
+        saveManifest()
+        publishSyncState()
+        scheduleRetry(after: retryDelay(forAttempts: (items.first { $0.id == item.id }?.attempts ?? item.attempts + 1)))
+    }
+
+    private func isFirestoreNotFound(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == FirestoreErrorDomain && nsError.code == FirestoreErrorCode.notFound.rawValue
+    }
+
+    private func finish(_ item: PendingJobPhotoUpload, removingLocalFile: Bool) {
+        guard activeUploadID == item.id else { return }
+
+        activeUploadID = nil
+        inFlightCount = 0
+
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            let removed = items.remove(at: index)
+            if removingLocalFile {
+                try? fileManager.removeItem(at: queueDirectory.appendingPathComponent(removed.fileName))
+            }
+        }
+
+        cycleDoneCount += 1
+        completedCount = cycleDoneCount
+        pendingCount = items.count
+        saveManifest()
+        publishSyncState()
+        processQueue()
+    }
+
+    private func scheduleRetry(after delay: TimeInterval) {
+        retryTask?.cancel()
+        retryTask = Task { [weak self] in
+            let nanoseconds = UInt64(max(delay, 1) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            await MainActor.run {
+                self?.retryTask = nil
+                self?.processQueue()
+            }
+        }
+    }
+
+    private func retryDelay(forAttempts attempts: Int) -> TimeInterval {
+        let cappedAttempts = min(max(attempts, 1), 5)
+        return min(pow(2.0, Double(cappedAttempts)) * 3.0, 60.0)
+    }
+
+    private func resetCycleIfFinished() {
+        guard activeUploadID == nil, items.isEmpty else { return }
+        if cycleTotalCount > 0, cycleDoneCount >= cycleTotalCount {
+            publishSyncState()
+        }
+        cycleTotalCount = 0
+        cycleDoneCount = 0
+        completedCount = 0
+        pendingCount = 0
+    }
+
+    private func loadManifest() {
+        guard let data = try? Data(contentsOf: manifestURL) else { return }
+        do {
+            let decoded = try JSONDecoder().decode([PendingJobPhotoUpload].self, from: data)
+            items = decoded.filter { fileManager.fileExists(atPath: queueDirectory.appendingPathComponent($0.fileName).path) }
+        } catch {
+            #if DEBUG
+            print("[JobPhotoUploadQueue] Failed to load manifest: \(error.localizedDescription)")
+            #endif
+            items = []
+        }
+    }
+
+    private func saveManifest() {
+        do {
+            let data = try JSONEncoder().encode(items)
+            try data.write(to: manifestURL, options: [.atomic])
+        } catch {
+            #if DEBUG
+            print("[JobPhotoUploadQueue] Failed to save manifest: \(error.localizedDescription)")
+            #endif
+        }
+    }
+
+    private func publishSyncState() {
+        let total = max(cycleTotalCount, items.count + cycleDoneCount)
+        let done = min(cycleDoneCount, total)
+        NotificationCenter.default.post(
+            name: .jobPhotoUploadsSyncStateDidChange,
+            object: nil,
+            userInfo: [
+                "total": total,
+                "done": done,
+                "uploaded": done,
+                "inFlight": inFlightCount,
+                "pending": items.count
+            ]
+        )
+    }
+}
+
+extension Notification.Name {
+    static let jobPhotoUploadsSyncStateDidChange = Notification.Name("jobPhotoUploadsSyncStateDidChange")
+}

--- a/Job Tracker/Job_TrackerApp.swift
+++ b/Job Tracker/Job_TrackerApp.swift
@@ -79,6 +79,7 @@ struct JobTrackerApp: App {
                             // Ensure the watch has the latest on first appearance
                             PhoneWatchSyncManager.shared.pushSnapshotToWatch()
                             arrivalAlertManager.updateJobs(jobsViewModel.jobs)
+                            JobPhotoUploadQueue.shared.retryPendingUploads()
                         }
                         .onReceive(jobsViewModel.$jobs) { jobs in
                             PhoneWatchSyncManager.shared.pushSnapshotToWatch()
@@ -187,6 +188,7 @@ struct JobTrackerApp: App {
                 switch phase {
                 case .active:
                     locationService.startStandardUpdates()
+                    JobPhotoUploadQueue.shared.retryPendingUploads()
                 case .background:
                     locationService.startSignificantChangeUpdates()
                 default:


### PR DESCRIPTION
### Motivation

- Provide a durable background mechanism to persist and upload job photos outside of the job save flow so uploads survive app restarts and can be retried. 
- Surface photo upload progress to the dashboard sync UI so photo uploads and job syncs are combined into a single banner state. 

### Description

- Add `JobPhotoUploadQueue` as a singleton service that persists pending photos to disk, uploads them via `FirebaseService.uploadImageData`, patches job documents, retries failed uploads with backoff, and posts `Notification.Name.jobPhotoUploadsSyncStateDidChange` updates. 
- Refactor `FirebaseService` to expose `uploadImageData(_:for:completion:)` and have existing `uploadImage(_:for:completion:)` delegate to it. 
- Change `JobDetailView` to persist selected photos to the `JobPhotoUploadQueue` by calling `enqueuePendingPhotosIfNeeded()` during save and finalize the job save afterwards. 
- Update `DashboardView` and `DashboardViewModel` to publish and consume the new photo-upload sync notifications and to combine job sync and photo sync counts into a single banner (`handlePhotoUploadSyncStateChange` and `updateCombinedSyncState`). 
- Trigger the queue to publish state and retry pending uploads from app lifecycle points by calling `JobPhotoUploadQueue.shared.publishCurrentSyncState()` on dashboard appear and `JobPhotoUploadQueue.shared.retryPendingUploads()` on app appear/activation. 

### Testing

- Built the app and launched in the simulator to verify the new queue initializes and enqueues files without crashing. 
- Exercised the save flow from `JobDetailView` to ensure photos are queued and job document updates are applied (manual functional verification). 
- Ran the project unit test suite and Xcode build; automated tests and build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18aaf2583c832da35a766faa423a6f)