### PR TITLE
Add option to take or choose job photos (camera + library support)

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -471,8 +471,10 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Job-Tracker-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Take job photos for house, NID, and CAN records.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "We need your location to sort jobs for route tracking";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We need your location to sort jobs for automatic routing";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Choose existing job photos for house, NID, and CAN records.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = location;
@@ -513,8 +515,10 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Job-Tracker-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Take job photos for house, NID, and CAN records.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "We need your location to sort jobs for route tracking";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "We need your location to sort jobs for automatic routing";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Choose existing job photos for house, NID, and CAN records.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = location;

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -97,7 +97,9 @@ private let jobPlacementChoices = ["OH", "UG"]
 
     // Photos
     @State private var showImagePicker = false
+    @State private var showPhotoSourceDialog = false
     @State private var activePhotoSlot: JobPhotoSlot?
+    @State private var selectedPhotoSource: UIImagePickerController.SourceType = .photoLibrary
     @State private var housePhotoImage: UIImage?
     @State private var nidPhotoImage: UIImage?
     @State private var canPhotoImage: UIImage?
@@ -368,25 +370,50 @@ private let jobPlacementChoices = ["OH", "UG"]
                 }
             }
             // Image picker
+            .confirmationDialog(
+                "Add Photo",
+                isPresented: $showPhotoSourceDialog,
+                titleVisibility: .visible
+            ) {
+                if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                    Button("Take Photo") {
+                        selectedPhotoSource = .camera
+                        showImagePicker = true
+                    }
+                }
+                Button("Choose from Photos") {
+                    selectedPhotoSource = .photoLibrary
+                    showImagePicker = true
+                }
+                Button("Cancel", role: .cancel) {
+                    activePhotoSlot = nil
+                }
+            } message: {
+                Text("Choose whether to use the camera now or pick an existing picture.")
+            }
             .sheet(isPresented: $showImagePicker, onDismiss: {
                 activePhotoSlot = nil
+                selectedPhotoSource = .photoLibrary
             }) {
-                ImagePicker(image: Binding(
-                    get: { nil },
-                    set: { newImage in
-                        guard let newImage else { return }
-                        switch activePhotoSlot {
-                        case .house:
-                            housePhotoImage = newImage
-                        case .nid:
-                            nidPhotoImage = newImage
-                        case .can:
-                            canPhotoImage = newImage
-                        case .none:
-                            break
+                ImagePicker(
+                    image: Binding(
+                        get: { nil },
+                        set: { newImage in
+                            guard let newImage else { return }
+                            switch activePhotoSlot {
+                            case .house:
+                                housePhotoImage = newImage
+                            case .nid:
+                                nidPhotoImage = newImage
+                            case .can:
+                                canPhotoImage = newImage
+                            case .none:
+                                break
+                            }
                         }
-                    }
-                ))
+                    ),
+                    sourceType: selectedPhotoSource
+                )
             }
             // Delete confirmation
             .alert("Delete Job", isPresented: $showDeleteConfirmation) {
@@ -640,7 +667,7 @@ extension JobDetailView {
 
             Button(image != nil || urlString?.isEmpty == false ? "Replace" : "Add") {
                 activePhotoSlot = slot
-                showImagePicker = true
+                showPhotoSourceDialog = true
             }
             .font(.subheadline)
             .buttonStyle(.borderless)

--- a/Job Tracker/Features/Shared/Components/ImagePicker.swift
+++ b/Job Tracker/Features/Shared/Components/ImagePicker.swift
@@ -11,15 +11,26 @@ import UIKit
 
 struct ImagePicker: UIViewControllerRepresentable {
     @Binding var image: UIImage?
+    let sourceType: UIImagePickerController.SourceType
+
+    init(image: Binding<UIImage?>, sourceType: UIImagePickerController.SourceType = .photoLibrary) {
+        _image = image
+        self.sourceType = sourceType
+    }
     
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
         picker.delegate = context.coordinator
-        picker.sourceType = .photoLibrary
+        picker.sourceType = UIImagePickerController.isSourceTypeAvailable(sourceType) ? sourceType : .photoLibrary
         return picker
     }
     
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+        let preferredSourceType = UIImagePickerController.isSourceTypeAvailable(sourceType) ? sourceType : .photoLibrary
+        if uiViewController.sourceType != preferredSourceType {
+            uiViewController.sourceType = preferredSourceType
+        }
+    }
     
     func makeCoordinator() -> Coordinator {
         Coordinator(self)


### PR DESCRIPTION
### Motivation
- Make it possible to either take a picture with the camera or pick one from the photo library when adding/replacing job photos for House, NID, and CAN. 
- Improve the current workflow so users don't need to leave the app to capture images.

### Description
- Added a source-selection confirmation dialog in `JobDetailView` that offers `Take Photo` (camera) and `Choose from Photos` (photo library) and only shows the camera option when available. 
- Wired the chosen source into the existing photo flow so captured or selected images populate the correct slot (`housePhotoImage`, `nidPhotoImage`, `canPhotoImage`).
- Extended the shared `ImagePicker` (`Features/Shared/Components/ImagePicker.swift`) to accept a `sourceType: UIImagePickerController.SourceType` with a safe fallback to `.photoLibrary` when the requested source is unavailable. 
- Added `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescription` entries to the app target build settings (`Job Tracker.xcodeproj/project.pbxproj`) so runtime permissions are described.

### Testing
- Ran `git diff --check` to ensure no trivial diff issues and it succeeded. 
- Validated `Job-Tracker-Info.plist` can be parsed with Python (`plistlib.load`) and the check succeeded. 
- Attempted `plutil -lint` but the environment `plutil` invocation differed, so validation was performed via Python instead. 
- `xcodebuild -list -project 'Job Tracker.xcodeproj'` could not be executed in this environment because `xcodebuild` is not available, so a local Xcode build/test should be run by CI/developers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b559a4f8832db6b0b9a6ed373eda)