### PR TITLE
Fix photo upload queue deinit isolation

### DIFF
--- a/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
+++ b/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
@@ -75,7 +75,13 @@ final class JobPhotoUploadQueue: ObservableObject {
 
     deinit {
         retryTask?.cancel()
-        endBackgroundTaskIfNeeded()
+
+        let taskID = backgroundTaskID
+        if taskID != .invalid {
+            Task { @MainActor in
+                UIApplication.shared.endBackgroundTask(taskID)
+            }
+        }
     }
 
     func enqueue(_ photos: [(slot: JobPhotoSlot, image: UIImage)], for jobID: String) {


### PR DESCRIPTION
### Motivation
- Avoid invoking the main-actor-isolated helper `endBackgroundTaskIfNeeded()` from the synchronous `deinit`, which produced the main-actor isolation error at runtime.

### Description
- In `Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift` replace the synchronous deinit call with capturing `backgroundTaskID` and invoking `UIApplication.shared.endBackgroundTask(taskID)` from a `Task { @MainActor in ... }` so the background task is ended on the main actor without calling the actor-isolated helper synchronously.

### Testing
- Ran `swift --version` which succeeded.
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` but `xcodebuild` is not available in this environment, so a full project build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18c65a1aa4832da7eb7dd03c685912)