### PR TITLE
Align supervisor dashboards with app theme

### DIFF
--- a/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
+++ b/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
@@ -24,6 +24,7 @@ struct SupervisorHomeDashboardView: View {
             }
             .navigationTitle("Supervisor Dashboard")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
             .onAppear { viewModel.start(for: selectedDate) }
             .onChange(of: selectedDate) { newDate in viewModel.start(for: newDate) }
             .onDisappear { viewModel.stop() }
@@ -43,10 +44,20 @@ struct SupervisorHomeDashboardView: View {
 
     private var datePickerCard: some View {
         GlassCard {
-            DatePicker("Date", selection: $selectedDate, displayedComponents: .date)
-                .datePickerStyle(.compact)
-                .font(JTTypography.body)
-                .padding(JTSpacing.lg)
+            HStack(spacing: JTSpacing.md) {
+                Image(systemName: "calendar")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.accent)
+                    .frame(width: 32, height: 32)
+                    .background(JTColors.glassHighlight, in: Circle())
+
+                DatePicker("Date", selection: $selectedDate, displayedComponents: .date)
+                    .datePickerStyle(.compact)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .tint(JTColors.accent)
+            }
+            .padding(JTSpacing.lg)
         }
     }
 
@@ -146,7 +157,7 @@ private struct SupervisorPositionCard: View {
             VStack(alignment: .leading, spacing: JTSpacing.md) {
                 HStack {
                     Text(position.displayName)
-                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .font(JTTypography.title3)
                         .foregroundStyle(JTColors.textPrimary)
                     Spacer()
                     Image(systemName: "chevron.right")
@@ -173,27 +184,40 @@ private struct SupervisorPositionUsersView: View {
     let jobs: [Job]
 
     var body: some View {
-        List {
-            if users.isEmpty {
-                Text("No users found for \(position.displayName).")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(users) { user in
-                    NavigationLink {
-                        SupervisorUserJobsView(user: user, date: date, jobs: jobsForUser(user))
-                    } label: {
-                        HStack {
-                            Text(displayName(for: user))
-                            Spacer()
-                            Text("\(jobsForUser(user).count)")
-                                .foregroundStyle(.secondary)
+        ZStack {
+            JTGradients.background
+                .ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: JTSpacing.md) {
+                    if users.isEmpty {
+                        GlassCard {
+                            Text("No users found for \(position.displayName).")
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .padding(JTSpacing.lg)
+                                .frame(maxWidth: .infinity)
+                        }
+                    } else {
+                        ForEach(users) { user in
+                            NavigationLink {
+                                SupervisorUserJobsView(user: user, date: date, jobs: jobsForUser(user))
+                            } label: {
+                                SupervisorUserRow(
+                                    name: displayName(for: user),
+                                    jobCount: jobsForUser(user).count
+                                )
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
                 }
+                .padding(JTSpacing.lg)
             }
         }
         .navigationTitle(position.displayName)
         .navigationBarTitleDisplayMode(.inline)
+        .jtNavigationBarStyle()
     }
 
     private func jobsForUser(_ user: AppUser) -> [Job] {
@@ -210,24 +234,76 @@ private struct SupervisorPositionUsersView: View {
     }
 }
 
+private struct SupervisorUserRow: View {
+    let name: String
+    let jobCount: Int
+
+    var body: some View {
+        GlassCard {
+            HStack(spacing: JTSpacing.md) {
+                Image(systemName: "person.fill")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.accent)
+                    .frame(width: 30, height: 30)
+                    .background(JTColors.glassHighlight, in: Circle())
+
+                Text(name)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Spacer()
+
+                Text("\(jobCount)")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .padding(.horizontal, JTSpacing.md)
+                    .padding(.vertical, JTSpacing.sm)
+                    .background(JTColors.glassHighlight, in: Capsule(style: .continuous))
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
 private struct SupervisorUserJobsView: View {
     let user: AppUser
     let date: Date
     let jobs: [Job]
 
     var body: some View {
-        List {
-            if jobs.isEmpty {
-                Text("No jobs for this date.")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(jobs) { job in
-                    SupervisorUserJobInfoCard(job: job)
+        ZStack {
+            JTGradients.background
+                .ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: JTSpacing.md) {
+                    if jobs.isEmpty {
+                        GlassCard {
+                            Text("No jobs for this date.")
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .padding(JTSpacing.lg)
+                                .frame(maxWidth: .infinity)
+                        }
+                    } else {
+                        ForEach(jobs) { job in
+                            GlassCard {
+                                SupervisorUserJobInfoCard(job: job)
+                                    .padding(JTSpacing.lg)
+                            }
+                        }
+                    }
                 }
+                .padding(JTSpacing.lg)
             }
         }
         .navigationTitle(displayName)
         .navigationBarTitleDisplayMode(.inline)
+        .jtNavigationBarStyle()
     }
 
     private var displayName: String {
@@ -264,7 +340,6 @@ private struct SupervisorUserJobInfoCard: View {
 
             detailRows
         }
-        .padding(.vertical, JTSpacing.sm)
     }
 
     @ViewBuilder

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -123,32 +123,13 @@ struct SupervisorDashboardView: View {
 
     var body: some View {
         ZStack {
-            // App-wide gradient background
-            JTGradients.background(stops: 4)
-            .ignoresSafeArea()
+            JTGradients.background
+                .ignoresSafeArea()
 
-            ScrollView {
-                VStack(spacing: 16) {
-                    // Title
-                    HStack {
-                        Text("Supervisor")
-                            .font(.system(size: 34, weight: .bold))
-                            .foregroundColor(.white)
-                        Spacer()
-                    }
-                    .padding(.top, 8)
-
-                    // Search
-                    HStack(spacing: 10) {
-                        Image(systemName: "magnifyingglass")
-                            .foregroundColor(.secondary)
-                        TextField("Search address, job #, notes…", text: $searchText)
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-                    }
-                    .padding(12)
-                    .background(Color.black.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                    header
+                    searchField
 
                     // Filters card
                     filtersCard
@@ -194,20 +175,24 @@ struct SupervisorDashboardView: View {
                     }
 
                     if pendingJobs.isEmpty && completedJobs.isEmpty && !vm.isLoading {
-                        Text("No jobs match these filters.")
-                            .foregroundColor(.white.opacity(0.8))
-                            .padding(.vertical, 24)
-                            .frame(maxWidth: .infinity)
+                        GlassCard {
+                            Text("No jobs match these filters.")
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .padding(.vertical, JTSpacing.xl)
+                                .frame(maxWidth: .infinity)
+                        }
                     }
                 }
-                .padding(.horizontal)
-                .padding(.top, 56)
-                .padding(.bottom, 24)
+                .padding(.horizontal, JTSpacing.lg)
+                .padding(.top, JTSpacing.xxl + JTSpacing.xl)
+                .padding(.bottom, JTSpacing.xl)
             }
         }
         .onAppear { vm.start(range: dateRange) }
         .onDisappear { vm.stop() }
         .onChange(of: dateRange) { _ in vm.start(range: dateRange) }
+        .jtNavigationBarStyle()
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if authViewModel.isSupervisorFlag || authViewModel.isAdminFlag {
@@ -240,21 +225,47 @@ struct SupervisorDashboardView: View {
     }
 
     // MARK: – Styled sections matching Dashboard
+    private var header: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            Text("Supervisor")
+                .font(JTTypography.screenTitle)
+                .foregroundStyle(JTColors.textPrimary)
+            Text("Filter crew jobs by role, status, and date range.")
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: JTSpacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(JTColors.textMuted)
+            TextField("Search address, job #, notes…", text: $searchText)
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textPrimary)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+        }
+        .padding(JTSpacing.md)
+        .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)
+    }
+
     private func sectionHeader(_ title: String) -> some View {
         HStack {
             Text(title)
-                .font(.title3).bold()
-                .foregroundColor(.white)
+                .font(JTTypography.title3)
+                .foregroundStyle(JTColors.textPrimary)
             Spacer()
         }
-        .padding(.top, 8)
+        .padding(.top, JTSpacing.sm)
     }
 
     private func dayHeader(_ date: Date) -> some View {
         HStack {
             Text(dayString(date))
-                .font(.subheadline).bold()
-                .foregroundColor(.white.opacity(0.85))
+                .font(JTTypography.captionEmphasized)
+                .foregroundStyle(JTColors.textSecondary)
             Spacer()
         }
     }
@@ -283,7 +294,7 @@ struct SupervisorDashboardView: View {
                     Button("This month") { setPresetThisMonth() }
                 } label: {
                     Label("Quick Range", systemImage: "calendar.badge.clock")
-                        .foregroundColor(.white)
+                        .foregroundStyle(JTColors.textPrimary)
                 }
                 Spacer(minLength: 0)
             }
@@ -291,37 +302,38 @@ struct SupervisorDashboardView: View {
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("From")
-                        .font(.footnote)
-                        .foregroundColor(.white.opacity(0.8))
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
                     DatePicker(
                         "From",
                         selection: Binding(get: { dateRange.start }, set: { dateRange = DateInterval(start: $0, end: dateRange.end) }),
                         displayedComponents: .date
                     )
                     .labelsHidden()
+                    .tint(JTColors.accent)
                     .accessibilityLabel("From")
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("To")
-                        .font(.footnote)
-                        .foregroundColor(.white.opacity(0.8))
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
                     DatePicker(
                         "To",
                         selection: Binding(get: { dateRange.end }, set: { dateRange = DateInterval(start: dateRange.start, end: $0) }),
                         displayedComponents: .date
                     )
                     .labelsHidden()
+                    .tint(JTColors.accent)
                     .accessibilityLabel("To")
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.top, 4)
         }
-        .padding(12)
-        .background(Color.black.opacity(0.25))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(JTSpacing.md)
+        .jtGlassBackground(cornerRadius: JTShapes.cardCornerRadius)
     }
 
     private func setPreset(days: Int) {
@@ -426,12 +438,11 @@ struct SupervisorDashboardView: View {
             Image(systemName: system)
             Text(text)
         }
-        .font(.caption)
-        .padding(.vertical, 6)
-        .padding(.horizontal, 10)
-        .background(Color.black.opacity(0.15))
-        .clipShape(Capsule())
-        .foregroundColor(.white)
+        .font(JTTypography.captionEmphasized)
+        .padding(.vertical, JTSpacing.sm)
+        .padding(.horizontal, JTSpacing.md)
+        .background(JTColors.glassHighlight, in: Capsule(style: .continuous))
+        .foregroundStyle(JTColors.textPrimary)
     }
 }
 
@@ -447,27 +458,27 @@ private struct SupervisorJobRow: View {
             header
             metadata
         }
-        .padding(16)
-        .supervisorGlassCard(cornerRadius: 16, shadow: 12)
+        .padding(JTSpacing.lg)
+        .jtGlassBackground(cornerRadius: JTShapes.cardCornerRadius)
+        .jtShadow(JTElevations.card)
     }
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(job.address)
-                .font(.headline.weight(.semibold))
-                .foregroundColor(.white)
+                .font(JTTypography.headline)
+                .foregroundStyle(JTColors.textPrimary)
                 .lineLimit(2)
                 .truncationMode(.tail)
 
             Spacer(minLength: 8)
 
             Text(job.displayStatus)
-                .font(.caption.weight(.semibold))
-                .foregroundColor(.white)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(statusBadgeColor)
-                .clipShape(Capsule())
+                .font(JTTypography.captionEmphasized)
+                .foregroundStyle(JTColors.textPrimary)
+                .padding(.horizontal, JTSpacing.md)
+                .padding(.vertical, JTSpacing.sm)
+                .background(statusBadgeColor, in: Capsule(style: .continuous))
         }
     }
 
@@ -482,8 +493,8 @@ private struct SupervisorJobRow: View {
                     } icon: {
                         Image(systemName: item.icon)
                     }
-                    .font(.caption)
-                    .foregroundColor(.white.opacity(0.85))
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -494,12 +505,11 @@ private struct SupervisorJobRow: View {
 
     private var hoursBadge: some View {
         Text(hoursText)
-            .font(.caption.weight(.semibold))
-            .foregroundColor(.white)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(Color.white.opacity(0.16))
-            .clipShape(Capsule())
+            .font(JTTypography.captionEmphasized)
+            .foregroundStyle(JTColors.textPrimary)
+            .padding(.horizontal, JTSpacing.md)
+            .padding(.vertical, JTSpacing.sm)
+            .background(JTColors.glassHighlight, in: Capsule(style: .continuous))
     }
 
     private var hoursText: String {
@@ -545,7 +555,7 @@ private struct SupervisorJobRow: View {
     }
 
     private var statusBadgeColor: Color {
-        job.status.lowercased() == "pending" ? Color.orange.opacity(0.35) : Color.teal.opacity(0.35)
+        job.status.lowercased() == "pending" ? JTColors.warning.opacity(0.28) : JTColors.success.opacity(0.28)
     }
 
     private func dateString(_ d: Date) -> String {
@@ -555,21 +565,6 @@ private struct SupervisorJobRow: View {
     }
 }
 
-private extension View {
-    func supervisorGlassCard(cornerRadius: CGFloat = 16, shadow: CGFloat = 10) -> some View {
-        self
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(.ultraThinMaterial)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .shadow(color: Color.black.opacity(0.20), radius: shadow, x: 0, y: 6)
-    }
-}
 
 // MARK: - Role filter (local to create view)
 private enum RoleFilter: String, CaseIterable, Identifiable {
@@ -651,7 +646,7 @@ struct SupervisorCreateJobView: View {
         NavigationStack {
             ZStack {
                 JTGradients.background(stops: 4)
-                .ignoresSafeArea()
+                    .ignoresSafeArea()
 
                 Form {
                     // Worker Role filter
@@ -670,7 +665,7 @@ struct SupervisorCreateJobView: View {
                                     .font(.body)
                                 Text(roleFilter == .all ? "Choose from all users" : "Filtered by \(roleFilter.rawValue)")
                                     .font(.caption)
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(JTColors.textMuted)
                             }
                             Spacer()
                             Button {
@@ -716,7 +711,7 @@ struct SupervisorCreateJobView: View {
                                                 VStack(alignment: .leading, spacing: 2) {
                                                     Text(item.title).font(.body)
                                                     if !item.subtitle.isEmpty {
-                                                        Text(item.subtitle).font(.caption).foregroundColor(.secondary)
+                                                        Text(item.subtitle).font(.caption).foregroundStyle(JTColors.textMuted)
                                                     }
                                                 }
                                                 Spacer()
@@ -771,7 +766,7 @@ struct SupervisorCreateJobView: View {
                             .disableAutocorrection(true)
                         Text("Enter the Gibson portal edit ID, or paste the full portal link and the app will store the ID.")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(JTColors.textMuted)
                         if isPortalIDInvalid {
                             Text("Enter a numeric Portal ID or paste a Gibson portal edit link.")
                                 .font(.caption)
@@ -786,7 +781,7 @@ struct SupervisorCreateJobView: View {
                             .disableAutocorrection(true)
                         Text("Use this when there is no Portal ID. Enter the location number or paste a Gibson consumer search link.")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(JTColors.textMuted)
                         if isLocationNumberInvalid {
                             Text("Enter a numeric location number or paste a Gibson consumer search link.")
                                 .font(.caption)
@@ -844,7 +839,10 @@ struct SupervisorCreateJobView: View {
     }
 
     private func saveJob() {
-        guard let supervisorID = authViewModel.currentUser?.id else { dismiss(); return }
+        guard let supervisorID = authViewModel.currentUser?.id else {
+            dismiss()
+            return
+        }
 
         // New jobs created by supervisors always start as Pending
         let finalStatus = "Pending"
@@ -895,7 +893,11 @@ private struct UserSelectSheet: View {
                         HStack {
                             Image(systemName: "person.crop.circle")
                             Text("Unassigned")
-                            if selectedUserID == nil { Spacer(); Image(systemName: "checkmark").foregroundColor(.accentColor) }
+                            if selectedUserID == nil {
+                                Spacer()
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.accentColor)
+                            }
                         }
                     }
                 }
@@ -913,7 +915,7 @@ private struct UserSelectSheet: View {
                                     Text("\(u.firstName) \(u.lastName)")
                                     Text(normalizedRole(u.position))
                                         .font(.caption)
-                                        .foregroundColor(.secondary)
+                                        .foregroundStyle(JTColors.textMuted)
                                 }
                                 Spacer()
                                 if selectedUserID == u.id {
@@ -926,12 +928,12 @@ private struct UserSelectSheet: View {
             }
             .navigationTitle("Choose User")
             .searchable(text: $search, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search users…")
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") { dismiss() }
                 }
             }
-            .jtNavigationBarStyle()
         }
     }
 


### PR DESCRIPTION
### Motivation
- The supervisor dashboards used older, standalone styling that didn't match the app design system and felt visually inconsistent with other screens.  
- The goal was to bring the supervisor views onto the shared theme (gradients, glass surfaces, tokens) so look-and-feel and components are consistent across the app.

### Description
- Restyled `SupervisorDashboardView` to use `JTGradients.background`, `JTTypography`, `JTSpacing`, `JTColors`, `GlassCard`/`jtGlassBackground`, and `.jtNavigationBarStyle()` for consistent background, typography, spacing, and navigation styling.  
- Reworked search, filter, and chip UI to use design-system tokens (`JTColors`, `JTTypography`, `JTSpacing`) and glass treatments, and updated status badges to use semantic `JTColors.warning`/`JTColors.success` tints.  
- Replaced default `List` usages in the supervisor home drill-downs with gradient-backed `ScrollView` + `LazyVStack`, added `SupervisorUserRow` component, glass-backed job/user empty states, and wrapped job rows in `GlassCard` with `jtShadow`.  
- Minor behavioral/formatting updates to related create/import sheets and date pickers (added `.tint(JTColors.accent)`, adjusted paddings, and fixed a few small control layouts) to match the refreshed aesthetic.

### Testing
- Ran `git diff --check` to validate there are no obvious diff-check issues and the repo diff-check returned clean results.  
- Ran the repository formatter/linter via `swift-format lint 'Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift' 'Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift'`, which completed successfully but reported style warnings (existing lint/format rules flagged a number of non-blocking issues).  
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` to validate Xcode project, but `xcodebuild` is not available in the Linux environment so that step could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18fceff028832db9da4285798c8b5f)