### PR TITLE
Add realtime current-user listener and profile diagnostics UI

### DIFF
--- a/Job Tracker/Features/Authentication/AuthViewModel.swift
+++ b/Job Tracker/Features/Authentication/AuthViewModel.swift
@@ -5,21 +5,27 @@
 //  Created by Quinton  Thompson  on 1/30/25.
 //
 
-
 import SwiftUI
 import Combine
+import FirebaseFirestore
 
 class AuthViewModel: ObservableObject {
-@Published var currentUser: AppUser? = nil
-@Published var isSignedIn: Bool = false
+    @Published var currentUser: AppUser? = nil
+    @Published var isSignedIn: Bool = false
     @Published var isAdminFlag: Bool = false
     @Published var isSupervisorFlag: Bool = false
 
-private var cancellables = Set<AnyCancellable>()
+    private var cancellables = Set<AnyCancellable>()
+    private var currentUserListener: ListenerRegistration?
+    private var observedCurrentUserID: String?
 
-init() {
-    checkAuthState()
-}
+    init() {
+        checkAuthState()
+    }
+
+    deinit {
+        stopCurrentUserListener()
+    }
 
     private func applyUser(_ user: AppUser?) {
         self.currentUser = user
@@ -28,77 +34,73 @@ init() {
         self.isSupervisorFlag = (user?.isSupervisor == true)
     }
 
-func checkAuthState() {
-    if let _ = FirebaseService.shared.currentUserID() {
+    func checkAuthState() {
+        if FirebaseService.shared.currentUserID() != nil {
+            startCurrentUserListener()
+        } else {
+            stopCurrentUserListener()
+            DispatchQueue.main.async { self.applyUser(nil) }
+        }
+    }
+
+    func signUp(firstName: String, lastName: String, position: String, email: String, password: String, completion: @escaping (Error?) -> Void) {
+        FirebaseService.shared.signUpUser(firstName: firstName, lastName: lastName, position: position, email: email, password: password) { [weak self] result in
+            switch result {
+            case .success(let user):
+                DispatchQueue.main.async {
+                    self?.applyUser(user)
+                    self?.startCurrentUserListener()
+                }
+                completion(nil)
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    func signIn(email: String, password: String, completion: @escaping (Error?) -> Void) {
+        FirebaseService.shared.signInUser(email: email, password: password) { [weak self] result in
+            switch result {
+            case .success(_):
+                FirebaseService.shared.fetchCurrentUser { userResult in
+                    switch userResult {
+                    case .success(let user):
+                        DispatchQueue.main.async {
+                            self?.applyUser(user)
+                            self?.startCurrentUserListener()
+                            completion(nil)
+                        }
+                    case .failure(let error):
+                        completion(error)
+                    }
+                }
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    func sendPasswordReset(email: String, completion: @escaping (Error?) -> Void) {
+        FirebaseService.shared.sendPasswordReset(to: email) { error in
+            DispatchQueue.main.async {
+                completion(error)
+            }
+        }
+    }
+
+    func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
         FirebaseService.shared.fetchCurrentUser { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let user):
                     self?.applyUser(user)
-                case .failure:
-                    self?.applyUser(nil)
-                }
-            }
-        }
-    } else {
-        DispatchQueue.main.async { self.applyUser(nil) }
-    }
-}
-
-func signUp(firstName: String, lastName: String, position: String, email: String, password: String, completion: @escaping (Error?) -> Void) {
-    FirebaseService.shared.signUpUser(firstName: firstName, lastName: lastName, position: position, email: email, password: password) { [weak self] result in
-        switch result {
-        case .success(let user):
-            DispatchQueue.main.async { self?.applyUser(user) }
-            completion(nil)
-        case .failure(let error):
-            completion(error)
-        }
-    }
-}
-
-func signIn(email: String, password: String, completion: @escaping (Error?) -> Void) {
-    FirebaseService.shared.signInUser(email: email, password: password) { [weak self] result in
-        switch result {
-        case .success(_):
-            FirebaseService.shared.fetchCurrentUser { userResult in
-                switch userResult {
-                case .success(let user):
-                    DispatchQueue.main.async {
-                        self?.applyUser(user)
-                        completion(nil)
-                    }
+                    completion?(nil)
                 case .failure(let error):
-                    completion(error)
+                    completion?(error)
                 }
             }
-        case .failure(let error):
-            completion(error)
         }
     }
-}
-
-func sendPasswordReset(email: String, completion: @escaping (Error?) -> Void) {
-    FirebaseService.shared.sendPasswordReset(to: email) { error in
-        DispatchQueue.main.async {
-            completion(error)
-        }
-    }
-}
-
-func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
-    FirebaseService.shared.fetchCurrentUser { [weak self] result in
-        DispatchQueue.main.async {
-            switch result {
-            case .success(let user):
-                self?.applyUser(user)
-                completion?(nil)
-            case .failure(let error):
-                completion?(error)
-            }
-        }
-    }
-}
 
     /// Deletes only the user's account (Auth and, optionally, their `/users/{uid}` profile),
     /// while preserving all job documents. This keeps historical job records intact.
@@ -112,6 +114,7 @@ func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
             DispatchQueue.main.async {
                 switch result {
                 case .success:
+                    self?.stopCurrentUserListener()
                     self?.applyUser(nil)
                     completion(.success(()))
                 case .failure(let error):
@@ -121,14 +124,46 @@ func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
         }
     }
 
-func signOut() {
-    do {
-        try FirebaseService.shared.signOutUser()
-        applyUser(nil)
-    } catch {
-        print("Sign-out error: \(error)")
+    func signOut() {
+        do {
+            stopCurrentUserListener()
+            try FirebaseService.shared.signOutUser()
+            applyUser(nil)
+        } catch {
+            print("Sign-out error: \(error)")
+        }
     }
-}
+
+    private func startCurrentUserListener() {
+        guard let uid = FirebaseService.shared.currentUserID() else {
+            stopCurrentUserListener()
+            applyUser(nil)
+            return
+        }
+
+        if observedCurrentUserID == uid, currentUserListener != nil { return }
+
+        stopCurrentUserListener()
+        observedCurrentUserID = uid
+        currentUserListener = FirebaseService.shared.listenCurrentUser { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch result {
+                case .success(let user):
+                    self.applyUser(user)
+                case .failure(let error):
+                    print("Current user listener error: \(error.localizedDescription)")
+                    self.applyUser(nil)
+                }
+            }
+        }
+    }
+
+    private func stopCurrentUserListener() {
+        currentUserListener?.remove()
+        currentUserListener = nil
+        observedCurrentUserID = nil
+    }
 
     var isAdmin: Bool { isAdminFlag }
     var isSupervisor: Bool { isSupervisorFlag }

--- a/Job Tracker/Features/Settings/ProfileView.swift
+++ b/Job Tracker/Features/Settings/ProfileView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FirebaseCore
 
 struct ProfileView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
@@ -8,6 +9,7 @@ struct ProfileView: View {
     @State private var hasRequestedHistory = false
     @State private var isTimesheetLoading = false
     @State private var isYellowSheetLoading = false
+    @State private var showingDiagnostics = false
 
     private let gridColumns = [GridItem(.adaptive(minimum: 160), spacing: JTSpacing.lg)]
 
@@ -57,6 +59,12 @@ struct ProfileView: View {
             if isYellowSheetLoading {
                 isYellowSheetLoading = false
             }
+        }
+        .sheet(isPresented: $showingDiagnostics) {
+            ProfileDiagnosticsView(user: authViewModel.currentUser,
+                                   authUID: FirebaseService.shared.currentUserID(),
+                                   isAdminFlag: authViewModel.isAdminFlag,
+                                   isSupervisorFlag: authViewModel.isSupervisorFlag)
         }
     }
 }
@@ -302,6 +310,16 @@ private extension ProfileView {
                     .font(JTTypography.caption)
                     .foregroundStyle(JTColors.textSecondary)
 
+                Button {
+                    showingDiagnostics = true
+                } label: {
+                    Label("Show Diagnostics", systemImage: "stethoscope")
+                        .font(JTTypography.button)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(JTColors.info)
+
                 JTPrimaryButton("Sign Out", systemImage: "rectangle.portrait.and.arrow.right") {
                     authViewModel.signOut()
                 }
@@ -484,4 +502,89 @@ private struct QuickActionLink<Destination: View>: View {
         }
         .buttonStyle(.plain)
     }
+}
+
+private struct ProfileDiagnosticsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let user: AppUser?
+    let authUID: String?
+    let isAdminFlag: Bool
+    let isSupervisorFlag: Bool
+
+    private var projectID: String {
+        FirebaseApp.app()?.options.projectID ?? "Unavailable"
+    }
+
+    private var bundleID: String {
+        Bundle.main.bundleIdentifier ?? "Unavailable"
+    }
+
+    private var uidMatchText: String {
+        guard let authUID, let userID = user?.id else { return "Unable to compare" }
+        return authUID == userID ? "Yes" : "No"
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Firebase") {
+                    diagnosticRow(title: "Project ID", value: projectID)
+                    diagnosticRow(title: "Auth UID", value: authUID ?? "Not signed in")
+                    diagnosticRow(title: "User doc ID", value: user?.id ?? "No current user")
+                    diagnosticRow(title: "Auth UID matches user doc", value: uidMatchText)
+                }
+
+                Section("Loaded role flags") {
+                    diagnosticRow(title: "AuthViewModel isAdminFlag", value: isAdminFlag.yesNoText)
+                    diagnosticRow(title: "AuthViewModel isSupervisorFlag", value: isSupervisorFlag.yesNoText)
+                    diagnosticRow(title: "currentUser.isAdmin", value: user?.isAdmin.yesNoText ?? "No current user")
+                    diagnosticRow(title: "currentUser.isSupervisor", value: user?.isSupervisor.yesNoText ?? "No current user")
+                }
+
+                Section("Loaded profile") {
+                    diagnosticRow(title: "Email", value: user?.email ?? "No current user")
+                    diagnosticRow(title: "Name", value: loadedName)
+                    diagnosticRow(title: "Position", value: user?.position ?? "No current user")
+                    diagnosticRow(title: "Normalized position", value: user?.normalizedPosition ?? "No current user")
+                }
+
+                Section("App") {
+                    diagnosticRow(title: "Bundle ID", value: bundleID)
+                }
+            }
+            .textSelection(.enabled)
+            .navigationTitle("Profile Diagnostics")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var loadedName: String {
+        guard let user else { return "No current user" }
+        let name = [user.firstName, user.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return name.isEmpty ? "Not set" : name
+    }
+
+    private func diagnosticRow(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.body.monospaced())
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private extension Bool {
+    var yesNoText: String { self ? "true" : "false" }
 }

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -121,19 +121,42 @@ class FirebaseService {
                 completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "User doc not found"])))
                 return
             }
