### PR TITLE
UI overhaul: Universal Job Detail, supervisor/job interactions, and timesheet/yellow-sheet restyling

### DIFF
--- a/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
+++ b/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
@@ -16,6 +16,15 @@ struct SupervisorHomeDashboardView: View {
                     VStack(alignment: .leading, spacing: JTSpacing.lg) {
                         header
                         datePickerCard
+
+                        if viewModel.isLoading {
+                            supervisorHomeStateCard(title: "Loading crew jobs…", systemImage: "hourglass")
+                        }
+
+                        if let error = viewModel.errorMessage {
+                            supervisorHomeStateCard(title: "Unable to load crew jobs", systemImage: "exclamationmark.triangle", message: error)
+                        }
+
                         positionGrid
                     }
                     .padding(.horizontal, JTSpacing.lg)
@@ -57,6 +66,27 @@ struct SupervisorHomeDashboardView: View {
                     .foregroundStyle(JTColors.textPrimary)
                     .tint(JTColors.accent)
             }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private func supervisorHomeStateCard(title: String, systemImage: String, message: String? = nil) -> some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+            VStack(spacing: JTSpacing.sm) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 28))
+                    .foregroundStyle(message == nil ? JTColors.textMuted : JTColors.error)
+                Text(title)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                if let message {
+                    Text(message)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
             .padding(JTSpacing.lg)
         }
     }
@@ -274,6 +304,8 @@ private struct SupervisorUserJobsView: View {
     let date: Date
     let jobs: [Job]
 
+    @State private var selectedJob: Job?
+
     var body: some View {
         ZStack {
             JTGradients.background
@@ -291,10 +323,16 @@ private struct SupervisorUserJobsView: View {
                         }
                     } else {
                         ForEach(jobs) { job in
-                            GlassCard {
-                                SupervisorUserJobInfoCard(job: job)
-                                    .padding(JTSpacing.lg)
+                            Button {
+                                selectedJob = job
+                            } label: {
+                                GlassCard {
+                                    SupervisorUserJobInfoCard(job: job)
+                                        .padding(JTSpacing.lg)
+                                }
                             }
+                            .buttonStyle(.plain)
+                            .accessibilityHint("Opens the full job details")
                         }
                     }
                 }
@@ -304,6 +342,9 @@ private struct SupervisorUserJobsView: View {
         .navigationTitle(displayName)
         .navigationBarTitleDisplayMode(.inline)
         .jtNavigationBarStyle()
+        .sheet(item: $selectedJob) { job in
+            UniversalJobDetailView(job: job, showsDoneButton: true)
+        }
     }
 
     private var displayName: String {
@@ -338,7 +379,15 @@ private struct SupervisorUserJobInfoCard: View {
                     .foregroundStyle(statusTint)
             }
 
-            detailRows
+            HStack(alignment: .top, spacing: JTSpacing.sm) {
+                VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                    detailRows
+                }
+                Spacer(minLength: JTSpacing.sm)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(JTColors.textMuted)
+            }
         }
     }
 
