### PR TITLE
Normalize 'Aerial' → 'OH', centralize crew-position/status logic, add current-user listener and supervisor dashboard

### DIFF
--- a/Job Tracker/Features/Authentication/AuthFlowView.swift
+++ b/Job Tracker/Features/Authentication/AuthFlowView.swift
@@ -271,7 +271,7 @@ private struct AuthSignUpForm: View {
     @State private var lastName = ""
     @State private var email = ""
     @State private var password = ""
-    @State private var position = "Aerial"
+    @State private var position = "OH"
 
     @State private var firstNameError: String?
     @State private var lastNameError: String?
@@ -290,7 +290,7 @@ private struct AuthSignUpForm: View {
         case password
     }
 
-    private let positions = ["Aerial", "Underground", "Nid", "Can"]
+    private let positions = CrewPosition.signupOptions
 
     var onShowSignIn: () -> Void
 

--- a/Job Tracker/Features/Authentication/AuthViewModel.swift
+++ b/Job Tracker/Features/Authentication/AuthViewModel.swift
@@ -5,21 +5,27 @@
 //  Created by Quinton  Thompson  on 1/30/25.
 //
 
-
 import SwiftUI
 import Combine
+import FirebaseFirestore
 
 class AuthViewModel: ObservableObject {
-@Published var currentUser: AppUser? = nil
-@Published var isSignedIn: Bool = false
+    @Published var currentUser: AppUser? = nil
+    @Published var isSignedIn: Bool = false
     @Published var isAdminFlag: Bool = false
     @Published var isSupervisorFlag: Bool = false
 
-private var cancellables = Set<AnyCancellable>()
+    private var cancellables = Set<AnyCancellable>()
+    private var currentUserListener: ListenerRegistration?
+    private var observedCurrentUserID: String?
 
-init() {
-    checkAuthState()
-}
+    init() {
+        checkAuthState()
+    }
+
+    deinit {
+        stopCurrentUserListener()
+    }
 
     private func applyUser(_ user: AppUser?) {
         self.currentUser = user
@@ -28,77 +34,73 @@ init() {
         self.isSupervisorFlag = (user?.isSupervisor == true)
     }
 
-func checkAuthState() {
-    if let _ = FirebaseService.shared.currentUserID() {
+    func checkAuthState() {
+        if FirebaseService.shared.currentUserID() != nil {
+            startCurrentUserListener()
+        } else {
+            stopCurrentUserListener()
+            DispatchQueue.main.async { self.applyUser(nil) }
+        }
+    }
+
+    func signUp(firstName: String, lastName: String, position: String, email: String, password: String, completion: @escaping (Error?) -> Void) {
+        FirebaseService.shared.signUpUser(firstName: firstName, lastName: lastName, position: position, email: email, password: password) { [weak self] result in
+            switch result {
+            case .success(let user):
+                DispatchQueue.main.async {
+                    self?.applyUser(user)
+                    self?.startCurrentUserListener()
+                }
+                completion(nil)
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    func signIn(email: String, password: String, completion: @escaping (Error?) -> Void) {
+        FirebaseService.shared.signInUser(email: email, password: password) { [weak self] result in
+            switch result {
+            case .success(_):
+                FirebaseService.shared.fetchCurrentUser { userResult in
+                    switch userResult {
+                    case .success(let user):
+                        DispatchQueue.main.async {
+                            self?.applyUser(user)
+                            self?.startCurrentUserListener()
+                            completion(nil)
+                        }
+                    case .failure(let error):
+                        completion(error)
+                    }
+                }
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+
+    func sendPasswordReset(email: String, completion: @escaping (Error?) -> Void) {
+        FirebaseService.shared.sendPasswordReset(to: email) { error in
+            DispatchQueue.main.async {
+                completion(error)
+            }
+        }
+    }
+
+    func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
         FirebaseService.shared.fetchCurrentUser { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let user):
                     self?.applyUser(user)
-                case .failure:
-                    self?.applyUser(nil)
-                }
-            }
-        }
-    } else {
-        DispatchQueue.main.async { self.applyUser(nil) }
-    }
-}
-
-func signUp(firstName: String, lastName: String, position: String, email: String, password: String, completion: @escaping (Error?) -> Void) {
-    FirebaseService.shared.signUpUser(firstName: firstName, lastName: lastName, position: position, email: email, password: password) { [weak self] result in
-        switch result {
-        case .success(let user):
-            DispatchQueue.main.async { self?.applyUser(user) }
-            completion(nil)
-        case .failure(let error):
-            completion(error)
-        }
-    }
-}
-
-func signIn(email: String, password: String, completion: @escaping (Error?) -> Void) {
-    FirebaseService.shared.signInUser(email: email, password: password) { [weak self] result in
-        switch result {
-        case .success(_):
-            FirebaseService.shared.fetchCurrentUser { userResult in
-                switch userResult {
-                case .success(let user):
-                    DispatchQueue.main.async {
-                        self?.applyUser(user)
-                        completion(nil)
-                    }
+                    completion?(nil)
                 case .failure(let error):
-                    completion(error)
+                    completion?(error)
                 }
             }
-        case .failure(let error):
-            completion(error)
         }
     }
-}
-
-func sendPasswordReset(email: String, completion: @escaping (Error?) -> Void) {
-    FirebaseService.shared.sendPasswordReset(to: email) { error in
-        DispatchQueue.main.async {
-            completion(error)
-        }
-    }
-}
-
-func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
-    FirebaseService.shared.fetchCurrentUser { [weak self] result in
-        DispatchQueue.main.async {
-            switch result {
-            case .success(let user):
-                self?.applyUser(user)
-                completion?(nil)
-            case .failure(let error):
-                completion?(error)
-            }
-        }
-    }
-}
 
     /// Deletes only the user's account (Auth and, optionally, their `/users/{uid}` profile),
     /// while preserving all job documents. This keeps historical job records intact.
@@ -112,6 +114,7 @@ func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
             DispatchQueue.main.async {
                 switch result {
                 case .success:
+                    self?.stopCurrentUserListener()
                     self?.applyUser(nil)
                     completion(.success(()))
                 case .failure(let error):
@@ -121,14 +124,46 @@ func refreshCurrentUser(completion: ((Error?) -> Void)? = nil) {
         }
     }
 
-func signOut() {
-    do {
-        try FirebaseService.shared.signOutUser()
-        applyUser(nil)
-    } catch {
-        print("Sign-out error: \(error)")
+    func signOut() {
+        do {
+            stopCurrentUserListener()
+            try FirebaseService.shared.signOutUser()
+            applyUser(nil)
+        } catch {
+            print("Sign-out error: \(error)")
+        }
     }
-}
+
+    private func startCurrentUserListener() {
+        guard let uid = FirebaseService.shared.currentUserID() else {
+            stopCurrentUserListener()
+            applyUser(nil)
+            return
+        }
+
+        if observedCurrentUserID == uid, currentUserListener != nil { return }
+
+        stopCurrentUserListener()
+        observedCurrentUserID = uid
+        currentUserListener = FirebaseService.shared.listenCurrentUser { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch result {
+                case .success(let user):
+                    self.applyUser(user)
+                case .failure(let error):
+                    print("Current user listener error: \(error.localizedDescription)")
+                    self.applyUser(nil)
+                }
+            }
+        }
+    }
+
+    private func stopCurrentUserListener() {
+        currentUserListener?.remove()
+        currentUserListener = nil
+        observedCurrentUserID = nil
+    }
 
     var isAdmin: Bool { isAdminFlag }
     var isSupervisor: Bool { isSupervisorFlag }

--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -226,7 +226,7 @@ struct JobCard: View {
             Button {
                 showStatusDialog = true
             } label: {
-                Text(job.status)
+                Text(job.displayStatus)
                     .font(JTTypography.subheadline)
                     .fontWeight(.semibold)
                     .padding(.horizontal, JTSpacing.md)

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -77,7 +77,7 @@ final class DashboardViewModel: ObservableObject {
 
     let statusOptions: [String] = [
         "Pending",
-        "Needs Aerial",
+        "Needs OH",
         "Needs Underground",
         "Needs Nid",
         "Needs Can",
@@ -308,7 +308,7 @@ final class DashboardViewModel: ObservableObject {
         let header = "\(shareSubject):"
         let lines = completedJobs.map { job in
             let address = houseNumberAndStreet(from: job.address)
-            var entry = "\(address) – \(job.status)"
+            var entry = "\(address) – \(job.displayStatus)"
             if let noteText = job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !noteText.isEmpty {
                 entry += " (Notes: \(noteText))"
             }

--- a/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
+++ b/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
@@ -1,0 +1,327 @@
+import FirebaseFirestore
+import SwiftUI
+
+struct SupervisorHomeDashboardView: View {
+    @EnvironmentObject private var usersViewModel: UsersViewModel
+    @StateObject private var viewModel = SupervisorHomeDashboardViewModel()
+    @State private var selectedDate = Date()
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                JTGradients.background
+                    .ignoresSafeArea()
+
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                        header
+                        datePickerCard
+                        positionGrid
+                    }
+                    .padding(.horizontal, JTSpacing.lg)
+                    .padding(.vertical, JTSpacing.xl)
+                }
+            }
+            .navigationTitle("Supervisor Dashboard")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear { viewModel.start(for: selectedDate) }
+            .onChange(of: selectedDate) { newDate in viewModel.start(for: newDate) }
+            .onDisappear { viewModel.stop() }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            Text("Crew Overview")
+                .font(JTTypography.screenTitle)
+                .foregroundStyle(JTColors.textPrimary)
+            Text("Review today's users by position and open their job notes, materials, assignments, and status updates.")
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+    }
+
+    private var datePickerCard: some View {
+        GlassCard {
+            DatePicker("Date", selection: $selectedDate, displayedComponents: .date)
+                .datePickerStyle(.compact)
+                .font(JTTypography.body)
+                .padding(JTSpacing.lg)
+        }
+    }
+
+    private var positionGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: JTSpacing.md)], spacing: JTSpacing.md) {
+            ForEach(CrewPosition.supervisorDashboardOptions) { position in
+                NavigationLink {
+                    SupervisorPositionUsersView(
+                        position: position,
+                        date: selectedDate,
+                        users: users(for: position),
+                        jobs: viewModel.jobs
+                    )
+                } label: {
+                    SupervisorPositionCard(
+                        position: position,
+                        userCount: users(for: position).count,
+                        jobCount: jobCount(for: position)
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func users(for position: CrewPosition) -> [AppUser] {
+        usersViewModel.allUsers.filter { CrewPosition.matches($0.position, position) }
+    }
+
+    private func jobCount(for position: CrewPosition) -> Int {
+        let ids = Set(users(for: position).map(\.id))
+        return viewModel.jobs.filter { job in
+            job.involvesAnyUser(in: ids)
+        }.count
+    }
+}
+
+final class SupervisorHomeDashboardViewModel: ObservableObject {
+    @Published private(set) var jobs: [Job] = []
+    @Published private(set) var isLoading = false
+    @Published private(set) var errorMessage: String?
+
+    private let db = Firestore.firestore()
+    private var listener: ListenerRegistration?
+
+    func start(for date: Date) {
+        stop()
+        isLoading = true
+        errorMessage = nil
+
+        let start = Calendar.current.startOfDay(for: date)
+        guard let end = Calendar.current.date(byAdding: .day, value: 1, to: start) else {
+            isLoading = false
+            return
+        }
+
+        listener = db.collection("jobs")
+            .whereField("date", isGreaterThanOrEqualTo: Timestamp(date: start))
+            .whereField("date", isLessThan: Timestamp(date: end))
+            .order(by: "date", descending: false)
+            .addSnapshotListener { [weak self] snapshot, error in
+                guard let self else { return }
+                if let error {
+                    DispatchQueue.main.async {
+                        self.errorMessage = error.localizedDescription
+                        self.isLoading = false
+                    }
+                    return
+                }
+
+                let decoded: [Job] = snapshot?.documents.compactMap { doc in
+                    var job = try? doc.data(as: Job.self)
+                    job?.id = doc.documentID
+                    return job
+                } ?? []
+
+                DispatchQueue.main.async {
+                    self.jobs = decoded
+                    self.isLoading = false
+                }
+            }
+    }
+
+    func stop() {
+        listener?.remove()
+        listener = nil
+    }
+}
+
+private struct SupervisorPositionCard: View {
+    let position: CrewPosition
+    let userCount: Int
+    let jobCount: Int
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                HStack {
+                    Text(position.displayName)
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .foregroundStyle(JTColors.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+
+                VStack(alignment: .leading, spacing: JTSpacing.xs) {
+                    Text("\(userCount) user\(userCount == 1 ? "" : "s")")
+                    Text("\(jobCount) job\(jobCount == 1 ? "" : "s") today")
+                }
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
+private struct SupervisorPositionUsersView: View {
+    let position: CrewPosition
+    let date: Date
+    let users: [AppUser]
+    let jobs: [Job]
+
+    var body: some View {
+        List {
+            if users.isEmpty {
+                Text("No users found for \(position.displayName).")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(users) { user in
+                    NavigationLink {
+                        SupervisorUserJobsView(user: user, date: date, jobs: jobsForUser(user))
+                    } label: {
+                        HStack {
+                            Text(displayName(for: user))
+                            Spacer()
+                            Text("\(jobsForUser(user).count)")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(position.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func jobsForUser(_ user: AppUser) -> [Job] {
+        jobs.filter { $0.involvesUser(user.id) }
+            .sorted { $0.date < $1.date }
+    }
+
+    private func displayName(for user: AppUser) -> String {
+        let name = [user.firstName, user.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return name.isEmpty ? "Unnamed User" : name
+    }
+}
+
+private struct SupervisorUserJobsView: View {
+    let user: AppUser
+    let date: Date
+    let jobs: [Job]
+
+    var body: some View {
+        List {
+            if jobs.isEmpty {
+                Text("No jobs for this date.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(jobs) { job in
+                    SupervisorUserJobInfoCard(job: job)
+                }
+            }
+        }
+        .navigationTitle(displayName)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var displayName: String {
+        let name = [user.firstName, user.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return name.isEmpty ? "Unnamed User" : name
+    }
+}
+
+private struct SupervisorUserJobInfoCard: View {
+    let job: Job
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(job.jobNumber?.trimmedNonEmpty ?? "No job number")
+                        .font(JTTypography.captionEmphasized)
+                        .foregroundStyle(JTColors.textSecondary)
+                    Text(job.address)
+                        .font(JTTypography.headline)
+                        .foregroundStyle(JTColors.textPrimary)
+                }
+                Spacer()
+                Text(job.displayStatus)
+                    .font(JTTypography.captionEmphasized)
+                    .padding(.horizontal, JTSpacing.sm)
+                    .padding(.vertical, JTSpacing.xs)
+                    .background(statusTint.opacity(0.18), in: Capsule())
+                    .foregroundStyle(statusTint)
+            }
+
+            detailRows
+        }
+        .padding(.vertical, JTSpacing.sm)
+    }
+
+    @ViewBuilder
+    private var detailRows: some View {
+        if let portalID = job.portalID?.trimmedNonEmpty {
+            detailRow("Portal ID", portalID)
+        }
+        if let locationNumber = job.locationNumber?.trimmedNonEmpty {
+            detailRow("Location", locationNumber)
+        }
+        if let assignments = job.assignments?.trimmedNonEmpty {
+            detailRow("Assignment", assignments)
+        }
+        if let materials = job.materialsUsed?.trimmedNonEmpty {
+            detailRow("Materials", materials)
+        }
+        if let notes = job.notes?.trimmedNonEmpty {
+            detailRow("Notes", notes)
+        }
+        if let placement = job.jobPlacement?.trimmedNonEmpty {
+            detailRow("Placement", CrewPosition.positionDisplayName(from: placement))
+        }
+    }
+
+    private var statusTint: Color {
+        job.status.lowercased() == "pending" ? Color.orange : JTColors.success
+    }
+
+    private func detailRow(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(JTColors.textSecondary)
+            Text(value)
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textPrimary)
+        }
+    }
+}
+
+private extension Job {
+    func involvesUser(_ userID: String) -> Bool {
+        createdBy == userID || assignedTo == userID || (participants ?? []).contains(userID)
+    }
+
+    func involvesAnyUser(in userIDs: Set<String>) -> Bool {
+        guard !userIDs.isEmpty else { return false }
+        if let createdBy, userIDs.contains(createdBy) { return true }
+        if let assignedTo, userIDs.contains(assignedTo) { return true }
+        return (participants ?? []).contains { userIDs.contains($0) }
+    }
+}
+
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Job Tracker/Features/Help/InteractiveTutorialView.swift
+++ b/Job Tracker/Features/Help/InteractiveTutorialView.swift
@@ -179,7 +179,7 @@ final class DashboardTutorialStageModel: ObservableObject {
 
     enum Status: String, CaseIterable, Identifiable {
         case pending = "Pending"
-        case needsAerial = "Needs Aerial"
+        case needsOH = "Needs OH"
         case done = "Done"
         case custom = "Custom"
 
@@ -188,7 +188,7 @@ final class DashboardTutorialStageModel: ObservableObject {
         var symbolName: String {
             switch self {
             case .pending: return "hourglass"
-            case .needsAerial: return "airplane"
+            case .needsOH: return "airplane"
             case .done: return "checkmark.circle"
             case .custom: return "sparkles"
             }
@@ -204,7 +204,7 @@ final class DashboardTutorialStageModel: ObservableObject {
         selectedDayIndex = 0
         jobs = [
             Job(title: "Splice drop", address: "711 Post Oak Ct", status: .pending),
-            Job(title: "Aerial survey", address: "108 Amber Wave Blvd", status: .needsAerial),
+            Job(title: "OH survey", address: "108 Amber Wave Blvd", status: .needsOH),
             Job(title: "Fiber pull", address: "1436 Lyonia Dr", status: .pending)
         ]
     }
@@ -235,7 +235,7 @@ final class DashboardTutorialStageModel: ObservableObject {
 final class CreateJobTutorialStageModel: ObservableObject {
     enum StatusOption: String, CaseIterable, Identifiable {
         case pending = "Pending"
-        case aerial = "Needs Aerial"
+        case oh = "Needs OH"
         case ug = "Underground"
         case done = "Done"
 
@@ -781,7 +781,7 @@ private struct DashboardTutorialStageView: View {
                                 statusMenu(for: job)
                                     .tutorialHighlight(
                                         id: "dashboard.status.\(job.id)",
-                                        message: "Tap the status pill to move work between Pending, Needs Aerial, Done, or Custom.",
+                                        message: "Tap the status pill to move work between Pending, Needs OH, Done, or Custom.",
                                         arrowEdge: .bottom,
                                         shape: .capsule,
                                         showsPulse: !model.didChangeStatus
@@ -843,7 +843,7 @@ private struct DashboardTutorialStageView: View {
     private func color(for status: DashboardTutorialStageModel.Status) -> Color {
         switch status {
         case .pending: return Color.yellow
-        case .needsAerial: return Color.orange
+        case .needsOH: return Color.orange
         case .done: return Color.green
         case .custom: return Color.purple
         }

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -187,7 +187,7 @@ struct CreateJobView: View {
 
     @State private var alertMessage: String?
 
-    let statusOptions = ["Pending","Aerial","UG","Nid","Can","Done","Talk to Rick","Custom"]
+    let statusOptions = ["Pending","OH","UG","Nid","Can","Done","Talk to Rick","Custom"]
 
     // Address suggestion state removed
 
@@ -480,11 +480,10 @@ struct CreateJobView: View {
     private func saveJobs(addressesToSave: [String]) {
         guard let userID = authViewModel.currentUser?.id else { dismiss(); return }
 
-        // Normalize legacy spelling ("Ariel" -> "Aerial") before saving
         let baseStatus = (status == "Custom")
             ? customStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
             : status
-        let finalStatus = baseStatus.caseInsensitiveCompare("Ariel") == .orderedSame ? "Aerial" : baseStatus
+        let finalStatus = CrewPosition.normalizedStatusForSaving(baseStatus)
 
         let sanitizedAssign = sanitizeAssignment(assignmentsText)
         let assignmentsValue = sanitizedAssign.isEmpty || !isValidAssignment(sanitizedAssign) ? nil : sanitizedAssign

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -48,7 +48,7 @@ struct JobDetailView: View {
     @State private var editedJobNumber = ""
     @State private var editedPortalID = ""
     @State private var editedLocationNumber = ""
-    @State private var selectedMaterialAriel = "None"
+    @State private var selectedMaterialOH = "None"
     @State private var selectedMaterialNid = ""
     @State private var preformCount = 0
     @State private var jHooksCount = 0
@@ -56,8 +56,8 @@ struct JobDetailView: View {
     @State private var nidFootage = ""
 
     // Materials refinements per role
-    @State private var uGuardCount = 0                 // Aerial & Can: 0–5 U-Guard pieces
-    @State private var storageBracket = false          // Aerial: toggle
+    @State private var uGuardCount = 0                 // OH & Can: 0–5 U-Guard pieces
+    @State private var storageBracket = false          // OH: toggle
     @State private var nidBoxUsed = false              // Nid: 1 box (toggle)
     @State private var jumpersCount = 0                // Nid: 0–4 jumpers
     @State private var canMaterialsText = ""           // Can Splicers: free text
@@ -80,7 +80,7 @@ struct JobDetailView: View {
 
     let statusOptions = [
         "Pending",
-        "Needs Aerial",
+        "Needs OH",
         "Needs Underground",
         "Needs Nid",
         "Needs Can",
@@ -88,7 +88,7 @@ struct JobDetailView: View {
         "Talk to Rick",   // fixed option
         "Custom"          // allows manual entry
     ]
-    let arielMaterials = ["None", "Weatherhead", "Rams Head"]
+    let ohMaterials = ["None", "Weatherhead", "Rams Head"]
     let nidMaterials: [String] = [] // NID uses toggles/steppers instead of fixed list
 private let fiberChoices = ["Flat", "Round", "Mainline"]
 private let jobPlacementChoices = ["OH", "UG"]
@@ -294,22 +294,23 @@ private let jobPlacementChoices = ["OH", "UG"]
 
                     // MARK: Materials (Separate Section by Role)
                     if let rawPosition = authViewModel.currentUser?.position {
-                        // Normalize legacy "Ariel" → "Aerial" for display
-                        let positionDisplay = (rawPosition.caseInsensitiveCompare("Ariel") == .orderedSame) ? "Aerial" : rawPosition
+                        let positionDisplay = CrewPosition.positionDisplayName(from: rawPosition)
 
                         Section(header: Text("Materials — \(positionDisplay)")) {
-                            switch rawPosition {
-                            case "Ariel", "Aerial":
-                                arielMaterialsSection
-                            case "Nid":
-                                nidMaterialsSection
-                            case "Can":
-                                canMaterialsSection
-                            case "Underground":
-                                undergroundMaterialsSection
-                            default:
-                                Text("No materials for this role.")
-                                    .foregroundColor(.secondary)
+                            if CrewPosition.matches(rawPosition, .oh) {
+                                ohMaterialsSection
+                            } else {
+                                switch rawPosition {
+                                case "Nid":
+                                    nidMaterialsSection
+                                case "Can":
+                                    canMaterialsSection
+                                case "Underground":
+                                    undergroundMaterialsSection
+                                default:
+                                    Text("No materials for this role.")
+                                        .foregroundColor(.secondary)
+                                }
                             }
                         }
                     }
@@ -487,16 +488,17 @@ private let jobPlacementChoices = ["OH", "UG"]
                     disableSuggestions = false
                 }
                 // Initialize editable fields
-                editedStatus     = job.status
-                if !statusOptions.contains(job.status) {
-                    customStatusText = job.status
+                let displayStatus = CrewPosition.statusDisplayName(from: job.status)
+                editedStatus = displayStatus
+                if !statusOptions.contains(displayStatus) {
+                    customStatusText = displayStatus
                     editedStatus = "Custom"
                 }
                 editedNotes      = job.notes ?? ""
                 editedJobNumber  = job.jobNumber ?? ""
                 editedPortalID   = job.portalID ?? ""
                 editedLocationNumber = job.locationNumber ?? ""
-                selectedMaterialAriel = "None"
+                selectedMaterialOH = "None"
                 selectedMaterialNid   = nidMaterials.first ?? ""
                 canFootage       = job.canFootage ?? ""
                 nidFootage       = job.nidFootage ?? ""
@@ -514,20 +516,22 @@ private let jobPlacementChoices = ["OH", "UG"]
                 // Restore previously saved materials into role-specific UI
                 if let position = authViewModel.currentUser?.position,
                    let materials = job.materialsUsed, !materials.isEmpty {
-                    switch position {
-                    case "Ariel":
+                    if CrewPosition.matches(position, .oh) {
                         preformCount = 0
                         jHooksCount = 0
-                        parseAerialMaterials(from: materials)
-                    case "Nid":
-                        parseNidMaterials(from: materials)
-                    case "Can":
-                        canMaterialsText = sanitizeCanMaterialsTokens(from: materials).joined(separator: ", ")
-                        if let n = captureInt(after: "u-guard:", in: materials.lowercased()) { uGuardCount = n }
-                    case "Underground":
-                        undergroundMaterialsText = materials
-                    default:
-                        break
+                        parseOHMaterials(from: materials)
+                    } else {
+                        switch position {
+                        case "Nid":
+                            parseNidMaterials(from: materials)
+                        case "Can":
+                            canMaterialsText = sanitizeCanMaterialsTokens(from: materials).joined(separator: ", ")
+                            if let n = captureInt(after: "u-guard:", in: materials.lowercased()) { uGuardCount = n }
+                        case "Underground":
+                            undergroundMaterialsText = materials
+                        default:
+                            break
+                        }
                     }
                 }
 
@@ -705,13 +709,13 @@ extension JobDetailView {
         .buttonStyle(.plain)
     }
 
-    // Ariel Materials Section (for Ariel position)
-    private var arielMaterialsSection: some View {
+    // OH Materials Section
+    private var ohMaterialsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             // Head type
             LabeledContent("Head Type") {
-                Picker("", selection: $selectedMaterialAriel) {
-                    ForEach(arielMaterials, id: \.self) { Text($0) }
+                Picker("", selection: $selectedMaterialOH) {
+                    ForEach(ohMaterials, id: \.self) { Text($0) }
                 }
                 .labelsHidden()
                 .pickerStyle(MenuPickerStyle())
@@ -875,9 +879,10 @@ extension JobDetailView {
         savingStatus = "Saving address"
 
         // 1) Update basic fields in memory
-        let finalStatus = editedStatus == "Custom"
+        let baseStatus = editedStatus == "Custom"
             ? customStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
             : editedStatus
+        let finalStatus = CrewPosition.normalizedStatusForSaving(baseStatus)
         job.status    = finalStatus
         job.notes     = editedNotes.isEmpty ? nil : editedNotes
         job.jobNumber = editedJobNumber.isEmpty ? nil : editedJobNumber
@@ -893,12 +898,11 @@ extension JobDetailView {
         savingProgress = 0.12
         savingStatus = "Saving job number"
         if let position = authViewModel.currentUser?.position {
-            switch position {
-            case "Ariel":
+            if CrewPosition.matches(position, .oh) {
                 var parts: [String] = []
                 if !fiberType.isEmpty { parts.append("Fiber: \(fiberType)") }
-                if !selectedMaterialAriel.isEmpty && selectedMaterialAriel != "None" {
-                    parts.append(selectedMaterialAriel) // Weatherhead or Rams Head
+                if !selectedMaterialOH.isEmpty && selectedMaterialOH != "None" {
+                    parts.append(selectedMaterialOH) // Weatherhead or Rams Head
                 }
                 if preformCount > 0 { parts.append("Preforms: \(preformCount)") }
                 if jHooksCount > 0 { parts.append("J Hooks: \(jHooksCount)") }
@@ -907,51 +911,53 @@ extension JobDetailView {
                 job.materialsUsed = parts.isEmpty ? nil : parts.joined(separator: ", ")
                 job.canFootage = canFootage.isEmpty ? nil : canFootage
                 job.nidFootage = nidFootage.isEmpty ? nil : nidFootage
+            } else {
+                switch position {
+                case "Nid":
+                    var parts: [String] = []
+                    if !fiberType.isEmpty { parts.append("Fiber: \(fiberType)") }
+                    if nidBoxUsed { parts.append("1 NID Box") }
+                    if jumpersCount > 0 { parts.append("Jumpers: \(jumpersCount)") }
+                    job.materialsUsed = parts.isEmpty ? nil : parts.joined(separator: ", ")
+                    job.canFootage = nil
+                    job.nidFootage = nil
 
-            case "Nid":
-                var parts: [String] = []
-                if !fiberType.isEmpty { parts.append("Fiber: \(fiberType)") }
-                if nidBoxUsed { parts.append("1 NID Box") }
-                if jumpersCount > 0 { parts.append("Jumpers: \(jumpersCount)") }
-                job.materialsUsed = parts.isEmpty ? nil : parts.joined(separator: ", ")
-                job.canFootage = nil
-                job.nidFootage = nil
+                case "Can":
+                    var parts: [String] = []
+                    var seenTokens = Set<String>()
+                    func appendUnique(_ token: String) {
+                        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        let key = trimmed.lowercased()
+                        guard !seenTokens.contains(key) else { return }
+                        seenTokens.insert(key)
+                        parts.append(trimmed)
+                    }
 
-            case "Can":
-                var parts: [String] = []
-                var seenTokens = Set<String>()
-                func appendUnique(_ token: String) {
-                    let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    let key = trimmed.lowercased()
-                    guard !seenTokens.contains(key) else { return }
-                    seenTokens.insert(key)
-                    parts.append(trimmed)
+                    if !fiberType.isEmpty { appendUnique("Fiber: \(fiberType)") }
+                    let customTokens = sanitizeCanMaterialsTokens(from: canMaterialsText)
+                    customTokens.forEach { appendUnique($0) }
+                    if uGuardCount > 0 { appendUnique("U-Guard: \(uGuardCount)") }
+                    job.materialsUsed = parts.isEmpty ? nil : parts.joined(separator: ", ")
+                    job.canFootage = canFootage.isEmpty ? nil : canFootage
+                    job.nidFootage = nidFootage.isEmpty ? nil : nidFootage
+
+                case "Underground":
+                    let text = undergroundMaterialsText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let prefix = fiberType.isEmpty ? nil : "Fiber: \(fiberType)"
+                    if let prefix = prefix, !text.isEmpty {
+                        job.materialsUsed = "\(prefix), \(text)"
+                    } else if let prefix = prefix {
+                        job.materialsUsed = prefix
+                    } else {
+                        job.materialsUsed = text.isEmpty ? nil : text
+                    }
+                    job.canFootage = canFootage.isEmpty ? nil : canFootage
+                    job.nidFootage = nidFootage.isEmpty ? nil : nidFootage
+
+                default:
+                    if !fiberType.isEmpty { job.materialsUsed = "Fiber: \(fiberType)" }
                 }
-
-                if !fiberType.isEmpty { appendUnique("Fiber: \(fiberType)") }
-                let customTokens = sanitizeCanMaterialsTokens(from: canMaterialsText)
-                customTokens.forEach { appendUnique($0) }
-                if uGuardCount > 0 { appendUnique("U-Guard: \(uGuardCount)") }
-                job.materialsUsed = parts.isEmpty ? nil : parts.joined(separator: ", ")
-                job.canFootage = canFootage.isEmpty ? nil : canFootage
-                job.nidFootage = nidFootage.isEmpty ? nil : nidFootage
-
-            case "Underground":
-                let text = undergroundMaterialsText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let prefix = fiberType.isEmpty ? nil : "Fiber: \(fiberType)"
-                if let prefix = prefix, !text.isEmpty {
-                    job.materialsUsed = "\(prefix), \(text)"
-                } else if let prefix = prefix {
-                    job.materialsUsed = prefix
-                } else {
-                    job.materialsUsed = text.isEmpty ? nil : text
-                }
-                job.canFootage = canFootage.isEmpty ? nil : canFootage
-                job.nidFootage = nidFootage.isEmpty ? nil : nidFootage
-
-            default:
-                if !fiberType.isEmpty { job.materialsUsed = "Fiber: \(fiberType)" }
             }
         }
 
@@ -998,19 +1004,19 @@ extension JobDetailView {
     }
 
     // MARK: - Materials Parsing Helpers
-    /// Parse an Aerial materials string we previously saved to restore UI state.
-    private func parseAerialMaterials(from text: String) {
+    /// Parse an OH materials string we previously saved to restore UI state.
+    private func parseOHMaterials(from text: String) {
         // Expected tokens like: "Weatherhead" or "Rams Head", "Preforms: N", "J Hooks: N", "U-Guard: N", "Storage Bracket"
-        selectedMaterialAriel = "None"
+        selectedMaterialOH = "None"
         let lower = text.lowercased()
         if lower.contains("weatherhead") {
-            selectedMaterialAriel = "Weatherhead"
+            selectedMaterialOH = "Weatherhead"
         } else if lower.contains("rams head") {
-            selectedMaterialAriel = "Rams Head"
+            selectedMaterialOH = "Rams Head"
         } else {
             // Legacy data may explicitly store "None" as a token
             let tokens = lower.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            if tokens.contains("none") { selectedMaterialAriel = "None" }
+            if tokens.contains("none") { selectedMaterialOH = "None" }
         }
 
         if let n = captureInt(after: "preforms:", in: lower) { preformCount = n }

--- a/Job Tracker/Features/Jobs/ExtraWorkView.swift
+++ b/Job Tracker/Features/Jobs/ExtraWorkView.swift
@@ -9,7 +9,7 @@ struct ExtraWorkView: View {
     
     // The statuses we consider "extra work"
     private let neededStatuses = [
-        "Needs Ariel",
+        "Needs OH",
         "Needs Underground",
         "Needs Nid",
         "Needs Can"
@@ -84,7 +84,7 @@ struct ExtraWorkView: View {
 
     private func unclaimedJobs(status: String) -> [Job] {
         jobsViewModel.jobs.filter { job in
-            job.status == status && job.assignedTo == nil
+            CrewPosition.statusDisplayName(from: job.status) == status && job.assignedTo == nil
         }
     }
     

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -25,7 +25,7 @@ private extension Notification.Name {
 
 enum SupervisorRole: String, CaseIterable, Identifiable {
     case ug = "UG"
-    case aerial = "Aerial"
+    case oh = "OH"
     case can = "Can"
     case nid = "Nid"
 
@@ -94,7 +94,7 @@ final class SupervisorJobsViewModel: ObservableObject {
 private func roleColor(_ role: SupervisorRole) -> Color {
     switch role {
     case .ug:     return Color.green.opacity(0.35)
-    case .aerial: return Color.blue.opacity(0.35)
+    case .oh: return Color.blue.opacity(0.35)
     case .can:    return Color.orange.opacity(0.35)
     case .nid:    return Color.purple.opacity(0.35)
     }
@@ -401,8 +401,7 @@ struct SupervisorDashboardView: View {
         guard let uid = uid, let user = usersViewModel.user(id: uid) else {
             return ""
         }
-        let pos = user.position.trimmingCharacters(in: .whitespacesAndNewlines)
-        return pos.caseInsensitiveCompare("Ariel") == .orderedSame ? "Aerial" : pos
+        CrewPosition.normalizedKey(from: user.position)
     }
 
     private func resolveUserName(forUserId uid: String?) -> String {
@@ -462,7 +461,7 @@ private struct SupervisorJobRow: View {
 
             Spacer(minLength: 8)
 
-            Text(job.status)
+            Text(job.displayStatus)
                 .font(.caption.weight(.semibold))
                 .foregroundColor(.white)
                 .padding(.horizontal, 10)
@@ -576,7 +575,7 @@ private extension View {
 private enum RoleFilter: String, CaseIterable, Identifiable {
     case all = "All"
     case underground = "UG"
-    case aerial = "Aerial"
+    case oh = "OH"
     case can = "Can"
     case nid = "Nid"
     var id: String { rawValue }
@@ -835,11 +834,9 @@ struct SupervisorCreateJobView: View {
         switch roleFilter {
         case .all:
             base = users
-        case .underground, .aerial, .can, .nid:
+        case .underground, .oh, .can, .nid:
             base = users.filter { user in
-                let pos = user.position.trimmingCharacters(in: .whitespacesAndNewlines)
-                let norm = pos.caseInsensitiveCompare("Ariel") == .orderedSame ? "Aerial" : pos
-                return norm.caseInsensitiveCompare(roleFilter.rawValue) == .orderedSame
+                CrewPosition.normalizedKey(from: user.position).caseInsensitiveCompare(roleFilter.rawValue) == .orderedSame
             }
         }
         return base.sorted { ($0.firstName + $0.lastName)
@@ -948,7 +945,6 @@ private struct UserSelectSheet: View {
     }
 
     private func normalizedRole(_ s: String) -> String {
-        let pos = s.trimmingCharacters(in: .whitespacesAndNewlines)
-        return pos.caseInsensitiveCompare("Ariel") == .orderedSame ? "Aerial" : pos
+        CrewPosition.positionDisplayName(from: s)
     }
 }

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -192,7 +192,7 @@ struct JobSearchDetailView: View {
                 }
 
                 HStack(spacing: JTSpacing.sm) {
-                    Text(job.status)
+                    Text(job.displayStatus)
                         .font(JTTypography.caption)
                         .fontWeight(.semibold)
                         .padding(.vertical, 6)

--- a/Job Tracker/Features/Search/JobSearchViewModel.swift
+++ b/Job Tracker/Features/Search/JobSearchViewModel.swift
@@ -276,7 +276,7 @@ final class JobSearchViewModel: ObservableObject {
                 secondary: secondaryAddress.isEmpty ? nil : secondaryAddress
             ),
             jobNumber: displayValue(entry.jobNumber),
-            status: entry.status.trimmingCharacters(in: .whitespacesAndNewlines),
+            status: CrewPosition.statusDisplayName(from: entry.status),
             date: entry.date,
             creator: creatorModel,
             snippet: snippet,
@@ -327,7 +327,7 @@ final class JobSearchViewModel: ObservableObject {
         if let normalized = normalizedNonEmpty(job.locationNumber) {
             haystackParts.append(normalized)
         }
-        if let normalized = normalizedNonEmpty(job.status) {
+        if let normalized = normalizedNonEmpty(CrewPosition.statusDisplayName(from: job.status)) {
             haystackParts.append(normalized)
         }
         if let normalized = normalizedNonEmpty(job.notes) {
@@ -372,7 +372,7 @@ final class JobSearchViewModel: ObservableObject {
         var creatorCounts: [String: (display: String, count: Int)] = [:]
 
         for entry in entries {
-            let status = entry.status.trimmingCharacters(in: .whitespacesAndNewlines)
+            let status = CrewPosition.statusDisplayName(from: entry.status).trimmingCharacters(in: .whitespacesAndNewlines)
             if !status.isEmpty {
                 let key = status.lowercased()
                 if var existing = statusCounts[key] {

--- a/Job Tracker/Features/Settings/ProfileView.swift
+++ b/Job Tracker/Features/Settings/ProfileView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FirebaseCore
 
 struct ProfileView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
@@ -8,6 +9,7 @@ struct ProfileView: View {
     @State private var hasRequestedHistory = false
     @State private var isTimesheetLoading = false
     @State private var isYellowSheetLoading = false
+    @State private var showingDiagnostics = false
 
     private let gridColumns = [GridItem(.adaptive(minimum: 160), spacing: JTSpacing.lg)]
 
@@ -57,6 +59,12 @@ struct ProfileView: View {
             if isYellowSheetLoading {
                 isYellowSheetLoading = false
             }
+        }
+        .sheet(isPresented: $showingDiagnostics) {
+            ProfileDiagnosticsView(user: authViewModel.currentUser,
+                                   authUID: FirebaseService.shared.currentUserID(),
+                                   isAdminFlag: authViewModel.isAdminFlag,
+                                   isSupervisorFlag: authViewModel.isSupervisorFlag)
         }
     }
 }
@@ -302,6 +310,16 @@ private extension ProfileView {
                     .font(JTTypography.caption)
                     .foregroundStyle(JTColors.textSecondary)
 
+                Button {
+                    showingDiagnostics = true
+                } label: {
+                    Label("Show Diagnostics", systemImage: "stethoscope")
+                        .font(JTTypography.button)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(JTColors.info)
+
                 JTPrimaryButton("Sign Out", systemImage: "rectangle.portrait.and.arrow.right") {
                     authViewModel.signOut()
                 }
@@ -484,4 +502,89 @@ private struct QuickActionLink<Destination: View>: View {
         }
         .buttonStyle(.plain)
     }
+}
+
+private struct ProfileDiagnosticsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let user: AppUser?
+    let authUID: String?
+    let isAdminFlag: Bool
+    let isSupervisorFlag: Bool
+
+    private var projectID: String {
+        FirebaseApp.app()?.options.projectID ?? "Unavailable"
+    }
+
+    private var bundleID: String {
+        Bundle.main.bundleIdentifier ?? "Unavailable"
+    }
+
+    private var uidMatchText: String {
+        guard let authUID, let userID = user?.id else { return "Unable to compare" }
+        return authUID == userID ? "Yes" : "No"
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Firebase") {
+                    diagnosticRow(title: "Project ID", value: projectID)
+                    diagnosticRow(title: "Auth UID", value: authUID ?? "Not signed in")
+                    diagnosticRow(title: "User doc ID", value: user?.id ?? "No current user")
+                    diagnosticRow(title: "Auth UID matches user doc", value: uidMatchText)
+                }
+
+                Section("Loaded role flags") {
+                    diagnosticRow(title: "AuthViewModel isAdminFlag", value: isAdminFlag.yesNoText)
+                    diagnosticRow(title: "AuthViewModel isSupervisorFlag", value: isSupervisorFlag.yesNoText)
+                    diagnosticRow(title: "currentUser.isAdmin", value: user?.isAdmin.yesNoText ?? "No current user")
+                    diagnosticRow(title: "currentUser.isSupervisor", value: user?.isSupervisor.yesNoText ?? "No current user")
+                }
+
+                Section("Loaded profile") {
+                    diagnosticRow(title: "Email", value: user?.email ?? "No current user")
+                    diagnosticRow(title: "Name", value: loadedName)
+                    diagnosticRow(title: "Position", value: user?.position ?? "No current user")
+                    diagnosticRow(title: "Normalized position", value: user?.normalizedPosition ?? "No current user")
+                }
+
+                Section("App") {
+                    diagnosticRow(title: "Bundle ID", value: bundleID)
+                }
+            }
+            .textSelection(.enabled)
+            .navigationTitle("Profile Diagnostics")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var loadedName: String {
+        guard let user else { return "No current user" }
+        let name = [user.firstName, user.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return name.isEmpty ? "Not set" : name
+    }
+
+    private func diagnosticRow(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.body.monospaced())
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private extension Bool {
+    var yesNoText: String { self ? "true" : "false" }
 }

--- a/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsView.swift
@@ -240,7 +240,7 @@ private struct RecentCrewJobRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: JTSpacing.sm) {
             HStack(alignment: .firstTextBaseline) {
-                Text(job.status)
+                Text(job.displayStatus)
                     .font(JTTypography.subheadline.weight(.semibold))
                     .foregroundStyle(JTColors.textPrimary)
                 Spacer()
@@ -370,7 +370,7 @@ private struct RecentCrewJobDetailSheet: View {
                     .multilineTextAlignment(.leading)
 
                 HStack(spacing: JTSpacing.xs) {
-                    CrewJobChip(text: job.status, tint: statusTint(for: job.status))
+                    CrewJobChip(text: job.displayStatus, tint: statusTint(for: job.status))
                     CrewJobChip(text: job.formattedDate, tint: JTColors.info)
                     if let role = job.displayCrewRole {
                         CrewJobChip(text: role, tint: JTColors.accent)
@@ -442,7 +442,7 @@ private struct RecentCrewJobDetailSheet: View {
         }
 
         items.append(DetailItem(icon: "calendar", title: "Date", value: job.formattedDate))
-        items.append(DetailItem(icon: "flag.fill", title: "Status", value: job.status))
+        items.append(DetailItem(icon: "flag.fill", title: "Status", value: job.displayStatus))
 
         if let crewName = Self.displayName(for: job.crewName, usersViewModel: usersViewModel) {
             items.append(DetailItem(icon: "person.2", title: "Crew Name", value: crewName))

--- a/Job Tracker/Features/Shared/More/RecentCrewJobsViewModel.swift
+++ b/Job Tracker/Features/Shared/More/RecentCrewJobsViewModel.swift
@@ -5,7 +5,7 @@ final class RecentCrewJobsViewModel: ObservableObject {
     enum CrewRoleFilter: String, CaseIterable, Identifiable {
         case all = "All"
         case underground = "Underground"
-        case aerial = "Aerial"
+        case oh = "OH"
         case can = "CAN"
         case nid = "NID"
 
@@ -94,7 +94,7 @@ final class RecentCrewJobsViewModel: ObservableObject {
         switch filter {
         case .all:
             filtered = jobs
-        case .underground, .aerial, .can, .nid:
+        case .underground, .oh, .can, .nid:
             filtered = jobs.filter { $0.matches(filter) }
         }
 
@@ -357,9 +357,13 @@ extension RecentCrewJob {
             return normalized
         }
         if let firstCandidate = documentRoleCandidates.first {
-            return firstCandidate
+            return CrewPosition.positionDisplayName(from: firstCandidate)
         }
         return normalizedSubmitterFallbackRole ?? submitterFallbackRole
+    }
+
+    var displayStatus: String {
+        CrewPosition.statusDisplayName(from: status)
     }
 
     fileprivate var hasDocumentCrewRole: Bool {
@@ -379,8 +383,8 @@ extension RecentCrewJob {
         if lower.contains("underground") || lower == "ug" || lower.contains("ug crew") || lower.contains("u/g") {
             return RecentCrewJobsViewModel.CrewRoleFilter.underground.rawValue
         }
-        if lower.contains("aerial") || lower.contains("ariel") {
-            return RecentCrewJobsViewModel.CrewRoleFilter.aerial.rawValue
+        if CrewPosition.matches(trimmed, .oh) {
+            return RecentCrewJobsViewModel.CrewRoleFilter.oh.rawValue
         }
         if lower.contains("can") {
             return RecentCrewJobsViewModel.CrewRoleFilter.can.rawValue

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -121,19 +121,42 @@ class FirebaseService {
                 completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "User doc not found"])))
                 return
             }
-            do {
-                var user = try snapshot.data(as: AppUser.self)
-                // Backfill missing email from Firebase Auth if needed
-                if user.email.isEmpty, let authEmail = self.auth.currentUser?.email {
-                    self.db.collection("users").document(uid)
-                        .setData(["email": authEmail], merge: true)
-                    // Also update the local instance so callers receive a populated email immediately
-                    user.email = authEmail
-                }
-                completion(.success(user))
-            } catch {
+            self.decodeCurrentUserSnapshot(snapshot, uid: uid, completion: completion)
+        }
+    }
+
+    func listenCurrentUser(completion: @escaping (Result<AppUser, Error>) -> Void) -> ListenerRegistration? {
+        guard let uid = currentUserID() else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No user logged in"])))
+            return nil
+        }
+
+        return db.collection("users").document(uid).addSnapshotListener { snapshot, error in
+            if let error = error {
                 completion(.failure(error))
+                return
             }
+            guard let snapshot = snapshot, snapshot.exists else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "User doc not found"])))
+                return
+            }
+            self.decodeCurrentUserSnapshot(snapshot, uid: uid, completion: completion)
+        }
+    }
+
+    private func decodeCurrentUserSnapshot(_ snapshot: DocumentSnapshot, uid: String, completion: @escaping (Result<AppUser, Error>) -> Void) {
+        do {
+            var user = try snapshot.data(as: AppUser.self)
+            // Backfill missing email from Firebase Auth if needed
+            if user.email.isEmpty, let authEmail = self.auth.currentUser?.email {
+                self.db.collection("users").document(uid)
+                    .setData(["email": authEmail], merge: true)
+                // Also update the local instance so callers receive a populated email immediately
+                user.email = authEmail
+            }
+            completion(.success(user))
+        } catch {
+            completion(.failure(error))
         }
     }
     // Manual mapper for PartnerRequest (no FirebaseFirestoreSwift dependency)

--- a/Job Tracker/Features/Shared/Shell/AppShellView.swift
+++ b/Job Tracker/Features/Shared/Shell/AppShellView.swift
@@ -78,12 +78,17 @@ private struct AppShellDetailView: View {
 
     @EnvironmentObject private var jobsViewModel: JobsViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
 
     @ViewBuilder
     var body: some View {
         switch destination {
         case .dashboard:
-            DashboardView()
+            if authViewModel.isSupervisorFlag {
+                SupervisorHomeDashboardView()
+            } else {
+                DashboardView()
+            }
         case .timesheets:
             WeeklyTimesheetView()
         case .yellowSheet:

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -13,6 +13,7 @@ private struct PrimaryTabContainer: View {
     @EnvironmentObject private var navigation: AppNavigationViewModel
     @EnvironmentObject private var jobsViewModel: JobsViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
 
     private var selection: Binding<AppNavigationViewModel.PrimaryDestination> {
         Binding(
@@ -23,12 +24,18 @@ private struct PrimaryTabContainer: View {
 
     var body: some View {
         TabView(selection: selection) {
-            DashboardView()
-                .tag(AppNavigationViewModel.PrimaryDestination.dashboard)
-                .tabItem {
-                    Label(AppNavigationViewModel.PrimaryDestination.dashboard.title,
-                          systemImage: AppNavigationViewModel.PrimaryDestination.dashboard.systemImage)
+            Group {
+                if authViewModel.isSupervisorFlag {
+                    SupervisorHomeDashboardView()
+                } else {
+                    DashboardView()
                 }
+            }
+            .tag(AppNavigationViewModel.PrimaryDestination.dashboard)
+            .tabItem {
+                Label(AppNavigationViewModel.PrimaryDestination.dashboard.title,
+                      systemImage: AppNavigationViewModel.PrimaryDestination.dashboard.systemImage)
+            }
 
             WeeklyTimesheetView()
                 .tag(AppNavigationViewModel.PrimaryDestination.timesheets)
@@ -135,14 +142,6 @@ private struct MoreMenuList: View {
                 }
             }
 
-            if authViewModel.isSupervisorFlag {
-                Section("Supervisor") {
-                    NavigationLink(value: AppNavigationViewModel.Destination.supervisor) {
-                        Label("Supervisor", systemImage: AppNavigationViewModel.Destination.supervisor.systemImage)
-                    }
-                }
-            }
-
             if authViewModel.isAdminFlag {
                 Section("Admin") {
                     NavigationLink(value: AppNavigationViewModel.Destination.admin) {
@@ -184,7 +183,7 @@ private struct MoreDestinationView: View {
         case .findPartner:
             FindPartnerView()
         case .supervisor:
-            SupervisorDashboardView()
+            SupervisorHomeDashboardView()
         case .admin:
             AdminPanelView()
         case .settings:

--- a/Job Tracker/Features/YellowSheet/YellowSheetJobCard.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetJobCard.swift
@@ -19,7 +19,7 @@ struct YellowSheetJobCard: View {
                     .foregroundColor(.white)
             }
             
-            Text("Status: \(job.status)")
+            Text("Status: \(job.displayStatus)")
                 .font(.subheadline)
                 .foregroundColor(.white)
             

--- a/Job Tracker/Features/YellowSheet/YellowSheetPDFGenerator.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetPDFGenerator.swift
@@ -51,7 +51,7 @@ class YellowSheetPDFGenerator {
                 var lines: [String] = []
                 lines.append("Address: \(job.address)")
                 lines.append("Job Number: \(job.jobNumber ?? "N/A")")
-                lines.append("Status: \(job.status)")
+                lines.append("Status: \(job.displayStatus)")
                 
                 if let nid = job.nidFootage, !nid.isEmpty {
                     lines.append("NID Footage: \(nid)")

--- a/Job Tracker/Models/AppUser.swift
+++ b/Job Tracker/Models/AppUser.swift
@@ -17,7 +17,7 @@ struct AppUser: Identifiable, Codable, Hashable {
     var firstName: String
     var lastName:  String
     var email:     String
-    /// "Ariel", "Underground", "Nid", or "Can"
+    /// "OH", "Underground", "Nid", or "Can"
     var position:  String
     /// Access flags
     var isAdmin: Bool      // platform admin (you)
@@ -73,10 +73,8 @@ extension AppUser {
         let l = lastName.first.map(String.init)  ?? ""
         return (f + l).uppercased()
     }
-    /// Normalized role (fixes legacy "Ariel" -> "Aerial")
+    /// Normalized role for display (legacy Aerial/Ariel/Arial values display as OH).
     var normalizedPosition: String {
-        let trimmed = position.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.caseInsensitiveCompare("Ariel") == .orderedSame { return "Aerial" }
-        return trimmed
+        CrewPosition.positionDisplayName(from: position)
     }
 }

--- a/Job Tracker/Models/CrewPosition.swift
+++ b/Job Tracker/Models/CrewPosition.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Shared crew-position normalization so legacy Aerial/Ariel/Arial values continue to work
+/// while the app displays and saves the current OH label.
+enum CrewPosition: String, CaseIterable, Identifiable, Hashable {
+    case ug = "UG"
+    case oh = "OH"
+    case can = "Can"
+    case nid = "Nid"
+
+    var id: String { rawValue }
+    var displayName: String { rawValue }
+
+    static let signupOptions = [oh.displayName, "Underground", nid.displayName, can.displayName]
+    static let supervisorDashboardOptions: [CrewPosition] = [.ug, .oh, .can, .nid]
+
+    static func positionDisplayName(from rawValue: String) -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return trimmed }
+        return isOH(trimmed) ? oh.displayName : trimmed
+    }
+
+    static func normalizedKey(from rawValue: String?) -> String {
+        guard let rawValue else { return "" }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let token = normalizedToken(trimmed)
+
+        if ohAliases.contains(token) { return oh.rawValue }
+        if token == "ug" || token == "underground" { return ug.rawValue }
+        if token == "can" { return can.rawValue }
+        if token == "nid" { return nid.rawValue }
+        return trimmed
+    }
+
+    static func matches(_ rawValue: String?, _ position: CrewPosition) -> Bool {
+        normalizedKey(from: rawValue).caseInsensitiveCompare(position.rawValue) == .orderedSame
+    }
+
+    static func normalizedStatusForSaving(_ rawStatus: String) -> String {
+        let trimmed = rawStatus.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isOH(trimmed) { return oh.rawValue }
+        if isNeedsOH(trimmed) { return "Needs OH" }
+        return trimmed
+    }
+
+    static func statusDisplayName(from rawStatus: String) -> String {
+        let trimmed = rawStatus.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isOH(trimmed) { return oh.rawValue }
+        if isNeedsOH(trimmed) { return "Needs OH" }
+        return trimmed
+    }
+
+    static func isOH(_ rawValue: String?) -> Bool {
+        guard let rawValue else { return false }
+        return ohAliases.contains(normalizedToken(rawValue))
+    }
+
+    private static func isNeedsOH(_ rawStatus: String) -> Bool {
+        let token = normalizedToken(rawStatus)
+        return token == "needsoh" || token == "needsaerial" || token == "needsariel" || token == "needsarial" || token == "needsoverhead"
+    }
+
+    private static let ohAliases: Set<String> = ["oh", "overhead", "aerial", "ariel", "arial"]
+
+    private static func normalizedToken(_ rawValue: String) -> String {
+        rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
+    }
+}

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -4,7 +4,7 @@ struct Job: Identifiable, Codable {
     var id: String                  // Firestore doc ID or UUID
     var address: String             // Full physical job address
     var date: Date                  // Date for scheduling/tracking
-    var status: String              // e.g. "Pending", "Needs Ariel", "Done", etc.
+    var status: String              // e.g. "Pending", "Needs OH", "Done", etc.
     var assignedTo: String?         // userID of whoever currently owns the job (nil = unclaimed)
     var createdBy: String?          // userID of whoever created the job
     var notes: String?              // Additional text notes
@@ -197,7 +197,10 @@ protocol JobSearchMatchable {
     var jobPlacement: String? { get }
 }
 
-extension Job: JobSearchMatchable {}
+extension Job: JobSearchMatchable {
+    var displayStatus: String { CrewPosition.statusDisplayName(from: status) }
+}
+
 
 struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearchMatchable {
     var id: String

--- a/Job Tracker/intent/CreateJobIntent.swift
+++ b/Job Tracker/intent/CreateJobIntent.swift
@@ -35,9 +35,9 @@ struct CreateJobIntent: AppIntent {
     
     // The perform method is called when Siri or Shortcuts executes this intent.
     func perform() async throws -> some ProvidesDialog {
-        let allowed = ["Pending","Needs Ariel","Needs Underground","Needs Nid","Needs Can","Done","Talk to Rick"]
+        let allowed = ["Pending","Needs OH","Needs Underground","Needs Nid","Needs Can","Done","Talk to Rick"]
         let chosen = status.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalized = allowed.first { $0.lowercased() == chosen.lowercased() } ?? chosen
+        let normalized = CrewPosition.normalizedStatusForSaving(allowed.first { $0.lowercased() == chosen.lowercased() } ?? chosen)
         
         // Construct a basic Job model
         let newJob = Job(

--- a/Job Tracker/intent/GetTodayJobsIntent.swift
+++ b/Job Tracker/intent/GetTodayJobsIntent.swift
@@ -27,7 +27,7 @@ struct GetTodayJobsIntent: AppIntent {
         // Keep dialog short for Siri
         let firstFew = visible.prefix(5).map { job in
             let addr = job.address.components(separatedBy: ",").first ?? job.address
-            return "\(addr) – \(job.status)"
+            return "\(addr) – \(job.displayStatus)"
         }.joined(separator: "; ")
 
         return .result(dialog: IntentDialog("Jobs today: \(firstFew)."))

--- a/Job Tracker/intent/UpdateJobStatusIntent.swift
+++ b/Job Tracker/intent/UpdateJobStatusIntent.swift
@@ -13,7 +13,7 @@ import CoreLocation
 @available(iOS 16.0, *)
 enum JobStatusIntentEnum: String, AppEnum {
     case pending = "Pending"
-    case needsAriel = "Needs Ariel"
+    case needsOH = "Needs OH"
     case needsUnderground = "Needs Underground"
     case needsNid = "Needs Nid"
     case needsCan = "Needs Can"
@@ -25,7 +25,7 @@ enum JobStatusIntentEnum: String, AppEnum {
 
     static var caseDisplayRepresentations: [JobStatusIntentEnum: DisplayRepresentation] = [
         .pending: "Pending",
-        .needsAriel: "Needs Ariel",
+        .needsOH: "Needs OH",
         .needsUnderground: "Needs Underground",
         .needsNid: "Needs Nid",
         .needsCan: "Needs Can",

--- a/website/app/PARITY_PLAN.md
+++ b/website/app/PARITY_PLAN.md
@@ -12,7 +12,7 @@ This audit compares the Firebase-backed web app in `website/app/` against the na
 
 1. Match the native auth flow more closely by using three segmented actions: Sign In, Sign Up, and Reset.
 2. Replace the login-only password reset button with a dedicated Reset form, matching the app copy and validation path.
-3. Align signup positions with the native crew position picker: Aerial, Underground, Nid, and Can.
+3. Align signup positions with the native crew position picker: OH, Underground, Nid, and Can.
 4. Add client-side validation before Firebase requests so blank/short values fail with clear messages instead of awkward browser or API errors.
 5. Guard against missing Firebase config before building Firestore URLs and fix the missing-config message to point at `website/app/config.js`.
 6. Correct the More page copy to say Firebase-backed persistence instead of local persistence.

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -45,7 +45,7 @@
             <label class="position-picker">
               Crew Position
               <select id="signupPosition">
-                <option>Aerial</option>
+                <option>OH</option>
                 <option>Underground</option>
                 <option>Nid</option>
                 <option>Can</option>
@@ -212,7 +212,7 @@
             <div class="form-grid three">
               <label>First name<input id="profileFirstName" /></label>
               <label>Last name<input id="profileLastName" /></label>
-              <label>Position<select id="profilePosition"><option>Aerial</option><option>Underground</option><option>Nid</option><option>Can</option><option>Supervisor</option><option>Admin</option></select></label>
+              <label>Position<select id="profilePosition"><option>OH</option><option>Underground</option><option>Nid</option><option>Can</option><option>Supervisor</option><option>Admin</option></select></label>
               <label>Email<input id="profileEmail" type="email" disabled /></label>
               <label>Phone<input id="profilePhone" placeholder="(555) 123-4567" /></label>
               <label>Home yard<input id="profileYard" placeholder="North Yard" /></label>
@@ -235,7 +235,7 @@
             <div class="section-heading"><div><p class="eyebrow">Find a partner</p><h2>Crew pairing requests</h2></div></div>
             <form class="partner-form" id="partnerForm">
               <label>Partner<select id="partnerUserInput" required></select></label>
-              <label>Needed for<select id="partnerNeedInput"><option>Aerial work</option><option>Underground pull</option><option>Splice assist</option><option>Late callback</option></select></label>
+              <label>Needed for<select id="partnerNeedInput"><option>OH work</option><option>Underground pull</option><option>Splice assist</option><option>Late callback</option></select></label>
               <label>Location<input id="partnerLocationInput" placeholder="Cabinet, address, or yard" required /></label>
               <label>When<input id="partnerWhenInput" type="time" required /></label>
               <label>Note<input id="partnerNoteInput" placeholder="What help is needed?" /></label>

--- a/website/app/parity-data-search.js
+++ b/website/app/parity-data-search.js
@@ -1,6 +1,6 @@
 // Web-only parity layer kept separate from parity-enhancements.js to avoid merge conflicts
 // with the shared baseline file while preserving iOS data/search/sharing behavior.
-const nativeStatusOptions = ["Pending", "Needs Aerial", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
+const nativeStatusOptions = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
 statuses.splice(0, statuses.length, ...nativeStatusOptions);
 
 appState.searchJobs = appState.searchJobs || [];
@@ -174,7 +174,7 @@ normalizeJob = function enhancedNormalizeJob(job) {
     id: job.id || createId(),
     address: job.address,
     date: job.date,
-    status: job.status,
+    status: typeof normalizeCrewStatus === "function" ? normalizeCrewStatus(job.status) : job.status,
     assignedTo: job.assignedTo || (job.status === "Pending" ? "" : currentUser.id),
     createdBy: job.createdBy || currentUser.id,
     notes: job.notes || "",
@@ -281,7 +281,7 @@ renderSearch = function enhancedRenderSearch() {
 
 function normalizedPosition(user = currentUser) {
   const position = String(user?.normalizedPosition || user?.position || "").trim();
-  return position.toLowerCase() === "ariel" ? "Aerial" : position;
+  return ["oh", "overhead", "aerial", "ariel", "arial"].includes(position.toLowerCase()) ? "OH" : position;
 }
 
 function isCanUser(user = currentUser) {
@@ -316,7 +316,7 @@ shareJob = async function enhancedShareJob(id) {
       fromUserName: senderName,
       address: job.address,
       date: job.date,
-      status: job.status,
+      status: typeof normalizeCrewStatus === "function" ? normalizeCrewStatus(job.status) : job.status,
       jobNumber: job.jobNumber || "",
       assignment: senderIsCan ? job.assignments || "" : "",
       senderIsCan,

--- a/website/app/parity-enhancements.js
+++ b/website/app/parity-enhancements.js
@@ -1,4 +1,4 @@
-const nativeStatusOptions = ["Pending", "Needs Aerial", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
+const nativeStatusOptions = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
 statuses.splice(0, statuses.length, ...nativeStatusOptions);
 
 const parityBase = {
@@ -16,7 +16,7 @@ encodeValue = function enhancedEncodeValue(value, key = "") {
 
 function normalizedPosition(user = currentUser) {
   const position = String(user?.normalizedPosition || user?.position || "").trim();
-  return position.toLowerCase() === "ariel" ? "Aerial" : position;
+  return ["oh", "overhead", "aerial", "ariel", "arial"].includes(position.toLowerCase()) ? "OH" : position;
 }
 
 function isCanUser(user = currentUser) {
@@ -51,7 +51,7 @@ shareJob = async function enhancedShareJob(id) {
       fromUserName: senderName,
       address: job.address,
       date: job.date,
-      status: job.status,
+      status: typeof normalizeCrewStatus === "function" ? normalizeCrewStatus(job.status) : job.status,
       jobNumber: job.jobNumber || "",
       assignment: senderIsCan ? job.assignments || "" : "",
       senderIsCan,

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -4,7 +4,7 @@ const tokenBase = "https://securetoken.googleapis.com/v1/token";
 const firestoreBase = config.projectId ? `https://firestore.googleapis.com/v1/projects/${config.projectId}/databases/(default)/documents` : "";
 const sessionKey = "job-tracker-web-firebase-session";
 const appDataCachePrefix = "job-tracker-web-app-data";
-const statuses = ["Pending", "Needs Aerial", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
+const statuses = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
 const weekDays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 const shortDays = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 const shareTokenAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789";
@@ -282,12 +282,20 @@ function canSeeJob(job) {
   return [job.createdBy, job.assignedTo].includes(currentUser.id) || (job.participants || []).includes(currentUser.id);
 }
 
+function normalizeCrewStatus(status) {
+  const value = String(status || "").trim();
+  const key = value.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (["oh", "overhead", "aerial", "ariel", "arial"].includes(key)) return "OH";
+  if (["needsoh", "needsoverhead", "needsaerial", "needsariel", "needsarial"].includes(key)) return "Needs OH";
+  return value;
+}
+
 function normalizeJob(job) {
   return {
     id: job.id || createId(),
     address: job.address,
     date: job.date,
-    status: job.status,
+    status: normalizeCrewStatus(job.status),
     assignedTo: job.assignedTo || currentUser.id,
     createdBy: job.createdBy || currentUser.id,
     notes: job.notes || "",
@@ -548,7 +556,7 @@ async function shareJob(id) {
       fromUserName: senderName,
       address: job.address,
       date: job.date,
-      status: job.status,
+      status: normalizeCrewStatus(job.status),
       jobNumber: job.jobNumber || "",
       assignment: senderIsCan ? job.assignments || "" : "",
       senderIsCan,
@@ -1018,7 +1026,7 @@ function renderSearch() {
 function hydrateUserForms() {
   $("#profileFirstName").value = currentUser.firstName || "";
   $("#profileLastName").value = currentUser.lastName || "";
-  $("#profilePosition").value = currentUser.position || "Aerial";
+  $("#profilePosition").value = currentUser.position || "OH";
   $("#profileEmail").value = currentUser.email || authSession.email || "";
   $("#profilePhone").value = currentUser.phone || "";
   $("#profileYard").value = currentUser.yard || "";


### PR DESCRIPTION
### Motivation
- Normalize legacy role/status labels (Aerial / Ariel / similar) to a single canonical "OH" value and centralize normalization to avoid scattered ad-hoc fixes. 
- Keep UI/status display consistent while preserving existing stored strings and supporting legacy data. 
- Improve current-user handling with a real-time listener so profile flags and role-based screens update immediately. 
- Add supervisor-focused views and diagnostics to support supervisor workflows and troubleshooting.

### Description
- Introduced `CrewPosition` model to centralize position/status normalization and mapping, including helpers like `positionDisplayName`, `normalizedKey`, `matches`, `statusDisplayName`, and `normalizedStatusForSaving`.
- Added `Job.displayStatus` computed property and switched many views to show `displayStatus` (instead of raw `status`) so legacy and new labels render consistently; updated multiple UI components, PDFs, intents, and web parity scripts accordingly.
- Reworked position/status usages across codebase: replaced literal "Aerial"/"Ariel" strings with `CrewPosition` helpers, updated materials sections and form options (Aerial → OH), and normalized status option arrays (e.g. "Needs OH").
- Enhanced `AuthViewModel` to start/stop a Firestore listener for the current user, added lifecycle cleanup, and wired `FirebaseService.listenCurrentUser` plus a `decodeCurrentUserSnapshot` helper to keep `currentUser` in sync in real time.
- Added new supervisor UI: `SupervisorHomeDashboardView` and related view-models/components for position cards, user lists, and job lists, and routed supervisor landing in shell/tab views when `authViewModel.isSupervisorFlag` is set.
- Added `ProfileDiagnosticsView` accessible from Profile to surface Firebase project, auth UID, and role/flag diagnostics for easier troubleshooting.
- Web parity changes: updated website scripts and UI to align with native normalization (OH), added `normalizeCrewStatus` in `script.js`, and updated parity files to use the new status/position labels.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d5549904832d8cbabab09b379da0)