### PR TITLE
Fix stale portal identifiers on job updates

### DIFF
--- a/Job Tracker/Features/Jobs/JobsViewModel.swift
+++ b/Job Tracker/Features/Jobs/JobsViewModel.swift
@@ -325,11 +325,27 @@ class JobsViewModel: ObservableObject {
                         print("updateJob: merge setData error: \(writeErr)")
                         return
                     }
+                    var patch: [String: Any] = [:]
+
+                    // The Firestore Codable encoder omits nil optionals. Because this update uses
+                    // merge: true, omitted identifier fields would leave stale portal/location
+                    // numbers on the server after a user clears or replaces one of them.
+                    if job.portalID == nil {
+                        patch["portalID"] = FieldValue.delete()
+                    }
+                    if job.locationNumber == nil {
+                        patch["locationNumber"] = FieldValue.delete()
+                    }
+
                     // 3) Re-assert participants if they existed (protects against encoder omitting/clearing them)
                     if !preservedParticipants.isEmpty {
-                        ref.updateData(["participants": preservedParticipants]) { patchErr in
+                        patch["participants"] = preservedParticipants
+                    }
+
+                    if !patch.isEmpty {
+                        ref.updateData(patch) { patchErr in
                             if let patchErr = patchErr {
-                                print("updateJob: failed to preserve participants: \(patchErr)")
+                                print("updateJob: failed to patch merged fields: \(patchErr)")
                             }
                         }
                     }


### PR DESCRIPTION
### Motivation
- Clearing or editing a job's `portalID` or `locationNumber` could leave the old identifier on Firestore because the Codable encoder omits `nil` optionals during a `merge` write, causing the app's "Open Portal" button to keep opening the stale URL.

### Description
- Update `Job Tracker/Features/Jobs/JobsViewModel.swift` to build a follow-up `patch` dictionary and call `ref.updateData(patch)` when needed.
- When `job.portalID == nil` or `job.locationNumber == nil` the code now inserts `FieldValue.delete()` into the patch so Firestore removes the fields instead of leaving stale values.
- Preserve the existing participants-reassertion behavior by including `participants` in the same patch and only calling `updateData` when `patch` is non-empty.
- Improve the patch error logging message to reflect the combined patch operation.

### Testing
- Ran `git diff --check` to validate changes and formatting, which reported no issues.
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` to inspect Xcode targets but `xcodebuild` is not available in this environment so full Xcode-based build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1986a2ff78832da29777dc7f592e68)