@@ -365,7 +414,7 @@ private struct SupervisorUserJobInfoCard: View {
     }
 
     private var statusTint: Color {
-        job.status.lowercased() == "pending" ? Color.orange : JTColors.success
+        universalStatusColor(job.status)
     }
 
     private func detailRow(_ title: String, _ value: String) -> some View {

--- a/Job Tracker/Features/Jobs/Editor/SupervisorJobImportView.swift
+++ b/Job Tracker/Features/Jobs/Editor/SupervisorJobImportView.swift
@@ -100,109 +100,32 @@ struct SupervisorJobImportView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 20) {
-                if let img = pickedImage {
-                    Image(uiImage: img)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(maxHeight: 200)
-                }
+            ZStack {
+                JTGradients.background(stops: 4)
+                    .ignoresSafeArea()
 
-                Button("Select Job Sheet") { showImagePicker = true }
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                        headerCard
+                        actionCard
 
-                Button("Parse Sheet") { runParsing() }
-                    .disabled(pickedImage == nil || isParsing)
-
-                if isParsing { ProgressView() }
-
-                if let err = parsingError {
-                    Text(err.localizedDescription).foregroundColor(.red)
-                }
-
-                if parsedEntries.isEmpty {
-                    Text("No job sheet selected")
-                        .foregroundColor(.secondary)
-                } else {
-                    List(parsedEntries) { entry in
-                        HStack(alignment: .top, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(entry.resolvedAddress)
-                                    .font(.headline)
-
-                                if let jobNumber = entry.jobNumber {
-                                    Text("Job #: \(jobNumber)")
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                }
-
-                                if let assignee = assigneeDisplayName(for: entry) {
-                                    Text("Assignee: \(assignee)")
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                }
-
-                                if let notes = entry.notes {
-                                    Text(notes)
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                } else if let fallbackNotes = entry.resolvedNotes {
-                                    Text(fallbackNotes)
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                }
-
-                                if entry.notes != nil,
-                                   let raw = entry.rawText,
-                                   !raw.isEmpty,
-                                   raw.caseInsensitiveCompare(entry.resolvedAddress) != .orderedSame {
-                                    Text("Original: \(raw)")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-
-                            Spacer()
-
-                            if confirmed.contains(token(for: entry)) {
-                                Image(systemName: "checkmark.circle")
-                                    .foregroundColor(.green)
-                            } else if pending.contains(token(for: entry)) {
-                                ProgressView()
-                            } else {
-                                VStack(alignment: .trailing, spacing: 8) {
-                                    Button("Import") {
-                                        let fields = fields(for: entry)
-                                        let supervisorID = authViewModel.currentUser?.id
-                                        let job = Job(
-                                            address: fields.address,
-                                            date: fields.date,
-                                            status: "Pending",
-                                            assignedTo: fields.assigneeID ?? "",
-                                            createdBy: supervisorID ?? "",
-                                            notes: fields.notes ?? "",
-                                            jobNumber: fields.jobNumber,
-                                            assignments: nil,
-                                            materialsUsed: "",
-                                            latitude: nil,
-                                            longitude: nil
-                                        )
-                                        importEntry(job, for: entry)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .disabled(!entry.hasResolvableAddress)
-
-                                    Button("Review…") {
-                                        reviewFields = fields(for: entry)
-                                        showReview = true
-                                    }
-                                    .disabled(!entry.hasResolvableAddress)
-                                }
+                        if let err = parsingError {
+                            GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                                Label(err.localizedDescription, systemImage: "exclamationmark.triangle")
+                                    .font(JTTypography.subheadline)
+                                    .foregroundStyle(JTColors.error)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(JTSpacing.lg)
                             }
                         }
+
+                        parsedEntriesSection
                     }
+                    .padding(JTSpacing.lg)
                 }
             }
-            .padding()
+            .navigationTitle("Import Job Sheet")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
@@ -232,6 +155,211 @@ struct SupervisorJobImportView: View {
                 showImagePicker = true
             }
         }
+    }
+
+    private var headerCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Label("Supervisor Import", systemImage: "doc.text.viewfinder")
+                    .font(JTTypography.title3)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Text("Choose a job sheet image, parse it, then import or review each job before it is assigned.")
+                    .font(JTTypography.subheadline)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let img = pickedImage {
+                    Image(uiImage: img)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 180)
+                        .clipShape(JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius))
+                        .overlay {
+                            JTShapes.roundedRectangle(cornerRadius: JTShapes.smallCardCornerRadius)
+                                .stroke(JTColors.glassSoftStroke, lineWidth: 1)
+                        }
+                } else {
+                    HStack(spacing: JTSpacing.sm) {
+                        Image(systemName: "photo")
+                        Text("No job sheet selected")
+                    }
+                    .font(JTTypography.subheadline)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, JTSpacing.xl)
+                    .jtGlassBackground(cornerRadius: JTShapes.smallCardCornerRadius, strokeColor: JTColors.glassSoftStroke)
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private var actionCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+            VStack(spacing: JTSpacing.md) {
+                Button {
+                    showImagePicker = true
+                } label: {
+                    Label("Select Job Sheet", systemImage: "photo.on.rectangle")
+                        .font(JTTypography.button)
+                        .foregroundStyle(JTColors.textPrimary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, JTSpacing.md)
+                        .jtGlassBackground(cornerRadius: JTShapes.buttonCornerRadius, strokeColor: JTColors.glassSoftStroke)
+                }
+                .buttonStyle(.plain)
+
+                JTPrimaryButton(isParsing ? "Parsing…" : "Parse Sheet", systemImage: "wand.and.stars") {
+                    runParsing()
+                }
+                .disabled(pickedImage == nil || isParsing)
+
+                if isParsing {
+                    ProgressView("Reading job sheet…")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .tint(JTColors.accent)
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    @ViewBuilder
+    private var parsedEntriesSection: some View {
+        if parsedEntries.isEmpty {
+            GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                VStack(spacing: JTSpacing.sm) {
+                    Image(systemName: "tray")
+                        .font(.system(size: 34))
+                        .foregroundStyle(JTColors.textMuted)
+                    Text("No parsed jobs yet")
+                        .font(JTTypography.headline)
+                        .foregroundStyle(JTColors.textPrimary)
+                    Text("Parsed jobs will appear here with import and review actions.")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(JTSpacing.xl)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Text("Parsed Jobs")
+                    .font(JTTypography.title3)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                ForEach(parsedEntries) { entry in
+                    parsedEntryCard(entry)
+                }
+            }
+        }
+    }
+
+    private func parsedEntryCard(_ entry: ParsedEntry) -> some View {
+        let entryToken = token(for: entry)
+        return GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                HStack(alignment: .top, spacing: JTSpacing.sm) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(entry.resolvedAddress)
+                            .font(JTTypography.headline)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        HStack(spacing: JTSpacing.xs) {
+                            if let jobNumber = entry.jobNumber {
+                                importChip("#\(jobNumber)", tint: JTColors.accent)
+                            }
+                            if let assignee = assigneeDisplayName(for: entry) {
+                                importChip(assignee, tint: JTColors.info)
+                            }
+                        }
+                    }
+
+                    Spacer(minLength: JTSpacing.sm)
+
+                    if confirmed.contains(entryToken) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(JTColors.success)
+                    } else if pending.contains(entryToken) {
+                        ProgressView()
+                            .tint(JTColors.accent)
+                    }
+                }
+
+                if let notes = entry.notes ?? entry.resolvedNotes {
+                    Text(notes)
+                        .font(JTTypography.subheadline)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if entry.notes != nil,
+                   let raw = entry.rawText,
+                   !raw.isEmpty,
+                   raw.caseInsensitiveCompare(entry.resolvedAddress) != .orderedSame {
+                    Text("Original: \(raw)")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if !confirmed.contains(entryToken) && !pending.contains(entryToken) {
+                    HStack(spacing: JTSpacing.sm) {
+                        Button {
+                            let fields = fields(for: entry)
+                            let supervisorID = authViewModel.currentUser?.id
+                            let job = Job(
+                                address: fields.address,
+                                date: fields.date,
+                                status: "Pending",
+                                assignedTo: fields.assigneeID ?? "",
+                                createdBy: supervisorID ?? "",
+                                notes: fields.notes ?? "",
+                                jobNumber: fields.jobNumber,
+                                assignments: nil,
+                                materialsUsed: "",
+                                latitude: nil,
+                                longitude: nil
+                            )
+                            importEntry(job, for: entry)
+                        } label: {
+                            Label("Import", systemImage: "tray.and.arrow.down")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(JTColors.accent)
+                        .disabled(!entry.hasResolvableAddress)
+
+                        Button {
+                            reviewFields = fields(for: entry)
+                            showReview = true
+                        } label: {
+                            Label("Review", systemImage: "square.and.pencil")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(JTColors.accent)
+                        .disabled(!entry.hasResolvableAddress)
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private func importChip(_ text: String, tint: Color) -> some View {
+        Text(text)
+            .font(JTTypography.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(tint)
+            .padding(.vertical, 5)
+            .padding(.horizontal, JTSpacing.sm)
+            .background(tint.opacity(0.16), in: Capsule())
     }
 
     // MARK: - Helpers

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -91,12 +91,13 @@ final class SupervisorJobsViewModel: ObservableObject {
 }
 
 // MARK: - UI helpers
+@MainActor
 private func roleColor(_ role: SupervisorRole) -> Color {
     switch role {
-    case .ug:     return Color.green.opacity(0.35)
-    case .oh: return Color.blue.opacity(0.35)
-    case .can:    return Color.orange.opacity(0.35)
-    case .nid:    return Color.purple.opacity(0.35)
+    case .ug:     return JTColors.success.opacity(0.35)
+    case .oh: return JTColors.info.opacity(0.35)
+    case .can:    return JTColors.warning.opacity(0.35)
+    case .nid:    return JTColors.accent.opacity(0.35)
     }
 }
 
@@ -109,6 +110,7 @@ struct SupervisorDashboardView: View {
     @StateObject private var vm = SupervisorJobsViewModel()
     @State private var showingCreate = false
     @State private var showingImport = false
+    @State private var selectedJob: Job?
 
     @State private var role: SupervisorRole = .ug
     @State private var status: StatusFilter = .all
@@ -138,6 +140,14 @@ struct SupervisorDashboardView: View {
                     summaryRow
                         .padding(.top, 4)
 
+                    if vm.isLoading {
+                        supervisorStateCard(title: "Loading jobs…", systemImage: "hourglass")
+                    }
+
+                    if let error = vm.error {
+                        supervisorStateCard(title: "Unable to load jobs", systemImage: "exclamationmark.triangle", message: error)
+                    }
+
                     // Pending section
                     if !pendingJobs.isEmpty {
                         sectionHeader("Not Completed")
@@ -146,11 +156,17 @@ struct SupervisorDashboardView: View {
                             ForEach(pendingGroups, id: \.key) { day, jobs in
                                 dayHeader(day)
                                 ForEach(jobs, id: \.id) { job in
-                                    SupervisorJobRow(
-                                        job: job,
-                                        userRoleResolver: resolveRole(forUserId:),
-                                        userNameResolver: resolveUserName(forUserId:)
-                                    )
+                                    Button {
+                                        selectedJob = job
+                                    } label: {
+                                        SupervisorJobRow(
+                                            job: job,
+                                            userRoleResolver: resolveRole(forUserId:),
+                                            userNameResolver: resolveUserName(forUserId:)
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityHint("Opens the full job details")
                                 }
                             }
                         }
@@ -164,11 +180,17 @@ struct SupervisorDashboardView: View {
                             ForEach(completedGroups, id: \.key) { day, jobs in
                                 dayHeader(day)
                                 ForEach(jobs, id: \.id) { job in
-                                    SupervisorJobRow(
-                                        job: job,
-                                        userRoleResolver: resolveRole(forUserId:),
-                                        userNameResolver: resolveUserName(forUserId:)
-                                    )
+                                    Button {
+                                        selectedJob = job
+                                    } label: {
+                                        SupervisorJobRow(
+                                            job: job,
+                                            userRoleResolver: resolveRole(forUserId:),
+                                            userNameResolver: resolveUserName(forUserId:)
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityHint("Opens the full job details")
                                 }
                             }
                         }
@@ -205,6 +227,9 @@ struct SupervisorDashboardView: View {
                     .accessibilityLabel("Create or Import Job")
                 }
             }
+        }
+        .sheet(item: $selectedJob) { job in
+            UniversalJobDetailView(job: job, showsDoneButton: true)
         }
         .sheet(isPresented: $showingCreate) {
             SupervisorCreateJobView()
@@ -249,6 +274,27 @@ struct SupervisorDashboardView: View {
         }
         .padding(JTSpacing.md)
         .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)
+    }
+
+    private func supervisorStateCard(title: String, systemImage: String, message: String? = nil) -> some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+            VStack(spacing: JTSpacing.sm) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 28))
+                    .foregroundStyle(message == nil ? JTColors.textMuted : JTColors.error)
+                Text(title)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                if let message {
+                    Text(message)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(JTSpacing.lg)
+        }
     }
 
     private func sectionHeader(_ title: String) -> some View {
@@ -500,6 +546,10 @@ private struct SupervisorJobRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             hoursBadge
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(JTColors.textMuted)
         }
     }
 
@@ -555,7 +605,7 @@ private struct SupervisorJobRow: View {
     }
 
     private var statusBadgeColor: Color {
-        job.status.lowercased() == "pending" ? JTColors.warning.opacity(0.28) : JTColors.success.opacity(0.28)
+        universalStatusColor(job.status).opacity(0.22)
     }
 
     private func dateString(_ d: Date) -> String {
@@ -721,8 +771,8 @@ struct SupervisorCreateJobView: View {
                                                         .font(.caption.bold())
                                                         .padding(.vertical, 5)
                                                         .padding(.horizontal, 8)
-                                                        .background(Capsule().fill(Color(.secondarySystemBackground)))
-                                                        .overlay(Capsule().stroke(Color.gray.opacity(0.25)))
+                                                        .background(JTColors.glassHighlight, in: Capsule())
+                                                        .overlay(Capsule().stroke(JTColors.glassSoftStroke))
                                                 }
                                             }
                                             .padding(.vertical, 10)
@@ -736,15 +786,8 @@ struct SupervisorCreateJobView: View {
                                         }
                                     }
                                 }
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .fill(Color(.systemBackground))
-                                        .shadow(radius: 6)
-                                )
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .stroke(Color.gray.opacity(0.2))
-                                )
+                                .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)
+                                .jtShadow(JTElevations.card)
                                 .padding(.top, 44)
                             }
                         }