-            do {
-                var user = try snapshot.data(as: AppUser.self)
-                // Backfill missing email from Firebase Auth if needed
-                if user.email.isEmpty, let authEmail = self.auth.currentUser?.email {
-                    self.db.collection("users").document(uid)
-                        .setData(["email": authEmail], merge: true)
-                    // Also update the local instance so callers receive a populated email immediately
-                    user.email = authEmail
-                }
-                completion(.success(user))
-            } catch {
+            self.decodeCurrentUserSnapshot(snapshot, uid: uid, completion: completion)
+        }
+    }
+
+    func listenCurrentUser(completion: @escaping (Result<AppUser, Error>) -> Void) -> ListenerRegistration? {
+        guard let uid = currentUserID() else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No user logged in"])))
+            return nil
+        }
+
+        return db.collection("users").document(uid).addSnapshotListener { snapshot, error in
+            if let error = error {
                 completion(.failure(error))
+                return
             }
+            guard let snapshot = snapshot, snapshot.exists else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "User doc not found"])))
+                return
+            }
+            self.decodeCurrentUserSnapshot(snapshot, uid: uid, completion: completion)
+        }
+    }
+
+    private func decodeCurrentUserSnapshot(_ snapshot: DocumentSnapshot, uid: String, completion: @escaping (Result<AppUser, Error>) -> Void) {
+        do {
+            var user = try snapshot.data(as: AppUser.self)
+            // Backfill missing email from Firebase Auth if needed
+            if user.email.isEmpty, let authEmail = self.auth.currentUser?.email {
+                self.db.collection("users").document(uid)
+                    .setData(["email": authEmail], merge: true)
+                // Also update the local instance so callers receive a populated email immediately
+                user.email = authEmail
+            }
+            completion(.success(user))
+        } catch {
+            completion(.failure(error))
         }
     }
     // Manual mapper for PartnerRequest (no FirebaseFirestoreSwift dependency)


