### PR TITLE
Fix supervisor dashboard role return

### DIFF
--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -401,7 +401,7 @@ struct SupervisorDashboardView: View {
         guard let uid = uid, let user = usersViewModel.user(id: uid) else {
             return ""
         }
-        CrewPosition.normalizedKey(from: user.position)
+        return CrewPosition.normalizedKey(from: user.position)
     }
 
     private func resolveUserName(forUserId uid: String?) -> String {


### PR DESCRIPTION
### Motivation
- Fix the Swift compiler error where `resolveRole(forUserId:)` in `Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift` did not always return a `String`, causing a "Missing return in instance method expected to return 'String'" error.

### Description
- Add an explicit `return` so `resolveRole(forUserId:)` returns `CrewPosition.normalizedKey(from: user.position)` when a user is found.

### Testing
- Ran `git diff --check` and `swift --version` (shows `Swift version 6.1.3`), and noted that `xcodebuild -list -project 'Job Tracker.xcodeproj'` could not be executed in this environment because `xcodebuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f66c8df0832d843e8cb31007faf9)