@@ -770,7 +813,7 @@ struct SupervisorCreateJobView: View {
                         if isPortalIDInvalid {
                             Text("Enter a numeric Portal ID or paste a Gibson portal edit link.")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                .foregroundStyle(JTColors.error)
                         }
                     }
 
@@ -785,7 +828,7 @@ struct SupervisorCreateJobView: View {
                         if isLocationNumberInvalid {
                             Text("Enter a numeric location number or paste a Gibson consumer search link.")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                .foregroundStyle(JTColors.error)
                         }
                     }
 
@@ -798,6 +841,8 @@ struct SupervisorCreateJobView: View {
                     }
                 }
                 .scrollContentBackground(.hidden)
+                .tint(JTColors.accent)
+                .foregroundStyle(JTColors.textPrimary)
             }
             .navigationTitle("New Job")
             .navigationBarTitleDisplayMode(.inline)
@@ -896,7 +941,7 @@ private struct UserSelectSheet: View {
                             if selectedUserID == nil {
                                 Spacer()
                                 Image(systemName: "checkmark")
-                                    .foregroundColor(.accentColor)
+                                    .foregroundStyle(JTColors.accent)
                             }
                         }
                     }
@@ -919,7 +964,7 @@ private struct UserSelectSheet: View {
                                 }
                                 Spacer()
                                 if selectedUserID == u.id {
-                                    Image(systemName: "checkmark.circle.fill").foregroundColor(.accentColor)
+                                    Image(systemName: "checkmark.circle.fill").foregroundStyle(JTColors.accent)
                                 }
                             }
                         }

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -637,3 +637,315 @@ private struct QuickActionButton: View {
         .buttonStyle(.plain)
     }
 }
+
+
+// MARK: - Shared job detail presentation
+
+struct UniversalJobDetailView: View {
+    let job: Job
+    var showsDoneButton = false
+
+    @EnvironmentObject private var usersViewModel: UsersViewModel
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
+
+    private var summaryTitle: String {
+        displayValue(job.shortAddress).flatMap { $0.isEmpty ? nil : $0 } ?? displayValue(job.address) ?? "Job"
+    }
+
+    private var assignedToText: String? {
+        guard let assignedID = job.assignedTo else { return nil }
+        return displayName(for: assignedID)
+    }
+
+    private var creatorText: String? {
+        guard let creatorID = job.createdBy else { return nil }
+        return displayName(for: creatorID)
+    }
+
+    private var detailItems: [UniversalJobInfoItem] {
+        var items: [UniversalJobInfoItem] = []
+
+        if let jobNumber = displayValue(job.jobNumber) {
+            items.append(.init(title: "Job Number", value: jobNumber, systemImage: "number"))
+        }
+        items.append(.init(title: "Status", value: job.displayStatus, systemImage: "flag.fill"))
+        items.append(.init(title: "Date", value: job.date.formatted(date: .abbreviated, time: .omitted), systemImage: "calendar"))
+        if let assignedToText {
+            items.append(.init(title: "Assigned to", value: assignedToText, systemImage: "person.crop.circle"))
+        }
+        if let creatorText {
+            items.append(.init(title: "Created by", value: creatorText, systemImage: "person.badge.key"))
+        }
+        if let portalID = displayValue(job.portalID) {
+            items.append(.init(title: "Portal ID", value: portalID, systemImage: "safari"))
+        }
+        if let locationNumber = displayValue(job.locationNumber) {
+            items.append(.init(title: "Location Number", value: locationNumber, systemImage: "mappin.and.ellipse"))
+        }
+        if let assignments = displayValue(job.assignments) {
+            items.append(.init(title: "Assignment", value: assignments, systemImage: "list.number"))
+        }
+        if let placement = displayValue(job.jobPlacement) {
+            items.append(.init(title: "Placement", value: placement, systemImage: "arrow.triangle.branch"))
+        }
+        if let nid = displayValue(job.nidFootage) {
+            items.append(.init(title: "NID Footage", value: nid, systemImage: "ruler"))
+        }
+        if let can = displayValue(job.canFootage) {
+            items.append(.init(title: "CAN Footage", value: can, systemImage: "ruler"))
+        }
+        if job.hours > 0 {
+            items.append(.init(title: "Hours logged", value: String(format: "%.1f hours", job.hours), systemImage: "clock"))
+        }
+
+        return items
+    }
+
+    private var photoURLStrings: [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for urlString in [job.housePhotoURL, job.nidPhotoURL, job.canPhotoURL].compactMap({ $0 }) + job.photos {
+            let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { continue }
+            ordered.append(trimmed)
+        }
+        return ordered
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .top) {
+                JTGradients.background(stops: 4)
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: JTSpacing.xl) {
+                        summaryCard
+
+                        if !detailItems.isEmpty {
+                            UniversalJobInfoCard(title: "Job information", items: detailItems)
+                        }
+
+                        if let materials = displayValue(job.materialsUsed) {
+                            UniversalJobTextCard(title: "Materials", systemImage: "shippingbox", text: materials)
+                        }
+
+                        if let notes = displayValue(job.notes) {
+                            UniversalJobTextCard(title: "Notes", systemImage: "note.text", text: notes)
+                        }
+
+                        if !photoURLStrings.isEmpty {
+                            PhotosSection(photos: photoURLStrings)
+                        }
+                    }
+                    .padding(.horizontal, JTSpacing.lg)
+                    .padding(.vertical, JTSpacing.xl)
+                }
+            }
+            .navigationTitle("Job Details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if showsDoneButton {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+            }
+        }
+        .jtNavigationBarStyle()
+    }
+
+    private var summaryCard: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                HStack(alignment: .top, spacing: JTSpacing.sm) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(summaryTitle)
+                            .font(JTTypography.title3)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .lineLimit(3)
+
+                        if displayValue(job.shortAddress) != displayValue(job.address), let address = displayValue(job.address) {
+                            Text(address)
+                                .font(JTTypography.subheadline)
+                                .foregroundStyle(JTColors.textSecondary)
+                                .lineLimit(3)
+                        }
+                    }
+                    Spacer(minLength: JTSpacing.sm)
+                    if let jobNumber = displayValue(job.jobNumber) {
+                        Text("#\(jobNumber)")
+                            .font(JTTypography.caption)
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 10)
+                            .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+                            .foregroundStyle(JTColors.textPrimary)
+                    }
+                }
+
+                HStack(spacing: JTSpacing.sm) {
+                    Text(job.displayStatus)
+                        .font(JTTypography.caption)
+                        .fontWeight(.semibold)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 10)
+                        .background(universalStatusColor(job.status).opacity(0.18), in: Capsule())
+                        .foregroundStyle(universalStatusColor(job.status))
+
+                    Text(job.date, style: .date)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+
+                HStack(spacing: JTSpacing.sm) {
+                    UniversalQuickActionButton(title: "Directions", systemImage: "map") {
+                        openInMaps(job: job)
+                    }
+
+                    if job.gibsonPortalURL != nil {
+                        UniversalQuickActionButton(title: job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari") {
+                            openPortal(job: job)
+                        }
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private func displayName(for idOrName: String) -> String {
+        let trimmed = idOrName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let user = usersViewModel.usersDict[trimmed] else { return trimmed }
+        let fullName = "\(user.firstName) \(user.lastName)".trimmingCharacters(in: .whitespacesAndNewlines)
+        return fullName.isEmpty ? user.email : fullName
+    }
+
+    private func openPortal(job: Job) {
+        guard let url = job.gibsonPortalURL else { return }
+        UIApplication.shared.open(url)
+    }
+
+    private func openInMaps(job: Job) {
+        guard let encoded = job.address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+        if suggestionProviderRaw == "google",
+           let url = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") {
+            UIApplication.shared.open(url, options: [:]) { success in
+                if success { return }
+                if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
+                    UIApplication.shared.open(appleURL)
+                }
+            }
+            return
+        }
+        if let appleURL = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)") {
+            UIApplication.shared.open(appleURL)
+        }
+    }
+
+    private func displayValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+private struct UniversalJobInfoItem: Identifiable, Hashable {
+    let id = UUID()
+    let title: String
+    let value: String
+    let systemImage: String
+}
+
+private struct UniversalJobInfoCard: View {
+    let title: String
+    let items: [UniversalJobInfoItem]
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Text(title)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    HStack(alignment: .top, spacing: JTSpacing.sm) {
+                        Image(systemName: item.systemImage)
+                            .foregroundStyle(JTColors.textSecondary)
+                            .frame(width: 22)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.title.uppercased())
+                                .font(JTTypography.caption)
+                                .foregroundStyle(JTColors.textSecondary)
+                            Text(item.value)
+                                .font(JTTypography.body)
+                                .foregroundStyle(JTColors.textPrimary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    if index < items.count - 1 {
+                        Divider()
+                            .overlay(JTColors.glassSoftStroke.opacity(0.5))
+                    }
+                }
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
+private struct UniversalJobTextCard: View {
+    let title: String
+    let systemImage: String
+    let text: String
+
+    var body: some View {
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                  strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                Label(title, systemImage: systemImage)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+
+                Text(text)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(JTSpacing.lg)
+        }
+    }
+}
+
+private struct UniversalQuickActionButton: View {
+    let title: String
+    let systemImage: String
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: JTSpacing.xs) {
+                Image(systemName: systemImage)
+                Text(title)
+            }
+            .font(JTTypography.caption)
+            .foregroundStyle(JTColors.textPrimary)
+            .padding(.vertical, JTSpacing.xs)
+            .padding(.horizontal, JTSpacing.sm)
+            .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+@MainActor
+func universalStatusColor(_ status: String) -> Color {
+    let lower = status.lowercased()
+    if lower.contains("complete") || lower.contains("done") { return JTColors.success }
+    if lower.contains("pending") || lower.contains("need") { return JTColors.info }
+    if lower.contains("hold") || lower.contains("talk") { return JTColors.warning }
+    return JTColors.accent
+}

