### PR TITLE
Add forced app update gate

### DIFF
--- a/Documentation/Features/AppUpdate.md
+++ b/Documentation/Features/AppUpdate.md
@@ -1,0 +1,28 @@
+# Forced App Updates
+
+The iOS app listens to a Firestore-backed version policy and blocks the main UI whenever the configured version is newer than the installed build. This lets administrators require technicians to update before continuing to use Job Tracker.
+
+## Firestore Configuration
+
+Create or update the document at `app_config/ios_version` with these fields:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `latestVersion` | String | Yes | Latest available marketing version, such as `2.2.0`. Any installed version lower than this is blocked. |
+| `latestBuild` | String | No | Latest available build number. When the marketing version matches, lower installed builds are blocked. |
+| `minimumRequiredVersion` | String | No | Optional hard floor. Installed versions below this value are blocked even if `latestVersion` is omitted. |
+| `minimumRequiredBuild` | String | No | Optional hard floor for build numbers. |
+| `updateURL` | String | Recommended | App Store, TestFlight, MDM, or internal distribution URL opened by the **Update Now** button. |
+| `releaseNotes` | String | No | Short message shown on the blocking update screen. |
+| `forceUpdateEnabled` | Bool | No | Defaults to `true`. Set to `false` to temporarily disable forced updates without deleting the document. |
+
+## Runtime Flow
+
+1. `JobTrackerApp` creates a `ForceUpdateViewModel` and starts monitoring Firestore when the root scene appears.
+2. `FirestoreAppUpdateRequirementProvider` listens to `app_config/ios_version` in real time.
+3. `AppVersionComparator` compares semantic version components numerically, so `1.10.0` correctly sorts after `1.2.9`.
+4. If the policy describes a newer version or build, `ForceUpdateView` is rendered over the app and cannot be dismissed. The only action is to open `updateURL`.
+
+## Testing Notes
+
+Keep version comparison coverage in `AppVersionComparatorTests` when changing the policy schema or comparison rules.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -6,6 +6,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 
 - [Admin](Features/Admin.md)
 - [Authentication](Features/Authentication.md)
+- [Forced App Updates](Features/AppUpdate.md)
 - [Dashboard](Features/Dashboard.md)
 - [Help](Features/Help.md)
 - [Jobs](Features/Jobs.md)

--- a/Job Tracker/Features/Shared/AppUpdate/AppUpdateRequirement.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/AppUpdateRequirement.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+struct AppUpdateRequirement: Equatable {
+    let latestVersion: String
+    let minimumRequiredVersion: String?
+    let latestBuild: String?
+    let minimumRequiredBuild: String?
+    let updateURL: URL?
+    let releaseNotes: String?
+    let isEnabled: Bool
+
+    init(
+        latestVersion: String,
+        minimumRequiredVersion: String? = nil,
+        latestBuild: String? = nil,
+        minimumRequiredBuild: String? = nil,
+        updateURL: URL? = nil,
+        releaseNotes: String? = nil,
+        isEnabled: Bool = true
+    ) {
+        self.latestVersion = latestVersion
+        self.minimumRequiredVersion = minimumRequiredVersion
+        self.latestBuild = latestBuild
+        self.minimumRequiredBuild = minimumRequiredBuild
+        self.updateURL = updateURL
+        self.releaseNotes = releaseNotes
+        self.isEnabled = isEnabled
+    }
+}
+
+enum AppUpdateDecision: Equatable {
+    case upToDate
+    case updateRequired(AppUpdateRequirement)
+}
+
+enum AppVersionComparator {
+    static func decision(
+        currentVersion: String,
+        currentBuild: String?,
+        requirement: AppUpdateRequirement?
+    ) -> AppUpdateDecision {
+        guard let requirement, requirement.isEnabled else { return .upToDate }
+
+        if let minimumRequiredVersion = requirement.minimumRequiredVersion,
+           compare(currentVersion, minimumRequiredVersion) == .orderedAscending {
+            return .updateRequired(requirement)
+        }
+
+        if let minimumRequiredBuild = requirement.minimumRequiredBuild,
+           let currentBuild,
+           compareBuild(currentBuild, minimumRequiredBuild) == .orderedAscending {
+            return .updateRequired(requirement)
+        }
+
+        if compare(currentVersion, requirement.latestVersion) == .orderedAscending {
+            return .updateRequired(requirement)
+        }
+
+        if let latestBuild = requirement.latestBuild,
+           let currentBuild,
+           compareBuild(currentBuild, latestBuild) == .orderedAscending,
+           compare(currentVersion, requirement.latestVersion) != .orderedDescending {
+            return .updateRequired(requirement)
+        }
+
+        return .upToDate
+    }
+
+    static func compare(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let left = normalizedVersionParts(lhs)
+        let right = normalizedVersionParts(rhs)
+        let maxCount = max(left.count, right.count)
+
+        for index in 0..<maxCount {
+            let leftValue = index < left.count ? left[index] : 0
+            let rightValue = index < right.count ? right[index] : 0
+
+            if leftValue < rightValue { return .orderedAscending }
+            if leftValue > rightValue { return .orderedDescending }
+        }
+
+        return .orderedSame
+    }
+
+    static func compareBuild(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        if let left = Int(lhs), let right = Int(rhs) {
+            if left < right { return .orderedAscending }
+            if left > right { return .orderedDescending }
+            return .orderedSame
+        }
+
+        return lhs.localizedStandardCompare(rhs)
+    }
+
+    private static func normalizedVersionParts(_ version: String) -> [Int] {
+        version
+            .split(separator: ".")
+            .map { part in
+                let numericPrefix = part.prefix { $0.isNumber }
+                return Int(numericPrefix) ?? 0
+            }
+    }
+}
+
+extension Bundle {
+    var appShortVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+    }
+
+    var appBuildVersion: String {
+        infoDictionary?["CFBundleVersion"] as? String ?? "0"
+    }
+}