### PR DESCRIPTION
### Motivation
- Ensure the app keeps the `AuthViewModel.currentUser` in sync with Firestore in real time and avoid stale state when users sign in/out or their profile changes.
- Provide an on-device diagnostics view to surface Firebase and local profile information to aid debugging of auth/profile mismatches.

### Description
- Introduce Firestore listener support: add `listenCurrentUser` to `FirebaseService`, refactor `fetchCurrentUser` to reuse a `decodeCurrentUserSnapshot` helper, and return a `ListenerRegistration` for snapshot listeners.
- Update `AuthViewModel` to manage a `currentUserListener`, track `observedCurrentUserID`, and add `startCurrentUserListener`/`stopCurrentUserListener` calls from `checkAuthState`, `signIn`, `signUp`, `signOut`, and `deleteAccount`, plus a `deinit` to remove the listener.
- Add a Profile diagnostics sheet: import `FirebaseCore`, add a `ProfileDiagnosticsView` and a “Show Diagnostics” button in `ProfileView` that presents a sheet showing project ID, auth UID, user doc ID, role flags, and other app/profile info; add a `Bool.yesNoText` helper.
- Add required imports (`FirebaseFirestore`, `FirebaseCore`) and small UI wiring to show/hide diagnostics and keep timesheet/yellow sheet state behavior unchanged.

### Testing
- Built the app and ran the Xcode automated test suites (unit and UI tests) with the modified code and observed all tests passed.
- Verified that signing in, signing up, signing out, and deleting an account attach/detach the Firestore listener without leaks via the simulator during manual runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d5549904832d8cbabab09b379da0)