--- a/Job Tracker/Features/Timesheets/DayTimesheetBox.swift
+++ b/Job Tracker/Features/Timesheets/DayTimesheetBox.swift
@@ -17,72 +17,114 @@ struct DayTimesheetBox: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(dateLabel)
-                .font(.headline)
-            
+        VStack(alignment: .leading, spacing: JTSpacing.md) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(dateLabel)
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                Spacer()
+                Text("\(jobs.count) job\(jobs.count == 1 ? "" : "s")")
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+            }
+
             if jobs.isEmpty {
-                Text("No jobs")
-                    .foregroundColor(.gray)
+                emptyState
             } else {
-                headingView
-                ForEach(jobs, id: \.id) { job in
-                    jobRow(job)
+                VStack(spacing: JTSpacing.sm) {
+                    ForEach(jobs, id: \.id) { job in
+                        jobRow(job)
+                    }
                 }
             }
-            
+
             totalHoursView
         }
-        .padding(8)
+        .padding(JTSpacing.lg)
         .frame(minHeight: 130)
-        .overlay(
-            RoundedRectangle(cornerRadius: 4)
-                .stroke(Color.gray, lineWidth: 1)
-        )
     }
-    
+
     // MARK: - Subviews
 
-    private var headingView: some View {
-        HStack {
-            Text("Job #")
-                .frame(width: 60, alignment: .leading)
-            Text("Hours")
-                .frame(width: 50, alignment: .leading)
-            Spacer()
+    private var emptyState: some View {
+        HStack(spacing: JTSpacing.sm) {
+            Image(systemName: "tray")
+            Text("No jobs")
         }
-        .font(.subheadline)
-        .foregroundColor(.blue)
+        .font(JTTypography.subheadline)
+        .foregroundStyle(JTColors.textSecondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, JTSpacing.md)
     }
-    
+
     private func jobRow(_ job: Job) -> some View {
-        HStack {
-            Text(job.jobNumber ?? "")
-                .frame(width: 60, alignment: .leading)
-            Text(String(format: "%.1f", job.hours))
-                .frame(width: 50, alignment: .leading)
-            // Display only the house number and street name.
-            Text(houseNumberAndStreet(from: job.shortAddress))
-            Spacer()
-        }
-        .font(.caption)
-        .contentShape(Rectangle())
-        .onTapGesture {
+        Button {
             onJobTap?(job)
+        } label: {
+            HStack(spacing: JTSpacing.md) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: JTSpacing.xs) {
+                        if let jobNumber = job.jobNumber, !jobNumber.isEmpty {
+                            Text("#\(jobNumber)")
+                                .font(JTTypography.captionEmphasized)
+                                .foregroundStyle(JTColors.textPrimary)
+                        }
+
+                        Text(job.displayStatus)
+                            .font(JTTypography.caption)
+                            .foregroundStyle(universalStatusColor(job.status))
+                            .padding(.horizontal, JTSpacing.sm)
+                            .padding(.vertical, 2)
+                            .background(universalStatusColor(job.status).opacity(0.16), in: Capsule())
+                    }
+
+                    Text(houseNumberAndStreet(from: job.shortAddress))
+                        .font(JTTypography.subheadline)
+                        .foregroundStyle(JTColors.textPrimary)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: JTSpacing.sm)
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(String(format: "%.1f", job.hours))
+                        .font(JTTypography.headline)
+                        .foregroundStyle(JTColors.textPrimary)
+                    Text("hrs")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(JTColors.textMuted)
+            }
+            .padding(JTSpacing.md)
+            .jtGlassBackground(cornerRadius: JTShapes.smallCardCornerRadius, strokeColor: JTColors.glassSoftStroke)
         }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens the full job details")
     }
-    
+
     private var totalHoursView: some View {
-        HStack {
-            Text("Total Hours:")
-                .font(.caption)
-            TextField("Enter total hours", text: $totalHoursEditable)
-                .font(.caption)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .frame(maxWidth: 80)
+        HStack(spacing: JTSpacing.sm) {
+            Label("Total Hours", systemImage: "clock")
+                .font(JTTypography.captionEmphasized)
+                .foregroundStyle(JTColors.textSecondary)
+            Spacer()
+            TextField("0.0", text: $totalHoursEditable)
+                .font(JTTypography.captionEmphasized)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing)
+                .padding(.vertical, JTSpacing.xs)
+                .padding(.horizontal, JTSpacing.sm)
+                .frame(maxWidth: 84)
+                .jtGlassBackground(cornerRadius: JTShapes.chipCornerRadius, strokeColor: JTColors.glassSoftStroke)
+                .foregroundStyle(JTColors.textPrimary)
         }
+        .padding(.top, JTSpacing.xs)
     }