--- a/Job Tracker/Features/Shared/AppUpdate/ForceUpdateView.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/ForceUpdateView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct ForceUpdateView: View {
+    let requirement: AppUpdateRequirement
+    let currentVersion: String
+    let currentBuild: String
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color(.systemIndigo), Color(.systemBlue), Color(.systemBackground)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Image(systemName: "arrow.down.app.fill")
+                    .font(.system(size: 64, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .shadow(radius: 8)
+
+                VStack(spacing: 10) {
+                    Text("Update Required")
+                        .font(.largeTitle.bold())
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+
+                    Text("A newer version of Job Tracker is available. Please update to continue using the app.")
+                        .font(.body)
+                        .foregroundStyle(.white.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Installed: \(currentVersion) (\(currentBuild))", systemImage: "iphone")
+                    Label("Available: \(requirement.latestVersion)\(availableBuildText)", systemImage: "sparkles")
+
+                    if let releaseNotes = requirement.releaseNotes, !releaseNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Divider()
+                        Text(releaseNotes)
+                            .font(.callout)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .font(.callout.weight(.medium))
+                .foregroundStyle(Color.primary)
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+
+                Button(action: openUpdateURL) {
+                    Text("Update Now")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(requirement.updateURL == nil)
+
+                if requirement.updateURL == nil {
+                    Text("Ask your administrator for the latest install link.")
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.85))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 520)
+        }
+        .interactiveDismissDisabled(true)
+        .accessibilityIdentifier("ForceUpdateView")
+    }
+
+    private var availableBuildText: String {
+        guard let latestBuild = requirement.latestBuild else { return "" }
+        return " (\(latestBuild))"
+    }
+
+    private func openUpdateURL() {
+        guard let updateURL = requirement.updateURL else { return }
+        openURL(updateURL)
+    }
+}

--- a/Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Combine
+import FirebaseFirestore
+
+protocol AppUpdateRequirementProviding {
+    @discardableResult
+    func observeRequirement(_ onChange: @escaping (Result<AppUpdateRequirement?, Error>) -> Void) -> ListenerRegistration?
+}
+
+final class FirestoreAppUpdateRequirementProvider: AppUpdateRequirementProviding {
+    private let db: Firestore
+    private let collection: String
+    private let documentID: String
+
+    init(
+        db: Firestore = Firestore.firestore(),
+        collection: String = "app_config",
+        documentID: String = "ios_version"
+    ) {
+        self.db = db
+        self.collection = collection
+        self.documentID = documentID
+    }
+
+    @discardableResult
+    func observeRequirement(_ onChange: @escaping (Result<AppUpdateRequirement?, Error>) -> Void) -> ListenerRegistration? {
+        db.collection(collection).document(documentID).addSnapshotListener { snapshot, error in
+            if let error {
+                onChange(.failure(error))
+                return
+            }
+
+            guard let data = snapshot?.data(), snapshot?.exists == true else {
+                onChange(.success(nil))
+                return
+            }
+
+            let updateURL: URL?
+            if let urlString = data["updateURL"] as? String {
+                updateURL = URL(string: urlString)
+            } else {
+                updateURL = nil
+            }
+
+            let requirement = AppUpdateRequirement(
+                latestVersion: data["latestVersion"] as? String ?? data["minimumRequiredVersion"] as? String ?? "0",
+                minimumRequiredVersion: data["minimumRequiredVersion"] as? String,
+                latestBuild: data["latestBuild"] as? String,
+                minimumRequiredBuild: data["minimumRequiredBuild"] as? String,
+                updateURL: updateURL,
+                releaseNotes: data["releaseNotes"] as? String,
+                isEnabled: data["forceUpdateEnabled"] as? Bool ?? true
+            )
+            onChange(.success(requirement))
+        }
+    }
+}
+
+@MainActor
+final class ForceUpdateViewModel: ObservableObject {
+    @Published private(set) var decision: AppUpdateDecision = .upToDate
+    @Published private(set) var lastErrorMessage: String?
+
+    private let provider: AppUpdateRequirementProviding
+    private let currentVersionProvider: () -> String
+    private let currentBuildProvider: () -> String
+    private var listener: ListenerRegistration?
+
+    init(
+        provider: AppUpdateRequirementProviding = FirestoreAppUpdateRequirementProvider(),
+        currentVersionProvider: @escaping () -> String = { Bundle.main.appShortVersion },
+        currentBuildProvider: @escaping () -> String = { Bundle.main.appBuildVersion }
+    ) {
+        self.provider = provider
+        self.currentVersionProvider = currentVersionProvider
+        self.currentBuildProvider = currentBuildProvider
+    }
+
+    deinit {
+        listener?.remove()
+    }
+
+    func startMonitoring() {
+        guard listener == nil else { return }
+
+        listener = provider.observeRequirement { [weak self] result in
+            Task { @MainActor in
+                guard let self else { return }
+
+                switch result {
+                case let .success(requirement):
+                    self.lastErrorMessage = nil
+                    self.decision = AppVersionComparator.decision(
+                        currentVersion: self.currentVersionProvider(),
+                        currentBuild: self.currentBuildProvider(),
+                        requirement: requirement
+                    )
+                case let .failure(error):
+                    self.lastErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/Job Tracker/Job_TrackerApp.swift
+++ b/Job Tracker/Job_TrackerApp.swift
@@ -44,6 +44,7 @@ struct JobTrackerApp: App {
     @StateObject private var usersViewModel = JobTrackerApp.makeUsersVM()
     @StateObject private var navigationViewModel = AppNavigationViewModel()
     @StateObject private var themeManager = JTThemeManager.shared
+    @StateObject private var forceUpdateViewModel = ForceUpdateViewModel()
     @AppStorage("arrivalAlertsEnabledToday") private var arrivalAlertsEnabledToday = true
     @State private var showSplash: Bool = true
     @State private var showImportSuccess: Bool = false
@@ -98,6 +99,16 @@ struct JobTrackerApp: App {
                     }
                     .transition(.opacity)
                 }
+
+                if case let .updateRequired(requirement) = forceUpdateViewModel.decision {
+                    ForceUpdateView(
+                        requirement: requirement,
+                        currentVersion: Bundle.main.appShortVersion,
+                        currentBuild: Bundle.main.appBuildVersion
+                    )
+                    .transition(.opacity)
+                    .zIndex(10)
+                }
                 
                 // Import banners (shown after deep link handling)
                 VStack(spacing: 8) {
@@ -125,6 +136,9 @@ struct JobTrackerApp: App {
             .environmentObject(themeManager)
             .preferredColorScheme(themeManager.theme.colorScheme)
             .tint(themeManager.theme.accentColor)
+            .task {
+                forceUpdateViewModel.startMonitoring()
+            }
             .sheet(item: $pendingSharedJobPreview) { preview in
                 JobImportPreviewView(
                     preview: preview,

--- a/Job TrackerTests/AppVersionComparatorTests.swift
+++ b/Job TrackerTests/AppVersionComparatorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Job_Tracker
+
+final class AppVersionComparatorTests: XCTestCase {
+    func testSemanticVersionsCompareNumerically() {
+        XCTAssertEqual(AppVersionComparator.compare("1.10.0", "1.2.9"), .orderedDescending)
+        XCTAssertEqual(AppVersionComparator.compare("2.0", "2.0.0"), .orderedSame)
+        XCTAssertEqual(AppVersionComparator.compare("2.0.1", "2.1"), .orderedAscending)
+    }
+
+    func testNewerLatestVersionRequiresUpdate() {
+        let requirement = AppUpdateRequirement(latestVersion: "2.2.0")
+        let decision = AppVersionComparator.decision(
+            currentVersion: "2.1.10",
+            currentBuild: "16",
+            requirement: requirement
+        )
+
+        XCTAssertEqual(decision, .updateRequired(requirement))
+    }
+
+    func testDisabledRequirementDoesNotBlockApp() {
+        let requirement = AppUpdateRequirement(latestVersion: "9.0.0", isEnabled: false)
+        let decision = AppVersionComparator.decision(
+            currentVersion: "1.0.0",
+            currentBuild: "1",
+            requirement: requirement
+        )
+
+        XCTAssertEqual(decision, .upToDate)
+    }
+
+    func testNewerBuildForSameVersionRequiresUpdate() {
+        let requirement = AppUpdateRequirement(latestVersion: "2.1.10", latestBuild: "20")
+        let decision = AppVersionComparator.decision(
+            currentVersion: "2.1.10",
+            currentBuild: "16",
+            requirement: requirement
+        )
+
+        XCTAssertEqual(decision, .updateRequired(requirement))
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent users from continuing to use the app when administrators publish a newer required version or build via a remote policy. 
- Make the requirement configurable and toggleable from Firestore so ops can enable/disable forced updates without redeploying the app.

### Description
- Add a small version policy model and comparator in `Job Tracker/Features/Shared/AppUpdate/AppUpdateRequirement.swift` that supports `latestVersion`, `latestBuild`, minimum version/build floors, and numeric semantic-version comparisons via `AppVersionComparator`.
- Add a Firestore-backed provider and observable view model in `Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift` (`FirestoreAppUpdateRequirementProvider` + `ForceUpdateViewModel`) that listens to the document at `app_config/ios_version` and computes a decision.
- Add a blocking SwiftUI screen `ForceUpdateView` in `Job Tracker/Features/Shared/AppUpdate/ForceUpdateView.swift` that shows installed vs available version, release notes and an **Update Now** action and disables interactive dismissal.
- Wire the gate into the app root by creating a `ForceUpdateViewModel` instance in `Job Tracker/Job_TrackerApp.swift`, starting monitoring with `forceUpdateViewModel.startMonitoring()`, and overlaying `ForceUpdateView` when the decision is `.updateRequired(...)`.
- Add documentation at `Documentation/Features/AppUpdate.md` and update `Documentation/README.md` for the new feature, and add unit tests in `Job TrackerTests/AppVersionComparatorTests.swift` to cover version comparison and blocking logic.

### Testing
- Ran a quick parse of the new comparator file with `swiftc -parse 'Job Tracker/Features/Shared/AppUpdate/AppUpdateRequirement.swift'` which succeeded.
- Added unit tests in `Job TrackerTests/AppVersionComparatorTests.swift` covering semantic comparisons and decision outcomes (tests added to the repo but not executed in this environment).
- Attempted a full Xcode build via `xcodebuild -scheme 'Job Tracker' -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation build` but `xcodebuild` is not available in this environment so an end-to-end build/test run wasn’t executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ed1cec6c832d83b0fa67a5e1b381)