### PR TITLE
Always show "Open Portal" for Gibson links

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -142,7 +142,7 @@ struct JobCard: View {
         .contextMenu {
             Button("Directions", systemImage: "map.fill", action: onMapTap)
             if job.gibsonPortalURL != nil {
-                Button(job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari", action: openPortal)
+                Button("Open Portal", systemImage: "safari", action: openPortal)
             }
             Button("Share", systemImage: "square.and.arrow.up", action: onShare)
             Button("Delete", role: .destructive, action: onDelete)
@@ -277,7 +277,7 @@ struct JobCard: View {
 
             if job.gibsonPortalURL != nil {
                 Button(action: openPortal) {
-                    Label(job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari")
+                    Label("Open Portal", systemImage: "safari")
                         .font(JTTypography.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(JTColors.textPrimary)
@@ -285,7 +285,7 @@ struct JobCard: View {
                         .padding(.vertical, JTSpacing.xs)
                         .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
                 }
-                .accessibilityLabel(job.portalURL == nil ? "Open Gibson location search" : "Open Gibson portal")
+                .accessibilityLabel("Open Gibson portal")
             }
 
             Button(action: onMapTap) {

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -230,7 +230,7 @@ struct JobSearchDetailView: View {
             }
 
             if job.gibsonPortalURL != nil {
-                QuickActionButton(title: job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari") {
+                QuickActionButton(title: "Open Portal", systemImage: "safari") {
                     openPortal(job: job)
                 }
             }
@@ -805,7 +805,7 @@ struct UniversalJobDetailView: View {
                     }
 
                     if job.gibsonPortalURL != nil {
-                        UniversalQuickActionButton(title: job.portalURL == nil ? "Open Location" : "Open Portal", systemImage: "safari") {
+                        UniversalQuickActionButton(title: "Open Portal", systemImage: "safari") {
                             openPortal(job: job)
                         }
                     }


### PR DESCRIPTION
### Motivation
- Make the portal action label consistent so links backed by a location number read "Open Portal" instead of "Open Location" to match portal-ID-backed links.

### Description
- Replaced conditional labels with a fixed "Open Portal" label in `Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift` for the context menu, main portal button, and accessibility label.
- Updated quick action labels in `Job Tracker/Features/Search/JobSearchDetailView.swift` and the universal detail view to always use "Open Portal".
- No behavior changes to URL handling or navigation; only the visible labels and one accessibility label were modified.

### Testing
- Ran `xcodebuild -list -project 'Job Tracker.xcodeproj'` which failed in this environment because `xcodebuild` is not installed. 
- Ran repository checks including `git status --short` which succeeded and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1976d8f044832d9a1160511a09498a)