-    
+
     // MARK: - Helper
 
     private var dateLabel: String {
@@ -97,14 +139,14 @@ struct DayTimesheetBox: View {
         if let comma = fullAddress.firstIndex(of: ",") {
             return String(fullAddress[..<comma]).trimmingCharacters(in: .whitespaces)
         }
-        
+
         // 2. Otherwise, keep tokens until we hit a known street suffix or run out.
         let suffixes: Set<String> = [
             "st", "street", "rd", "road", "ave", "avenue",
             "blvd", "circle", "cir", "ln", "lane", "dr", "drive",
             "ct", "court", "pkwy", "pl", "place", "ter", "terrace"
         ]
-        
+
         var resultTokens: [Substring] = []
         for token in fullAddress.split(separator: " ") {
             resultTokens.append(token)

--- a/Job Tracker/Features/Timesheets/PastTimesheetsView.swift
+++ b/Job Tracker/Features/Timesheets/PastTimesheetsView.swift
@@ -3,43 +3,27 @@ import SwiftUI
 struct PastTimesheetsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @StateObject private var timesheetListVM = UserTimesheetsViewModel()
-    
+
     var body: some View {
         NavigationView {
             ZStack {
-                // Background gradient (same as Dashboard/CreateJobView)
                 JTGradients.background(stops: 4)
-                .edgesIgnoringSafeArea(.all)
-                
+                    .ignoresSafeArea()
+
                 List {
                     ForEach(timesheetListVM.timesheets) { timesheet in
                         NavigationLink(destination: TimesheetDetailView(timesheet: timesheet)) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Week Starting: \(formattedDate(timesheet.weekStart))")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                Text("Total Hours: \(timesheet.totalHours)")
-                                    .font(.subheadline)
-                                    .foregroundColor(.white)
-                                if let pdfURL = timesheet.pdfURL, !pdfURL.isEmpty {
-                                    Text("PDF Created")
-                                        .font(.caption)
-                                        .foregroundColor(.green)
-                                } else {
-                                    Text("No PDF Available")
-                                        .font(.caption)
-                                        .foregroundColor(.red)
-                                }
-                            }
+                            PastTimesheetRow(timesheet: timesheet)
                         }
+                        .listRowBackground(Color.clear)
                     }
                     .onDelete(perform: deleteSheet)
                 }
-                .listStyle(GroupedListStyle())
-                // This modifier makes the List’s background transparent.
+                .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Past Timesheets")
+            .navigationBarTitleDisplayMode(.inline)
             .jtNavigationBarStyle()
             .onAppear {
                 if let user = authViewModel.currentUser {
@@ -48,13 +32,7 @@ struct PastTimesheetsView: View {
             }
         }
     }
-    
-    private func formattedDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        return formatter.string(from: date)
-    }
-    
+
     private func deleteSheet(at offsets: IndexSet) {
         offsets.forEach { index in
             let sheet = timesheetListVM.timesheets[index]
@@ -67,5 +45,39 @@ struct PastTimesheetsView: View {
             }
         }
         timesheetListVM.timesheets.remove(atOffsets: offsets)
+    }
+}
+
+private struct PastTimesheetRow: View {
+    let timesheet: Timesheet
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Week Starting: \(formattedDate(timesheet.weekStart))")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(JTColors.textMuted)
+            }
+
+            Text("Total Hours: \(timesheet.totalHours)")
+                .font(JTTypography.subheadline)
+                .foregroundStyle(JTColors.textSecondary)
+
+            Label(timesheet.pdfURL?.isEmpty == false ? "PDF Created" : "No PDF Available",
+                  systemImage: timesheet.pdfURL?.isEmpty == false ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(JTTypography.caption)
+                .foregroundStyle(timesheet.pdfURL?.isEmpty == false ? JTColors.success : JTColors.error)
+        }
+        .padding(.vertical, JTSpacing.sm)
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
     }
 }

--- a/Job Tracker/Features/Timesheets/TimesheetDetailView.swift
+++ b/Job Tracker/Features/Timesheets/TimesheetDetailView.swift
@@ -4,61 +4,92 @@ import PDFKit
 struct TimesheetDetailView: View {
     let timesheet: Timesheet
     @State private var showPDFViewer = false
-    
+
     var body: some View {
         ZStack {
-            // Background gradient.
             JTGradients.background(stops: 4)
-                .edgesIgnoringSafeArea(.all)
-            
+                .ignoresSafeArea()
+
             ScrollView {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Week Starting: \(formattedDate(timesheet.weekStart))")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                    Text("Supervisor: \(timesheet.supervisor)")
-                        .foregroundColor(.white)
-                    Text("Name: \(timesheet.name1) \(timesheet.name2)")
-                        .foregroundColor(.white)
-                    Text("Gibson Hours: \(timesheet.gibsonHours)")
-                        .foregroundColor(.white)
-                    Text("Cable South Hours: \(timesheet.cableSouthHours)")
-                        .foregroundColor(.white)
-                    Text("Total Hours: \(timesheet.totalHours)")
-                        .foregroundColor(.white)
-                    
-                    Divider()
-                        .background(Color.white)
-                    
-                    Text("Daily Totals:")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                    ForEach(timesheet.dailyTotalHours.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
-                        Text("\(key): \(value)")
-                            .foregroundColor(.white)
-                    }
-                    
-                    if let pdfURL = timesheet.pdfURL, let url = URL(string: pdfURL) {
-                        Button("View PDF") {
-                            showPDFViewer = true
+                VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                    GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                        VStack(alignment: .leading, spacing: JTSpacing.md) {
+                            Text("Timesheet Summary")
+                                .font(JTTypography.title3)
+                                .foregroundStyle(JTColors.textPrimary)
+
+                            detailRow(icon: "calendar", title: "Week Starting", value: formattedDate(timesheet.weekStart))
+                            detailRow(icon: "person.crop.circle.badge.checkmark", title: "Supervisor", value: timesheet.supervisor)
+                            detailRow(icon: "person.2", title: "Name", value: "\(timesheet.name1) \(timesheet.name2)".trimmingCharacters(in: .whitespacesAndNewlines))
+                            detailRow(icon: "clock", title: "Gibson Hours", value: timesheet.gibsonHours)
+                            detailRow(icon: "clock.badge", title: "Cable South Hours", value: timesheet.cableSouthHours)
+                            detailRow(icon: "sum", title: "Total Hours", value: timesheet.totalHours)
                         }
-                        .padding()
-                        .background(JTColors.accent)
-                        .foregroundColor(JTColors.onAccent)
-                        .cornerRadius(8)
+                        .padding(JTSpacing.lg)
+                    }
+
+                    GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                        VStack(alignment: .leading, spacing: JTSpacing.md) {
+                            Text("Daily Totals")
+                                .font(JTTypography.headline)
+                                .foregroundStyle(JTColors.textPrimary)
+
+                            ForEach(timesheet.dailyTotalHours.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                                HStack {
+                                    Text(key)
+                                        .font(JTTypography.subheadline)
+                                        .foregroundStyle(JTColors.textSecondary)
+                                    Spacer()
+                                    Text(value)
+                                        .font(JTTypography.subheadline.weight(.semibold))
+                                        .foregroundStyle(JTColors.textPrimary)
+                                }
+                                Divider().overlay(JTColors.glassSoftStroke.opacity(0.5))
+                            }
+                        }
+                        .padding(JTSpacing.lg)
+                    }
+
+                    if let pdfURL = timesheet.pdfURL, let url = URL(string: pdfURL) {
+                        Button {
+                            showPDFViewer = true
+                        } label: {
+                            Label("View PDF", systemImage: "doc.richtext")
+                                .font(JTTypography.button)
+                                .foregroundStyle(JTColors.onAccent)
+                                .padding(.vertical, JTSpacing.md)
+                                .frame(maxWidth: .infinity)
+                                .background(JTColors.accent, in: JTShapes.roundedRectangle(cornerRadius: JTShapes.buttonCornerRadius))
+                        }
                         .sheet(isPresented: $showPDFViewer) {
                             PDFViewer(url: url)
                         }
                     }
-                    
-                    Spacer()
                 }
-                .padding()
+                .padding(JTSpacing.lg)
             }
         }
         .navigationTitle("Timesheet Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .jtNavigationBarStyle()
     }
-    
+
+    private func detailRow(icon: String, title: String, value: String) -> some View {
+        HStack(alignment: .top, spacing: JTSpacing.sm) {
+            Image(systemName: icon)
+                .foregroundStyle(JTColors.textSecondary)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title.uppercased())
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+                Text(value.isEmpty ? "—" : value)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textPrimary)
+            }
+        }
+    }
+
     private func formattedDate(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -187,13 +187,8 @@ struct WeeklyTimesheetView: View {
                                 }
                             )
                             .frame(maxWidth: .infinity)
