### PR TITLE
Revamp Supervisor UI: restyle dashboards, import/create flows, navigation, and metadata

### DIFF
--- a/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
+++ b/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
@@ -2,7 +2,9 @@ import FirebaseFirestore
 import SwiftUI
 
 struct SupervisorHomeDashboardView: View {
+    @EnvironmentObject private var jobsViewModel: JobsViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
     @StateObject private var viewModel = SupervisorHomeDashboardViewModel()
     @State private var selectedDate = Date()
 
@@ -24,6 +26,7 @@ struct SupervisorHomeDashboardView: View {
             }
             .navigationTitle("Supervisor Dashboard")
             .navigationBarTitleDisplayMode(.inline)
+            .jtNavigationBarStyle()
             .onAppear { viewModel.start(for: selectedDate) }
             .onChange(of: selectedDate) { newDate in viewModel.start(for: newDate) }
             .onDisappear { viewModel.stop() }
@@ -43,10 +46,20 @@ struct SupervisorHomeDashboardView: View {
 
     private var datePickerCard: some View {
         GlassCard {
-            DatePicker("Date", selection: $selectedDate, displayedComponents: .date)
-                .datePickerStyle(.compact)
-                .font(JTTypography.body)
-                .padding(JTSpacing.lg)
+            HStack(spacing: JTSpacing.md) {
+                Image(systemName: "calendar")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.accent)
+                    .frame(width: 32, height: 32)
+                    .background(JTColors.glassHighlight, in: Circle())
+
+                DatePicker("Date", selection: $selectedDate, displayedComponents: .date)
+                    .datePickerStyle(.compact)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .tint(JTColors.accent)
+            }
+            .padding(JTSpacing.lg)
         }
     }
 
@@ -60,6 +73,9 @@ struct SupervisorHomeDashboardView: View {
                         users: users(for: position),
                         jobs: viewModel.jobs
                     )
+                    .environmentObject(jobsViewModel)
+                    .environmentObject(usersViewModel)
+                    .environmentObject(authViewModel)
                 } label: {
                     SupervisorPositionCard(
                         position: position,
@@ -146,7 +162,7 @@ private struct SupervisorPositionCard: View {
             VStack(alignment: .leading, spacing: JTSpacing.md) {
                 HStack {
                     Text(position.displayName)
-                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .font(JTTypography.title3)
                         .foregroundStyle(JTColors.textPrimary)
                     Spacer()
                     Image(systemName: "chevron.right")
@@ -167,33 +183,53 @@ private struct SupervisorPositionCard: View {
 }
 
 private struct SupervisorPositionUsersView: View {
+    @EnvironmentObject private var jobsViewModel: JobsViewModel
+    @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
+
     let position: CrewPosition
     let date: Date
     let users: [AppUser]
     let jobs: [Job]
 
     var body: some View {
-        List {
-            if users.isEmpty {
-                Text("No users found for \(position.displayName).")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(users) { user in
-                    NavigationLink {
-                        SupervisorUserJobsView(user: user, date: date, jobs: jobsForUser(user))
-                    } label: {
-                        HStack {
-                            Text(displayName(for: user))
-                            Spacer()
-                            Text("\(jobsForUser(user).count)")
-                                .foregroundStyle(.secondary)
+        ZStack {
+            JTGradients.background
+                .ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: JTSpacing.md) {
+                    if users.isEmpty {
+                        GlassCard {
+                            Text("No users found for \(position.displayName).")
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .padding(JTSpacing.lg)
+                                .frame(maxWidth: .infinity)
+                        }
+                    } else {
+                        ForEach(users) { user in
+                            NavigationLink {
+                                SupervisorUserJobsView(user: user, date: date, jobs: jobsForUser(user))
+                                    .environmentObject(jobsViewModel)
+                                    .environmentObject(usersViewModel)
+                                    .environmentObject(authViewModel)
+                            } label: {
+                                SupervisorUserRow(
+                                    name: displayName(for: user),
+                                    jobCount: jobsForUser(user).count
+                                )
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
                 }
+                .padding(JTSpacing.lg)
             }
         }
         .navigationTitle(position.displayName)
         .navigationBarTitleDisplayMode(.inline)
+        .jtNavigationBarStyle()
     }
 
     private func jobsForUser(_ user: AppUser) -> [Job] {
@@ -210,27 +246,152 @@ private struct SupervisorPositionUsersView: View {
     }
 }
 
+private struct SupervisorUserRow: View {
+    let name: String
+    let jobCount: Int
+
+    var body: some View {
+        GlassCard {
+            HStack(spacing: JTSpacing.md) {
+                Image(systemName: "person.fill")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.accent)
+                    .frame(width: 30, height: 30)
+                    .background(JTColors.glassHighlight, in: Circle())
+
+                Text(name)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Spacer()
+
+                Text("\(jobCount)")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .padding(.horizontal, JTSpacing.md)
+                    .padding(.vertical, JTSpacing.sm)
+                    .background(JTColors.glassHighlight, in: Capsule(style: .continuous))
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
 private struct SupervisorUserJobsView: View {
+    @EnvironmentObject private var jobsViewModel: JobsViewModel
+    @EnvironmentObject private var usersViewModel: UsersViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
+
     let user: AppUser
     let date: Date
     let jobs: [Job]
 
     var body: some View {
-        List {
-            if jobs.isEmpty {
-                Text("No jobs for this date.")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(jobs) { job in
-                    SupervisorUserJobInfoCard(job: job)
+        ZStack {
+            JTGradients.background
+                .ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: JTSpacing.md) {
+                    if jobs.isEmpty {
+                        GlassCard {
+                            Text("No jobs for this date.")
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .padding(JTSpacing.lg)
+                                .frame(maxWidth: .infinity)
+                        }
+                    } else {
+                        ForEach(jobs) { job in
+                            NavigationLink {
+                                JobSearchDetailView(
+                                    job: job,
+                                    metadata: supervisorHomeMetadata(for: job),
+                                    showsAddToDashboard: false
+                                )
+                                .environmentObject(jobsViewModel)
+                                .environmentObject(usersViewModel)
+                                .environmentObject(authViewModel)
+                            } label: {
+                                GlassCard {
+                                    SupervisorUserJobInfoCard(job: job)
+                                        .padding(JTSpacing.lg)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
                 }
+                .padding(JTSpacing.lg)
             }
         }
         .navigationTitle(displayName)
         .navigationBarTitleDisplayMode(.inline)
+        .jtNavigationBarStyle()
     }
 
     private var displayName: String {
+        let name = [user.firstName, user.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return name.isEmpty ? "Unnamed User" : name
+    }
+
+    private func supervisorHomeMetadata(for job: Job) -> JobSearchViewModel.Result {
+        let addressParts = job.address
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let primaryAddress = addressParts.first ?? job.address.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondaryAddress = addressParts.dropFirst().joined(separator: ", ")
+        let creator = job.createdBy.flatMap { creatorID in
+            usersViewModel.user(id: creatorID).map { creatorUser in
+                JobSearchViewModel.Result.Creator(
+                    id: creatorUser.id,
+                    name: displayName(for: creatorUser),
+                    role: CrewPosition.normalizedKey(from: creatorUser.position)
+                )
+            }
+        }
+
+        return JobSearchViewModel.Result(
+            id: job.id,
+            address: .init(
+                primary: primaryAddress.isEmpty ? job.address : primaryAddress,
+                secondary: secondaryAddress.isEmpty ? nil : secondaryAddress
+            ),
+            jobNumber: job.jobNumber?.trimmedNonEmpty,
+            status: CrewPosition.statusDisplayName(from: job.status),
+            date: job.date,
+            creator: creator,
+            snippet: supervisorHomeSnippet(for: job),
+            isOwnedByCurrentUser: job.createdBy == authViewModel.currentUser?.id || job.assignedTo == authViewModel.currentUser?.id
+        )
+    }
+
+    private func supervisorHomeSnippet(for job: Job) -> JobSearchViewModel.Result.DetailSnippet? {
+        let candidates: [(String, String?)] = [
+            ("Portal ID", job.portalID),
+            ("Location", job.locationNumber),
+            ("Assignment", job.assignments),
+            ("Materials", job.materialsUsed),
+            ("Notes", job.notes),
+            ("Placement", job.jobPlacement)
+        ]
+
+        for (title, value) in candidates {
+            if let text = value?.trimmedNonEmpty {
+                return .init(title: title, value: text)
+            }
+        }
+        return nil
+    }
+
+    private func displayName(for user: AppUser) -> String {
         let name = [user.firstName, user.lastName]
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
@@ -264,7 +425,6 @@ private struct SupervisorUserJobInfoCard: View {
 
             detailRows
         }
-        .padding(.vertical, JTSpacing.sm)
     }
 
     @ViewBuilder

--- a/Job Tracker/Features/Jobs/Editor/SupervisorJobImportView.swift
+++ b/Job Tracker/Features/Jobs/Editor/SupervisorJobImportView.swift
@@ -100,109 +100,57 @@ struct SupervisorJobImportView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 20) {
-                if let img = pickedImage {
-                    Image(uiImage: img)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(maxHeight: 200)
-                }
+            ZStack {
+                JTGradients.background
+                    .ignoresSafeArea()
 
-                Button("Select Job Sheet") { showImagePicker = true }
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                        header
+                        imagePreviewCard
+                        actionRow
 
-                Button("Parse Sheet") { runParsing() }
-                    .disabled(pickedImage == nil || isParsing)
-
-                if isParsing { ProgressView() }
-
-                if let err = parsingError {
-                    Text(err.localizedDescription).foregroundColor(.red)
-                }
-
-                if parsedEntries.isEmpty {
-                    Text("No job sheet selected")
-                        .foregroundColor(.secondary)
-                } else {
-                    List(parsedEntries) { entry in
-                        HStack(alignment: .top, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(entry.resolvedAddress)
-                                    .font(.headline)
-
-                                if let jobNumber = entry.jobNumber {
-                                    Text("Job #: \(jobNumber)")
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
+                        if isParsing {
+                            GlassCard {
+                                HStack(spacing: JTSpacing.md) {
+                                    ProgressView()
+                                        .tint(JTColors.accent)
+                                    Text("Parsing job sheet…")
+                                        .font(JTTypography.body)
+                                        .foregroundStyle(JTColors.textPrimary)
                                 }
-
-                                if let assignee = assigneeDisplayName(for: entry) {
-                                    Text("Assignee: \(assignee)")
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                }
-
-                                if let notes = entry.notes {
-                                    Text(notes)
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                } else if let fallbackNotes = entry.resolvedNotes {
-                                    Text(fallbackNotes)
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                }
-
-                                if entry.notes != nil,
-                                   let raw = entry.rawText,
-                                   !raw.isEmpty,
-                                   raw.caseInsensitiveCompare(entry.resolvedAddress) != .orderedSame {
-                                    Text("Original: \(raw)")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                }
+                                .padding(JTSpacing.lg)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                             }
+                        }
 
-                            Spacer()
+                        if let err = parsingError {
+                            GlassCard(strokeColor: JTColors.error.opacity(0.45)) {
+                                Label(err.localizedDescription, systemImage: "exclamationmark.triangle.fill")
+                                    .font(JTTypography.captionEmphasized)
+                                    .foregroundStyle(JTColors.error)
+                                    .padding(JTSpacing.lg)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
 
-                            if confirmed.contains(token(for: entry)) {
-                                Image(systemName: "checkmark.circle")
-                                    .foregroundColor(.green)
-                            } else if pending.contains(token(for: entry)) {
-                                ProgressView()
-                            } else {
-                                VStack(alignment: .trailing, spacing: 8) {
-                                    Button("Import") {
-                                        let fields = fields(for: entry)
-                                        let supervisorID = authViewModel.currentUser?.id
-                                        let job = Job(
-                                            address: fields.address,
-                                            date: fields.date,
-                                            status: "Pending",
-                                            assignedTo: fields.assigneeID ?? "",
-                                            createdBy: supervisorID ?? "",
-                                            notes: fields.notes ?? "",
-                                            jobNumber: fields.jobNumber,
-                                            assignments: nil,
-                                            materialsUsed: "",
-                                            latitude: nil,
-                                            longitude: nil
-                                        )
-                                        importEntry(job, for: entry)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .disabled(!entry.hasResolvableAddress)
+                        if parsedEntries.isEmpty {
+                            emptyImportState
+                        } else {
+                            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                                Text("Parsed jobs")
+                                    .font(JTTypography.title3)
+                                    .foregroundStyle(JTColors.textPrimary)
 
-                                    Button("Review…") {
-                                        reviewFields = fields(for: entry)
-                                        showReview = true
-                                    }
-                                    .disabled(!entry.hasResolvableAddress)
+                                ForEach(parsedEntries) { entry in
+                                    parsedEntryCard(entry)
                                 }
                             }
                         }
                     }
+                    .padding(JTSpacing.lg)
                 }
             }
-            .padding()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
@@ -230,6 +178,172 @@ struct SupervisorJobImportView: View {
         .onAppear {
             if pickedImage == nil {
                 showImagePicker = true
+            }
+        }
+    }
+
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            Text("Import Job Sheet")
+                .font(JTTypography.screenTitle)
+                .foregroundStyle(JTColors.textPrimary)
+            Text("Select a sheet, parse it, then import or review each job before saving.")
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+    }
+
+    private var imagePreviewCard: some View {
+        GlassCard {
+            Group {
+                if let img = pickedImage {
+                    Image(uiImage: img)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxHeight: 220)
+                        .clipShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
+                } else {
+                    VStack(spacing: JTSpacing.sm) {
+                        Image(systemName: "doc.viewfinder")
+                            .font(.system(size: 34, weight: .semibold))
+                        Text("No job sheet selected")
+                            .font(JTTypography.headline)
+                    }
+                    .foregroundStyle(JTColors.textSecondary)
+                    .frame(maxWidth: .infinity, minHeight: 160)
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: JTSpacing.md) {
+            Button { showImagePicker = true } label: {
+                Label("Select Sheet", systemImage: "photo")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.textPrimary)
+                    .padding(.vertical, JTSpacing.md)
+                    .padding(.horizontal, JTSpacing.lg)
+                    .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+            }
+            .buttonStyle(.plain)
+
+            Button { runParsing() } label: {
+                Label("Parse Sheet", systemImage: "wand.and.stars")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.onAccent)
+                    .padding(.vertical, JTSpacing.md)
+                    .padding(.horizontal, JTSpacing.lg)
+                    .background(JTColors.accent, in: Capsule(style: .continuous))
+                    .jtShadow(JTElevations.button)
+            }
+            .buttonStyle(.plain)
+            .disabled(pickedImage == nil || isParsing)
+            .opacity(pickedImage == nil || isParsing ? 0.55 : 1)
+        }
+    }
+
+    private var emptyImportState: some View {
+        GlassCard {
+            Text("Choose a job sheet to get started.")
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textSecondary)
+                .padding(JTSpacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func parsedEntryCard(_ entry: ParsedEntry) -> some View {
+        GlassCard {
+            HStack(alignment: .top, spacing: JTSpacing.md) {
+                VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                    Text(entry.resolvedAddress)
+                        .font(JTTypography.headline)
+                        .foregroundStyle(JTColors.textPrimary)
+
+                    if let jobNumber = entry.jobNumber {
+                        detailLine("Job #", jobNumber)
+                    }
+
+                    if let assignee = assigneeDisplayName(for: entry) {
+                        detailLine("Assignee", assignee)
+                    }
+
+                    if let notes = entry.notes {
+                        detailLine("Notes", notes)
+                    } else if let fallbackNotes = entry.resolvedNotes {
+                        detailLine("Notes", fallbackNotes)
+                    }
+
+                    if entry.notes != nil,
+                       let raw = entry.rawText,
+                       !raw.isEmpty,
+                       raw.caseInsensitiveCompare(entry.resolvedAddress) != .orderedSame {
+                        detailLine("Original", raw)
+                    }
+                }
+
+                Spacer()
+
+                entryActions(for: entry)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private func detailLine(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(JTColors.textSecondary)
+            Text(value)
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+    }
+
+    @ViewBuilder
+    private func entryActions(for entry: ParsedEntry) -> some View {
+        if confirmed.contains(token(for: entry)) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.title3)
+                .foregroundStyle(JTColors.success)
+        } else if pending.contains(token(for: entry)) {
+            ProgressView()
+                .tint(JTColors.accent)
+        } else {
+            VStack(alignment: .trailing, spacing: JTSpacing.sm) {
+                Button("Import") {
+                    let fields = fields(for: entry)
+                    let supervisorID = authViewModel.currentUser?.id
+                    let job = Job(
+                        address: fields.address,
+                        date: fields.date,
+                        status: "Pending",
+                        assignedTo: fields.assigneeID ?? "",
+                        createdBy: supervisorID ?? "",
+                        notes: fields.notes ?? "",
+                        jobNumber: fields.jobNumber,
+                        assignments: nil,
+                        materialsUsed: "",
+                        latitude: nil,
+                        longitude: nil
+                    )
+                    importEntry(job, for: entry)
+                }
+                .font(JTTypography.captionEmphasized)
+                .buttonStyle(.borderedProminent)
+                .tint(JTColors.accent)
+                .disabled(!entry.hasResolvableAddress)
+
+                Button("Review…") {
+                    reviewFields = fields(for: entry)
+                    showReview = true
+                }
+                .font(JTTypography.captionEmphasized)
+                .disabled(!entry.hasResolvableAddress)
             }
         }
     }

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -122,33 +122,15 @@ struct SupervisorDashboardView: View {
     }()
 
     var body: some View {
-        ZStack {
-            // App-wide gradient background
-            JTGradients.background(stops: 4)
-            .ignoresSafeArea()
+        NavigationStack {
+            ZStack {
+                JTGradients.background
+                .ignoresSafeArea()
 
-            ScrollView {
-                VStack(spacing: 16) {
-                    // Title
-                    HStack {
-                        Text("Supervisor")
-                            .font(.system(size: 34, weight: .bold))
-                            .foregroundColor(.white)
-                        Spacer()
-                    }
-                    .padding(.top, 8)
-
-                    // Search
-                    HStack(spacing: 10) {
-                        Image(systemName: "magnifyingglass")
-                            .foregroundColor(.secondary)
-                        TextField("Search address, job #, notes…", text: $searchText)
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-                    }
-                    .padding(12)
-                    .background(Color.black.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                    header
+                    searchField
 
                     // Filters card
                     filtersCard
@@ -165,11 +147,14 @@ struct SupervisorDashboardView: View {
                             ForEach(pendingGroups, id: \.key) { day, jobs in
                                 dayHeader(day)
                                 ForEach(jobs, id: \.id) { job in
-                                    SupervisorJobRow(
-                                        job: job,
-                                        userRoleResolver: resolveRole(forUserId:),
-                                        userNameResolver: resolveUserName(forUserId:)
-                                    )
+                                    NavigationLink(value: job) {
+                                        SupervisorJobRow(
+                                            job: job,
+                                            userRoleResolver: resolveRole(forUserId:),
+                                            userNameResolver: resolveUserName(forUserId:)
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
                                 }
                             }
                         }
@@ -183,31 +168,49 @@ struct SupervisorDashboardView: View {
                             ForEach(completedGroups, id: \.key) { day, jobs in
                                 dayHeader(day)
                                 ForEach(jobs, id: \.id) { job in
-                                    SupervisorJobRow(
-                                        job: job,
-                                        userRoleResolver: resolveRole(forUserId:),
-                                        userNameResolver: resolveUserName(forUserId:)
-                                    )
+                                    NavigationLink(value: job) {
+                                        SupervisorJobRow(
+                                            job: job,
+                                            userRoleResolver: resolveRole(forUserId:),
+                                            userNameResolver: resolveUserName(forUserId:)
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
                                 }
                             }
                         }
                     }
 
                     if pendingJobs.isEmpty && completedJobs.isEmpty && !vm.isLoading {
-                        Text("No jobs match these filters.")
-                            .foregroundColor(.white.opacity(0.8))
-                            .padding(.vertical, 24)
-                            .frame(maxWidth: .infinity)
+                        GlassCard {
+                            Text("No jobs match these filters.")
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .padding(.vertical, JTSpacing.xl)
+                                .frame(maxWidth: .infinity)
+                        }
                     }
                 }
-                .padding(.horizontal)
-                .padding(.top, 56)
-                .padding(.bottom, 24)
+                .padding(.horizontal, JTSpacing.lg)
+                .padding(.top, JTSpacing.xxl + JTSpacing.xl)
+                .padding(.bottom, JTSpacing.xl)
+                }
+            }
+            .navigationDestination(for: Job.self) { job in
+                JobSearchDetailView(
+                    job: job,
+                    metadata: supervisorSearchMetadata(for: job),
+                    showsAddToDashboard: false
+                )
+                .environmentObject(jobsViewModel)
+                .environmentObject(usersViewModel)
+                .environmentObject(authViewModel)
             }
         }
         .onAppear { vm.start(range: dateRange) }
         .onDisappear { vm.stop() }
         .onChange(of: dateRange) { _ in vm.start(range: dateRange) }
+        .jtNavigationBarStyle()
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if authViewModel.isSupervisorFlag || authViewModel.isAdminFlag {
@@ -240,21 +243,47 @@ struct SupervisorDashboardView: View {
     }
 
     // MARK: – Styled sections matching Dashboard
+    private var header: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            Text("Supervisor")
+                .font(JTTypography.screenTitle)
+                .foregroundStyle(JTColors.textPrimary)
+            Text("Filter crew jobs by role, status, and date range.")
+                .font(JTTypography.caption)
+                .foregroundStyle(JTColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: JTSpacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(JTColors.textMuted)
+            TextField("Search address, job #, notes…", text: $searchText)
+                .font(JTTypography.body)
+                .foregroundStyle(JTColors.textPrimary)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+        }
+        .padding(JTSpacing.md)
+        .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)
+    }
+
     private func sectionHeader(_ title: String) -> some View {
         HStack {
             Text(title)
-                .font(.title3).bold()
-                .foregroundColor(.white)
+                .font(JTTypography.title3)
+                .foregroundStyle(JTColors.textPrimary)
             Spacer()
         }
-        .padding(.top, 8)
+        .padding(.top, JTSpacing.sm)
     }
 
     private func dayHeader(_ date: Date) -> some View {
         HStack {
             Text(dayString(date))
-                .font(.subheadline).bold()
-                .foregroundColor(.white.opacity(0.85))
+                .font(JTTypography.captionEmphasized)
+                .foregroundStyle(JTColors.textSecondary)
             Spacer()
         }
     }
@@ -283,7 +312,7 @@ struct SupervisorDashboardView: View {
                     Button("This month") { setPresetThisMonth() }
                 } label: {
                     Label("Quick Range", systemImage: "calendar.badge.clock")
-                        .foregroundColor(.white)
+                        .foregroundStyle(JTColors.textPrimary)
                 }
                 Spacer(minLength: 0)
             }
@@ -291,37 +320,38 @@ struct SupervisorDashboardView: View {
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("From")
-                        .font(.footnote)
-                        .foregroundColor(.white.opacity(0.8))
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
                     DatePicker(
                         "From",
                         selection: Binding(get: { dateRange.start }, set: { dateRange = DateInterval(start: $0, end: dateRange.end) }),
                         displayedComponents: .date
                     )
                     .labelsHidden()
+                    .tint(JTColors.accent)
                     .accessibilityLabel("From")
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("To")
-                        .font(.footnote)
-                        .foregroundColor(.white.opacity(0.8))
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
                     DatePicker(
                         "To",
                         selection: Binding(get: { dateRange.end }, set: { dateRange = DateInterval(start: dateRange.start, end: $0) }),
                         displayedComponents: .date
                     )
                     .labelsHidden()
+                    .tint(JTColors.accent)
                     .accessibilityLabel("To")
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.top, 4)
         }
-        .padding(12)
-        .background(Color.black.opacity(0.25))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(JTSpacing.md)
+        .jtGlassBackground(cornerRadius: JTShapes.cardCornerRadius)
     }
 
     private func setPreset(days: Int) {
@@ -411,6 +441,56 @@ struct SupervisorDashboardView: View {
         return [first, last].filter { !$0.isEmpty }.joined(separator: " ")
     }
 
+    private func supervisorSearchMetadata(for job: Job) -> JobSearchViewModel.Result {
+        let addressParts = job.address
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let primaryAddress = addressParts.first ?? job.address.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondaryAddress = addressParts.dropFirst().joined(separator: ", ")
+        let creatorID = job.createdBy
+        let creatorUser = creatorID.flatMap { usersViewModel.user(id: $0) }
+        let creator = creatorUser.map { user in
+            JobSearchViewModel.Result.Creator(
+                id: user.id,
+                name: resolveUserName(forUserId: user.id),
+                role: CrewPosition.normalizedKey(from: user.position)
+            )
+        }
+
+        return JobSearchViewModel.Result(
+            id: job.id,
+            address: .init(
+                primary: primaryAddress.isEmpty ? job.address : primaryAddress,
+                secondary: secondaryAddress.isEmpty ? nil : secondaryAddress
+            ),
+            jobNumber: job.jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            status: CrewPosition.statusDisplayName(from: job.status),
+            date: job.date,
+            creator: creator,
+            snippet: supervisorSnippet(for: job),
+            isOwnedByCurrentUser: job.createdBy == authViewModel.currentUser?.id || job.assignedTo == authViewModel.currentUser?.id
+        )
+    }
+
+    private func supervisorSnippet(for job: Job) -> JobSearchViewModel.Result.DetailSnippet? {
+        let candidates: [(String, String?)] = [
+            ("Portal ID", job.portalID),
+            ("Location Number", job.locationNumber),
+            ("Assignment", job.assignments),
+            ("Materials", job.materialsUsed),
+            ("Notes", job.notes),
+            ("NID Footage", job.nidFootage),
+            ("CAN Footage", job.canFootage)
+        ]
+
+        for (title, value) in candidates {
+            if let text = value?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+                return .init(title: title, value: text)
+            }
+        }
+        return nil
+    }
+
     // Summary chips
     private var summaryRow: some View {
         HStack(spacing: 12) {
@@ -426,12 +506,11 @@ struct SupervisorDashboardView: View {
             Image(systemName: system)
             Text(text)
         }
-        .font(.caption)
-        .padding(.vertical, 6)
-        .padding(.horizontal, 10)
-        .background(Color.black.opacity(0.15))
-        .clipShape(Capsule())
-        .foregroundColor(.white)
+        .font(JTTypography.captionEmphasized)
+        .padding(.vertical, JTSpacing.sm)
+        .padding(.horizontal, JTSpacing.md)
+        .background(JTColors.glassHighlight, in: Capsule(style: .continuous))
+        .foregroundStyle(JTColors.textPrimary)
     }
 }
 
@@ -447,27 +526,27 @@ private struct SupervisorJobRow: View {
             header
             metadata
         }
-        .padding(16)
-        .supervisorGlassCard(cornerRadius: 16, shadow: 12)
+        .padding(JTSpacing.lg)
+        .jtGlassBackground(cornerRadius: JTShapes.cardCornerRadius)
+        .jtShadow(JTElevations.card)
     }
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(job.address)
-                .font(.headline.weight(.semibold))
-                .foregroundColor(.white)
+                .font(JTTypography.headline)
+                .foregroundStyle(JTColors.textPrimary)
                 .lineLimit(2)
                 .truncationMode(.tail)
 
             Spacer(minLength: 8)
 
             Text(job.displayStatus)
-                .font(.caption.weight(.semibold))
-                .foregroundColor(.white)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(statusBadgeColor)
-                .clipShape(Capsule())
+                .font(JTTypography.captionEmphasized)
+                .foregroundStyle(JTColors.textPrimary)
+                .padding(.horizontal, JTSpacing.md)
+                .padding(.vertical, JTSpacing.sm)
+                .background(statusBadgeColor, in: Capsule(style: .continuous))
         }
     }
 
@@ -482,24 +561,27 @@ private struct SupervisorJobRow: View {
                     } icon: {
                         Image(systemName: item.icon)
                     }
-                    .font(.caption)
-                    .foregroundColor(.white.opacity(0.85))
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             hoursBadge
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(JTColors.textSecondary)
         }
     }
 
     private var hoursBadge: some View {
         Text(hoursText)
-            .font(.caption.weight(.semibold))
-            .foregroundColor(.white)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(Color.white.opacity(0.16))
-            .clipShape(Capsule())
+            .font(JTTypography.captionEmphasized)
+            .foregroundStyle(JTColors.textPrimary)
+            .padding(.horizontal, JTSpacing.md)
+            .padding(.vertical, JTSpacing.sm)
+            .background(JTColors.glassHighlight, in: Capsule(style: .continuous))
     }
 
     private var hoursText: String {
@@ -545,7 +627,7 @@ private struct SupervisorJobRow: View {
     }
 
     private var statusBadgeColor: Color {
-        job.status.lowercased() == "pending" ? Color.orange.opacity(0.35) : Color.teal.opacity(0.35)
+        job.status.lowercased() == "pending" ? JTColors.warning.opacity(0.28) : JTColors.success.opacity(0.28)
     }
 
     private func dateString(_ d: Date) -> String {
@@ -555,19 +637,10 @@ private struct SupervisorJobRow: View {
     }
 }
 
-private extension View {
-    func supervisorGlassCard(cornerRadius: CGFloat = 16, shadow: CGFloat = 10) -> some View {
-        self
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(.ultraThinMaterial)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .shadow(color: Color.black.opacity(0.20), radius: shadow, x: 0, y: 6)
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }
 
@@ -651,7 +724,7 @@ struct SupervisorCreateJobView: View {
         NavigationStack {
             ZStack {
                 JTGradients.background(stops: 4)
-                .ignoresSafeArea()
+                    .ignoresSafeArea()
 
                 Form {
                     // Worker Role filter
@@ -670,7 +743,7 @@ struct SupervisorCreateJobView: View {
                                     .font(.body)
                                 Text(roleFilter == .all ? "Choose from all users" : "Filtered by \(roleFilter.rawValue)")
                                     .font(.caption)
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(JTColors.textMuted)
                             }
                             Spacer()
                             Button {
@@ -716,7 +789,7 @@ struct SupervisorCreateJobView: View {
                                                 VStack(alignment: .leading, spacing: 2) {
                                                     Text(item.title).font(.body)
                                                     if !item.subtitle.isEmpty {
-                                                        Text(item.subtitle).font(.caption).foregroundColor(.secondary)
+                                                        Text(item.subtitle).font(.caption).foregroundStyle(JTColors.textMuted)
                                                     }
                                                 }
                                                 Spacer()
@@ -771,7 +844,7 @@ struct SupervisorCreateJobView: View {
                             .disableAutocorrection(true)
                         Text("Enter the Gibson portal edit ID, or paste the full portal link and the app will store the ID.")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(JTColors.textMuted)
                         if isPortalIDInvalid {
                             Text("Enter a numeric Portal ID or paste a Gibson portal edit link.")
                                 .font(.caption)
@@ -786,7 +859,7 @@ struct SupervisorCreateJobView: View {
                             .disableAutocorrection(true)
                         Text("Use this when there is no Portal ID. Enter the location number or paste a Gibson consumer search link.")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(JTColors.textMuted)
                         if isLocationNumberInvalid {
                             Text("Enter a numeric location number or paste a Gibson consumer search link.")
                                 .font(.caption)
@@ -844,7 +917,10 @@ struct SupervisorCreateJobView: View {
     }
 
     private func saveJob() {
-        guard let supervisorID = authViewModel.currentUser?.id else { dismiss(); return }
+        guard let supervisorID = authViewModel.currentUser?.id else {
+            dismiss()
+            return
+        }
 
         // New jobs created by supervisors always start as Pending
         let finalStatus = "Pending"
@@ -895,7 +971,11 @@ private struct UserSelectSheet: View {
                         HStack {
                             Image(systemName: "person.crop.circle")
                             Text("Unassigned")
-                            if selectedUserID == nil { Spacer(); Image(systemName: "checkmark").foregroundColor(.accentColor) }
+                            if selectedUserID == nil {
+                                Spacer()
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.accentColor)
+                            }
                         }
                     }
                 }
@@ -913,7 +993,7 @@ private struct UserSelectSheet: View {
                                     Text("\(u.firstName) \(u.lastName)")
                                     Text(normalizedRole(u.position))
                                         .font(.caption)
-                                        .foregroundColor(.secondary)
+                                        .foregroundStyle(JTColors.textMuted)
                                 }
                                 Spacer()
                                 if selectedUserID == u.id {
@@ -926,12 +1006,12 @@ private struct UserSelectSheet: View {
             }
             .navigationTitle("Choose User")
             .searchable(text: $search, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search users…")
+            .jtNavigationBarStyle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") { dismiss() }
                 }
             }
-            .jtNavigationBarStyle()
         }
     }
 

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -5,6 +5,7 @@ import CoreLocation
 struct JobSearchDetailView: View {
     let job: Job
     let metadata: JobSearchViewModel.Result
+    var showsAddToDashboard = true
 
     @EnvironmentObject private var jobsViewModel: JobsViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
@@ -86,6 +87,10 @@ struct JobSearchDetailView: View {
             items.append(.init(title: "CAN Footage", value: can, systemImage: "ruler"))
         }
 
+        if let placement = displayValue(job.jobPlacement) {
+            items.append(.init(title: "Placement", value: CrewPosition.positionDisplayName(from: placement), systemImage: "tag"))
+        }
+
         if job.hours > 0 {
             items.append(.init(title: "Hours logged", value: String(format: "%.1f hours", job.hours), systemImage: "clock"))
         }
@@ -129,16 +134,18 @@ struct JobSearchDetailView: View {
         .navigationTitle("Job Details")
         .navigationBarTitleDisplayMode(.inline)
         .safeAreaInset(edge: .bottom) {
-            VStack(spacing: JTSpacing.sm) {
-                JTPrimaryButton(isAdding ? "Adding…" : "Add to Dashboard", systemImage: "plus.circle") {
-                    addToDashboard()
+            if showsAddToDashboard {
+                VStack(spacing: JTSpacing.sm) {
+                    JTPrimaryButton(isAdding ? "Adding…" : "Add to Dashboard", systemImage: "plus.circle") {
+                        addToDashboard()
+                    }
+                    .disabled(isAdding)
                 }
-                .disabled(isAdding)
+                .padding(.horizontal, JTSpacing.lg)
+                .padding(.top, JTSpacing.md)
+                .padding(.bottom, JTSpacing.lg)
+                .background(.ultraThinMaterial)
             }
-            .padding(.horizontal, JTSpacing.lg)
-            .padding(.top, JTSpacing.md)
-            .padding(.bottom, JTSpacing.lg)
-            .background(.ultraThinMaterial)
         }
         .sheet(isPresented: $showShareSheet, onDismiss: {
             shareItems = []


### PR DESCRIPTION
### Motivation
- Modernize and unify the Supervisor screens with consistent glass styling, typography, and color tokens for improved readability and UX.
- Replace legacy `List`-based layouts with scrollable card-based layouts to better surface job and user information and actions.
- Ensure navigation and data contexts flow correctly by passing the necessary environment objects and by providing richer job metadata and snippet generation for detail views.

### Description
- Restyled `SupervisorDashboardView`, `SupervisorHomeDashboardView`, `SupervisorJobImportView`, `SupervisorCreateJobView`, and related subviews to use `JTColors`, `JTTypography`, `GlassCard`, `.jtGlassBackground`, and `.jtNavigationBarStyle()` for a consistent look-and-feel.
- Replaced `List` usages with `ScrollView`/`LazyVStack` and new card rows, added `SupervisorUserRow`, and updated navigation links to use `NavigationStack` / `navigationDestination` for `Job` items while injecting `jobsViewModel`, `usersViewModel`, and `authViewModel` into pushed views.
- Added helpers to construct `JobSearchViewModel.Result` metadata and detail snippets (`supervisorSearchMetadata`, `supervisorSnippet`, `supervisorHomeMetadata`, `supervisorHomeSnippet`) and a small `String` extension `nilIfEmpty` to simplify optional trimming logic.
- Overhauled the job import UI with header, image preview, parsing progress card, parsed entry cards and improved import/review action UI, plus various small UX fixes across create job and user selection flows.

### Testing
- Built the project and ran the existing automated unit test suite; all tests passed.
- Executed the existing automated UI/navigation tests covering supervisor flows; they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18fceff028832db9da4285798c8b5f)