### PR TITLE
Support iOS background execution for pending job photo uploads and tighten finish/error handling

### DIFF
--- a/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
+++ b/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
@@ -36,8 +36,8 @@ private struct PendingJobPhotoUpload: Identifiable, Codable, Equatable {
 ///
 /// Firestore queues document writes offline, but Firebase Storage does not provide the
 /// same durable offline write queue. This service gives photo uploads the same user
-/// experience as job saves by keeping local image files and retrying uploads while the
-/// app is running.
+/// experience as job saves by keeping local image files, requesting iOS background
+/// execution time for active uploads, and retrying unfinished uploads when the app runs again.
 @MainActor
 final class JobPhotoUploadQueue: ObservableObject {
     static let shared = JobPhotoUploadQueue()
@@ -54,6 +54,7 @@ final class JobPhotoUploadQueue: ObservableObject {
     private var items: [PendingJobPhotoUpload] = []
     private var activeUploadID: String?
     private var retryTask: Task<Void, Never>?
+    private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     private var cycleTotalCount: Int = 0
     private var cycleDoneCount: Int = 0
 
@@ -74,6 +75,7 @@ final class JobPhotoUploadQueue: ObservableObject {
 
     deinit {
         retryTask?.cancel()
+        endBackgroundTaskIfNeeded()
     }
 
     func enqueue(_ photos: [(slot: JobPhotoSlot, image: UIImage)], for jobID: String) {
@@ -108,6 +110,7 @@ final class JobPhotoUploadQueue: ObservableObject {
 
         guard !addedItems.isEmpty else { return }
         items.append(contentsOf: addedItems)
+        ensureBackgroundTaskIfNeeded()
         cycleTotalCount += addedItems.count
         pendingCount = items.count
         saveManifest()
@@ -132,6 +135,7 @@ final class JobPhotoUploadQueue: ObservableObject {
             return
         }
 
+        ensureBackgroundTaskIfNeeded()
         activeUploadID = next.id
         inFlightCount = 1
         publishSyncState()
@@ -187,6 +191,7 @@ final class JobPhotoUploadQueue: ObservableObject {
         pendingCount = items.count
         saveManifest()
         publishSyncState()
+        ensureBackgroundTaskIfNeeded()
         scheduleRetry(after: retryDelay(forAttempts: (items.first { $0.id == item.id }?.attempts ?? item.attempts + 1)))
     }
 
@@ -196,16 +201,21 @@ final class JobPhotoUploadQueue: ObservableObject {
     }
 
     private func finish(_ item: PendingJobPhotoUpload, removingLocalFile: Bool) {
-        guard activeUploadID == item.id else { return }
+        guard activeUploadID == nil || activeUploadID == item.id else { return }
 
-        activeUploadID = nil
-        inFlightCount = 0
+        if activeUploadID == item.id {
+            activeUploadID = nil
+            inFlightCount = 0
+        }
 
-        if let index = items.firstIndex(where: { $0.id == item.id }) {
-            let removed = items.remove(at: index)
-            if removingLocalFile {
-                try? fileManager.removeItem(at: queueDirectory.appendingPathComponent(removed.fileName))
-            }
+        guard let index = items.firstIndex(where: { $0.id == item.id }) else {
+            endBackgroundTaskIfIdle()
+            return
+        }
+
+        let removed = items.remove(at: index)
+        if removingLocalFile {
+            try? fileManager.removeItem(at: queueDirectory.appendingPathComponent(removed.fileName))
         }
 
         cycleDoneCount += 1
@@ -242,6 +252,40 @@ final class JobPhotoUploadQueue: ObservableObject {
         cycleDoneCount = 0
         completedCount = 0
         pendingCount = 0
+        endBackgroundTaskIfIdle()
+    }
+
+    private func ensureBackgroundTaskIfNeeded() {
+        guard backgroundTaskID == .invalid, !items.isEmpty else { return }
+
+        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "JobPhotoUploadQueue") { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleBackgroundTaskExpired()
+            }
+        }
+    }
+
+    private func handleBackgroundTaskExpired() {
+        retryTask?.cancel()
+        retryTask = nil
+        activeUploadID = nil
+        inFlightCount = 0
+        pendingCount = items.count
+        saveManifest()
+        publishSyncState()
+        endBackgroundTaskIfNeeded()
+    }
+
+    private func endBackgroundTaskIfIdle() {
+        guard activeUploadID == nil, items.isEmpty else { return }
+        endBackgroundTaskIfNeeded()
+    }
+
+    private func endBackgroundTaskIfNeeded() {
+        guard backgroundTaskID != .invalid else { return }
+        let taskID = backgroundTaskID
+        backgroundTaskID = .invalid
+        UIApplication.shared.endBackgroundTask(taskID)
     }
 
     private func loadManifest() {


### PR DESCRIPTION
### Motivation
- Ensure pending photo uploads can continue (or at least have more time) when the app goes to the background by requesting iOS background execution time. 
- Keep the upload queue state durable and consistent when uploads fail, expire, or the app lifecycle changes. 
- Avoid leaving stray background tasks running and tighten the logic around completing/removing queue items.

### Description
- Added background task lifecycle management with a `backgroundTaskID` property and helper methods `ensureBackgroundTaskIfNeeded()`, `handleBackgroundTaskExpired()`, `endBackgroundTaskIfIdle()`, and `endBackgroundTaskIfNeeded()` to request and end `UIApplication` background tasks. 
- Invoke `ensureBackgroundTaskIfNeeded()` when enqueueing items, when starting processing, and after failures to ensure the OS gives the app background execution time while uploads are pending. 
- Hardened `finish(_:,removingLocalFile:)` to allow finishing when `activeUploadID` is nil or matches the item, moved item removal into a single path, and ensure background tasks are ended when the queue becomes idle. 
- Cancel retry tasks and reset in-flight state when a background task expires and make `deinit` call `endBackgroundTaskIfNeeded()` to clean up.

### Testing
- No new automated tests were added for background behavior. 
- The existing automated test suite was executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18baaab0f8832d922b4a59f528d06c)