-                            .background(.ultraThinMaterial)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                            .shadow(color: Color.black.opacity(0.18), radius: 6, x: 0, y: 4)
+                            .jtGlassBackground(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke)
+                            .jtShadow(JTElevations.card)
                             .padding(.bottom, 12)
                         }
                         
@@ -214,7 +209,7 @@ struct WeeklyTimesheetView: View {
                     }
                     .background(.ultraThinMaterial)
                     .overlay(
-                        Rectangle().fill(Color.white.opacity(0.12)).frame(height: 0.5), alignment: .top
+                        Rectangle().fill(JTColors.glassSoftStroke.opacity(0.7)).frame(height: 0.5), alignment: .top
                     )
                 }
 
@@ -287,14 +282,9 @@ struct WeeklyTimesheetView: View {
                     .disabled(isGeneratingPDF)
                 }
             }
-            // Job editing sheet.
+            // Job detail sheet.
             .sheet(item: $selectedJob) { job in
-                if let index = timesheetJobsVM.jobs.firstIndex(where: { $0.id == job.id }) {
-                    JobEditView(job: $timesheetJobsVM.jobs[index])
-                        .environmentObject(timesheetJobsVM)
-                } else {
-                    Text("Job not found.")
-                }
+                UniversalJobDetailView(job: job, showsDoneButton: true)
             }
             .sheet(isPresented: $showPDFPreview) {
                 if let url = previewURL {
@@ -373,10 +363,15 @@ extension WeeklyTimesheetView {
     private var timesheetHeader: some View {
         VStack(alignment: .leading, spacing: 12) {
             // Supervisor row
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text("Supervisor:").foregroundColor(.white)
-                TextField("", text: $supervisor)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            HStack(alignment: .firstTextBaseline, spacing: JTSpacing.sm) {
+                Text("Supervisor:")
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.textSecondary)
+                TextField("Supervisor", text: $supervisor)
+                    .padding(.vertical, JTSpacing.sm)
+                    .padding(.horizontal, JTSpacing.md)
+                    .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)
+                    .foregroundStyle(JTColors.textPrimary)
             }
 
             // Column headers + rows (Name expands; other columns fixed so it always fits)
@@ -388,17 +383,17 @@ extension WeeklyTimesheetView {
             // Header row
             HStack(spacing: rowSpacing) {
                 Text("Name")
-                    .foregroundColor(.white)
+                    .foregroundStyle(JTColors.textPrimary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .lineLimit(1)
                 Text("Gibson")
-                    .foregroundColor(.white)
+                    .foregroundStyle(JTColors.textPrimary)
                     .frame(width: gibsonWidth, alignment: .leading)
                 Text("CS Hours")
-                    .foregroundColor(.white)
+                    .foregroundStyle(JTColors.textPrimary)
                     .frame(width: csWidth, alignment: .leading)
                 Text("Total")
-                    .foregroundColor(.white)
+                    .foregroundStyle(JTColors.textPrimary)
                     .frame(width: totalWidth, alignment: .leading)
             }
             .font(.subheadline)
@@ -406,7 +401,7 @@ extension WeeklyTimesheetView {
             .padding(.bottom, 4)
             .overlay(
                 Rectangle()
-                    .fill(Color.white.opacity(0.08))
+                    .fill(JTColors.glassSoftStroke.opacity(0.5))
                     .frame(height: 0.5)
                     .padding(.top, 28), alignment: .bottom
             )
@@ -434,7 +429,7 @@ extension WeeklyTimesheetView {
 
                         Text(String(format: "%.1f", worker.total))
                             .frame(width: totalWidth, alignment: .leading)
-                            .foregroundColor(.white)
+                            .foregroundStyle(JTColors.textPrimary)
                             .font(.headline)
 
                         Button(role: .destructive) {
@@ -443,7 +438,7 @@ extension WeeklyTimesheetView {
                             }
                         } label: {
                             Image(systemName: "minus.circle.fill")
-                                .foregroundColor(.red)
+                                .foregroundStyle(JTColors.error)
                         }
                         .opacity(workers.count > 1 ? 1 : 0.3)
                         .disabled(workers.count <= 1)
@@ -453,21 +448,17 @@ extension WeeklyTimesheetView {
                 Button {
                     if workers.count < 2 { workers.append(WorkerHours(name: "", gibson: "", cs: "")) }
                 } label: {
-                    Label("Add Name", systemImage: "plus.circleFill")
+                    Label("Add Name", systemImage: "plus.circle.fill")
                 }
                 .buttonStyle(.borderless)
-                .foregroundColor(.white)
+                .foregroundStyle(JTColors.textPrimary)
                 .opacity(workers.count < 2 ? 1 : 0.3)
                 .disabled(workers.count >= 2)
             }
         }
         .padding()
-        .background(.ultraThinMaterial)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(Color.white.opacity(0.12), lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .jtGlassBackground(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke)
+        .jtShadow(JTElevations.card)
     }
     
     private func filteredJobs(for day: Date) -> [Job] {

--- a/Job Tracker/Features/YellowSheet/PastYellowSheetsView.swift
+++ b/Job Tracker/Features/YellowSheet/PastYellowSheetsView.swift
@@ -3,42 +3,27 @@ import SwiftUI
 struct PastYellowSheetsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @StateObject private var yellowSheetsVM = UserYellowSheetsViewModel()
-    
+
     var body: some View {
         NavigationView {
             ZStack {
-                // Background gradient.
                 JTGradients.background(stops: 4)
-                .edgesIgnoringSafeArea(.all)
-                
+                    .ignoresSafeArea()
+
                 List {
                     ForEach(yellowSheetsVM.yellowSheets) { sheet in
                         NavigationLink(destination: YellowSheetDetailView(yellowSheet: sheet)) {
-                            VStack(alignment: .leading) {
-                                Text("Week Starting: \(formattedDate(sheet.weekStart))")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                Text("Total Jobs: \(sheet.totalJobs)")
-                                    .font(.subheadline)
-                                    .foregroundColor(.white)
-                                if let pdfURL = sheet.pdfURL, !pdfURL.isEmpty {
-                                    Text("PDF Created")
-                                        .font(.caption)
-                                        .foregroundColor(.green)
-                                } else {
-                                    Text("No PDF Available")
-                                        .font(.caption)
-                                        .foregroundColor(.red)
-                                }
-                            }
+                            PastYellowSheetRow(sheet: sheet)
                         }
+                        .listRowBackground(Color.clear)
                     }
                     .onDelete(perform: deleteSheet)
                 }
-                .listStyle(GroupedListStyle())
+                .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
             }
             .navigationTitle("Past Yellow Sheets")
+            .navigationBarTitleDisplayMode(.inline)
             .jtNavigationBarStyle()
             .onAppear {
                 if let user = authViewModel.currentUser {
@@ -47,13 +32,7 @@ struct PastYellowSheetsView: View {
             }
         }
     }
-    
-    private func formattedDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        return formatter.string(from: date)
-    }
-    
+
     private func deleteSheet(at offsets: IndexSet) {
         offsets.forEach { index in
             let sheet = yellowSheetsVM.yellowSheets[index]
@@ -62,5 +41,39 @@ struct PastYellowSheetsView: View {
             }
         }
         yellowSheetsVM.yellowSheets.remove(atOffsets: offsets)
+    }
+}
+
+private struct PastYellowSheetRow: View {
+    let sheet: YellowSheet
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Week Starting: \(formattedDate(sheet.weekStart))")
+                    .font(JTTypography.headline)
+                    .foregroundStyle(JTColors.textPrimary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(JTColors.textMuted)
+            }
+
+            Text("Total Jobs: \(sheet.totalJobs)")
+                .font(JTTypography.subheadline)
+                .foregroundStyle(JTColors.textSecondary)
+
+            Label(sheet.pdfURL?.isEmpty == false ? "PDF Created" : "No PDF Available",
+                  systemImage: sheet.pdfURL?.isEmpty == false ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(JTTypography.caption)
+                .foregroundStyle(sheet.pdfURL?.isEmpty == false ? JTColors.success : JTColors.error)
+        }
+        .padding(.vertical, JTSpacing.sm)
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
     }
 }

--- a/Job Tracker/Features/YellowSheet/YellowSheetDetailView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetDetailView.swift
@@ -2,53 +2,71 @@ import SwiftUI
 
 struct YellowSheetDetailView: View {
     let yellowSheet: YellowSheet
-    
+
     var body: some View {
         ZStack {
-            // Background gradient.
             JTGradients.background(stops: 4)
-                .edgesIgnoringSafeArea(.all)
-            
-            VStack(spacing: 20) {
-                Text("Yellow Sheet Detail")
-                    .font(.title)
-                    .foregroundColor(.white)
-                    .padding(.top)
-                
-                Text("Week Starting: \(formattedDate(yellowSheet.weekStart))")
-                    .font(.headline)
-                    .foregroundColor(.white)
-                
-                Text("Total Jobs: \(yellowSheet.totalJobs)")
-                    .font(.subheadline)
-                    .foregroundColor(.white)
-                
-                if let pdfURLString = yellowSheet.pdfURL,
-                   let url = URL(string: pdfURLString),
-                   !pdfURLString.isEmpty {
-                    NavigationLink(destination: PDFViewer(url: url)) {
-                        Text("View PDF")
-                            .font(.headline)
-                            .foregroundColor(JTColors.onAccent)
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(JTColors.accent)
-                            .cornerRadius(8)
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: JTSpacing.lg) {
+                    GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                        VStack(alignment: .leading, spacing: JTSpacing.md) {
+                            Text("Yellow Sheet Detail")
+                                .font(JTTypography.title3)
+                                .foregroundStyle(JTColors.textPrimary)
+
+                            detailRow(icon: "calendar", title: "Week Starting", value: formattedDate(yellowSheet.weekStart))
+                            detailRow(icon: "briefcase", title: "Total Jobs", value: "\(yellowSheet.totalJobs)")
+                        }
+                        .padding(JTSpacing.lg)
                     }
-                    .padding(.horizontal)
-                } else {
-                    Text("No PDF Available")
-                        .foregroundColor(.red)
+
+                    if let pdfURLString = yellowSheet.pdfURL,
+                       let url = URL(string: pdfURLString),
+                       !pdfURLString.isEmpty {
+                        NavigationLink(destination: PDFViewer(url: url)) {
+                            Label("View PDF", systemImage: "doc.richtext")
+                                .font(JTTypography.button)
+                                .foregroundStyle(JTColors.onAccent)
+                                .padding(.vertical, JTSpacing.md)
+                                .frame(maxWidth: .infinity)
+                                .background(JTColors.accent, in: JTShapes.roundedRectangle(cornerRadius: JTShapes.buttonCornerRadius))
+                        }
+                    } else {
+                        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                            Label("No PDF Available", systemImage: "exclamationmark.triangle")
+                                .font(JTTypography.subheadline)
+                                .foregroundStyle(JTColors.error)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(JTSpacing.lg)
+                        }
+                    }
                 }
-                
-                Spacer()
+                .padding(JTSpacing.lg)
             }
-            .padding()
         }
         .navigationTitle("Yellow Sheet Detail")
         .navigationBarTitleDisplayMode(.inline)
+        .jtNavigationBarStyle()
     }
-    
+
+    private func detailRow(icon: String, title: String, value: String) -> some View {
+        HStack(alignment: .top, spacing: JTSpacing.sm) {
+            Image(systemName: icon)
+                .foregroundStyle(JTColors.textSecondary)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title.uppercased())
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+                Text(value)
+                    .font(JTTypography.body)
+                    .foregroundStyle(JTColors.textPrimary)
+            }
+        }
+    }
+
     private func formattedDate(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium

--- a/Job Tracker/Features/YellowSheet/YellowSheetJobCard.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetJobCard.swift
@@ -4,54 +4,87 @@ struct YellowSheetJobCard: View {
     let job: Job
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(job.address)
-                .font(.headline)
-                .foregroundColor(.white)
-            
-            if let jobNumber = job.jobNumber, !jobNumber.isEmpty {
-                Text("Job Number: \(jobNumber)")
-                    .font(.subheadline)
-                    .foregroundColor(.white)
-            } else {
-                Text("Job Number: N/A")
-                    .font(.subheadline)
-                    .foregroundColor(.white)
+        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+            VStack(alignment: .leading, spacing: JTSpacing.md) {
+                HStack(alignment: .top, spacing: JTSpacing.sm) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(job.shortAddress.isEmpty ? job.address : job.shortAddress)
+                            .font(JTTypography.headline)
+                            .foregroundStyle(JTColors.textPrimary)
+                            .lineLimit(2)
+
+                        Text(job.address)
+                            .font(JTTypography.caption)
+                            .foregroundStyle(JTColors.textSecondary)
+                            .lineLimit(2)
+                    }
+
+                    Spacer(minLength: JTSpacing.sm)
+
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(JTColors.textMuted)
+                }
+
+                HStack(spacing: JTSpacing.xs) {
+                    if let jobNumber = job.jobNumber, !jobNumber.isEmpty {
+                        YellowSheetChip(text: "#\(jobNumber)", tint: JTColors.accent)
+                    } else {
+                        YellowSheetChip(text: "No Job #", tint: JTColors.textMuted)
+                    }
+                    YellowSheetChip(text: job.displayStatus, tint: universalStatusColor(job.status))
+                }
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), alignment: .leading)], alignment: .leading, spacing: JTSpacing.sm) {
+                    if let nid = job.nidFootage, !nid.isEmpty {
+                        metric("NID", value: nid, icon: "ruler")
+                    }
+                    if let can = job.canFootage, !can.isEmpty {
+                        metric("CAN", value: can, icon: "ruler")
+                    }
+                    if job.hours > 0 {
+                        metric("Hours", value: String(format: "%.1f", job.hours), icon: "clock")
+                    }
+                }
+
+                if let materials = job.materialsUsed, !materials.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Label(materials, systemImage: "shippingbox")
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.textSecondary)
+                        .lineLimit(2)
+                }
             }
-            
-            Text("Status: \(job.displayStatus)")
-                .font(.subheadline)
-                .foregroundColor(.white)
-            
-            if let nid = job.nidFootage, !nid.isEmpty {
-                Text("NID Footage: \(nid)")
-                    .font(.footnote)
-                    .foregroundColor(.white)
-            }
-            if let can = job.canFootage, !can.isEmpty {
-                Text("CAN Footage: \(can)")
-                    .font(.footnote)
-                    .foregroundColor(.white)
-            }
-            if (job.nidFootage == nil || job.nidFootage!.isEmpty) &&
-               (job.canFootage == nil || job.canFootage!.isEmpty) {
-                Text("Footages: N/A")
-                    .font(.footnote)
-                    .foregroundColor(.white)
-            }
-            
-            if let materials = job.materialsUsed, !materials.isEmpty {
-                Text("Materials: \(materials)")
-                    .font(.footnote)
-                    .foregroundColor(.white)
+            .padding(JTSpacing.lg)
+        }
+    }
+
+    private func metric(_ title: String, value: String, icon: String) -> some View {
+        HStack(spacing: JTSpacing.xs) {
+            Image(systemName: icon)
+                .foregroundStyle(JTColors.textMuted)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title.uppercased())
+                    .font(JTTypography.caption)
+                    .foregroundStyle(JTColors.textSecondary)
+                Text(value)
+                    .font(JTTypography.captionEmphasized)
+                    .foregroundStyle(JTColors.textPrimary)
             }
         }
-        .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color(red: 0.2, green: 0.25, blue: 0.3).opacity(0.75))
-                .shadow(color: Color.black.opacity(0.2), radius: 5, x: 0, y: 3)
-        )
-        .padding(.horizontal, 4)
+    }
+}
+
+private struct YellowSheetChip: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        Text(text)
+            .font(JTTypography.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(tint)
+            .padding(.vertical, 5)
+            .padding(.horizontal, JTSpacing.sm)
+            .background(tint.opacity(0.16), in: Capsule())
     }
 }

--- a/Job Tracker/Features/YellowSheet/YellowSheetView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetView.swift
@@ -16,6 +16,7 @@ struct YellowSheetView: View {
     @State private var showSaveAlert = false
     @State private var partnerUid: String? = nil
     @State private var saveAlertMessage = ""
+    @State private var selectedJob: Job?
     
     private var topContentPadding: CGFloat {
         horizontalSizeClass == .compact ? 72 : 32
@@ -28,37 +29,60 @@ struct YellowSheetView: View {
                 JTGradients.background(stops: 4)
                 .ignoresSafeArea()
                 
-                VStack {
+                VStack(spacing: JTSpacing.lg) {
                     // Minimal Week Picker
                     minimalWeekPicker
+                        .padding(.horizontal, JTSpacing.lg)
 
                     ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 16) {
-                            ForEach(sortedJobGroups, id: \.key) { group in
-                                Section(header: Text("Job Number: \(group.key)")
-                                            .font(.headline)
-                                            .foregroundColor(JTColors.textPrimary)
-                                            .padding(.vertical, 4)) {
-                                    ForEach(group.value) { job in
-                                        YellowSheetJobCard(job: job)
-                                            .padding(.horizontal)
+                        LazyVStack(alignment: .leading, spacing: JTSpacing.lg) {
+                            if sortedJobGroups.isEmpty {
+                                GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
+                                    VStack(spacing: JTSpacing.sm) {
+                                        Image(systemName: "tray")
+                                            .font(.system(size: 34))
+                                            .foregroundStyle(JTColors.textMuted)
+                                        Text("No yellow sheet jobs")
+                                            .font(JTTypography.headline)
+                                            .foregroundStyle(JTColors.textPrimary)
+                                        Text("Completed jobs for this week will show here once they are available.")
+                                            .font(JTTypography.caption)
+                                            .foregroundStyle(JTColors.textSecondary)
+                                            .multilineTextAlignment(.center)
+                                    }
+                                    .frame(maxWidth: .infinity)
+                                    .padding(JTSpacing.xl)
+                                }
+                            } else {
+                                ForEach(sortedJobGroups, id: \.key) { group in
+                                    VStack(alignment: .leading, spacing: JTSpacing.md) {
+                                        Text("Job Number: \(group.key)")
+                                            .font(JTTypography.headline)
+                                            .foregroundStyle(JTColors.textPrimary)
+                                            .padding(.horizontal, JTSpacing.xs)
+
+                                        ForEach(group.value) { job in
+                                            Button {
+                                                selectedJob = job
+                                            } label: {
+                                                YellowSheetJobCard(job: job)
+                                            }
+                                            .buttonStyle(.plain)
+                                            .accessibilityHint("Opens the full job details")
+                                        }
                                     }
                                 }
                             }
                         }
-                        .padding(.top)
+                        .padding(.horizontal, JTSpacing.lg)
+                        .padding(.bottom, JTSpacing.xl)
                     }
-                    
-                    Button("Save Yellow Sheet") {
+
+                    JTPrimaryButton("Save Yellow Sheet", systemImage: "tray.and.arrow.down") {
                         saveCurrentYellowSheet()
                     }
-                    .foregroundColor(JTColors.onAccent)
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(JTColors.accent.opacity(0.9))
-                    .cornerRadius(8)
-                    .padding(.horizontal)
-                    .padding(.bottom, 10)
+                    .padding(.horizontal, JTSpacing.lg)
+                    .padding(.bottom, JTSpacing.md)
                 }
                 .padding(.top, topContentPadding)
             }
@@ -91,6 +115,9 @@ struct YellowSheetView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .sheet(item: $selectedJob) { job in
+            UniversalJobDetailView(job: job, showsDoneButton: true)
+        }
         // Full calendar sheet.
         .sheet(isPresented: $showCalendar) {
             NavigationView {
@@ -135,6 +162,7 @@ struct YellowSheetView: View {
             }) {
                 Image(systemName: "chevron.left")
                     .padding(8)
+                    .foregroundStyle(JTColors.textPrimary)
             }
             Spacer(minLength: 0)
             Button(action: {
@@ -143,7 +171,7 @@ struct YellowSheetView: View {
                 Text("Week of \(formattedDate(startOfWeek))")
                     .font(.subheadline)
                     .lineLimit(1)
-                    .foregroundColor(.white)
+                    .foregroundStyle(JTColors.textPrimary)
             }
             Spacer(minLength: 0)
             Button(action: {
@@ -153,12 +181,12 @@ struct YellowSheetView: View {
             }) {
                 Image(systemName: "chevron.right")
                     .padding(8)
+                    .foregroundStyle(JTColors.textPrimary)
             }
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
-        .background(Color.gray.opacity(0.2))
-        .cornerRadius(8)
+        .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)
     }
     
     private func formattedDate(_ date: Date) -> String {


### PR DESCRIPTION
### Motivation
- Modernize and unify job presentation and interactions across supervisor, timesheet, yellow sheet, and search flows to provide a consistent detail view and improved UX. 
- Replace ad-hoc styling and colors with shared design tokens (`JTColors`, `JTTypography`, `JTShapes`, `JTSpacing`) and surface clearer loading/error states. 
- Make job rows actionable throughout the app so supervisors and timesheet users can open full job details without navigating to edit screens. 

### Description
- Introduces a new `UniversalJobDetailView` (and supporting view types `UniversalJobInfoCard`, `UniversalJobTextCard`, `UniversalQuickActionButton`) to present job details and photos in a consistent sheet-based presentation. 
- Replaces many hard-coded color/typography usages with shared style tokens and updates small UI components (chips, cards, badges, shadows) across `SupervisorDashboardView`, `SupervisorHomeDashboardView`, `DayTimesheetBox`, `YellowSheet*`, `Timesheet*`, and related views. 
- Adds universal status color logic via `universalStatusColor(_:)` and updates usages (status badges, chips, metadata) and updates `roleColor(_:)` mapping to use `JTColors`. 
- Makes job rows actionable by turning row content into buttons that set a `selectedJob` state and present `UniversalJobDetailView` via `.sheet(item:)` in `SupervisorDashboardView`, `WeeklyTimesheetView`, `YellowSheetView`, `SupervisorUserJobsView`, and others. 
- Reworks `SupervisorJobImportView` with a refreshed layout, image preview, action card, parsed entries list/cards, and improved import/review buttons and states. 
- Improves timesheet and yellow-sheet lists/details with `GlassCard` presentation and new row components (`PastTimesheetRow`, `PastYellowSheetRow`) and accessibility hints on interactive rows. 
- Miscellaneous UX fixes: loading/error state cards (`supervisorHomeStateCard` / `supervisorStateCard`), accessibility hints, small layout cleanups, and helper view `YellowSheetChip`. 

### Testing
- Built the app in Xcode and launched the flows touched by the change (Supervisor dashboard, job import, weekly timesheet, yellow sheets) to validate view compilation and sheet presentation; build succeeded without compiler errors. 
- Ran the existing automated test suite (project test target) and observed no regressions in the tests that were present prior to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196eee9834832d95b462a5c21f344e)