### PR TITLE
Admin: add ability to delete users from Admin panel

### DIFF
--- a/Job Tracker/Features/Admin/AdminPanelViewModel.swift
+++ b/Job Tracker/Features/Admin/AdminPanelViewModel.swift
@@ -9,6 +9,8 @@ protocol AdminPanelService: AnyObject {
         completion: @escaping (Result<Void, Error>) -> Void
     )
 
+    func deleteUser(uid: String, completion: @escaping (Result<Void, Error>) -> Void)
+
     func adminBackfillParticipantsForAllJobs(
         progress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?,
         completion: @escaping (Result<Int, Error>) -> Void
@@ -54,6 +56,7 @@ final class AdminPanelViewModel: ObservableObject {
     @Published private(set) var roster: [AppUser]
     @Published private(set) var updatingAdminIDs: Set<String> = []
     @Published private(set) var updatingSupervisorIDs: Set<String> = []
+    @Published private(set) var deletingUserIDs: Set<String> = []
     @Published var alert: AlertItem?
     @Published private(set) var maintenanceStatus: MaintenanceStatus = .idle
 
@@ -109,8 +112,46 @@ final class AdminPanelViewModel: ObservableObject {
         updateFlags(for: user, admin: user.isAdmin, supervisor: isSupervisor, changedFlag: .supervisor)
     }
 
+    func deleteUser(_ user: AppUser) {
+        let userID = user.id
+        guard currentUserIDProvider() != userID else {
+            alert = AlertItem(
+                title: "Delete Blocked",
+                message: "You cannot delete your own admin account from this screen.",
+                kind: .error
+            )
+            return
+        }
+
+        guard !isMutating(userID: userID) else { return }
+
+        deletingUserIDs.insert(userID)
+        service.deleteUser(uid: userID) { [weak self] result in
+            guard let self else { return }
+            Task { @MainActor in
+                self.deletingUserIDs.remove(userID)
+
+                switch result {
+                case .success:
+                    self.roster.removeAll { $0.id == userID }
+                    self.alert = AlertItem(
+                        title: "User Deleted",
+                        message: "Removed \(user.firstName) \(user.lastName) from the app roster.",
+                        kind: .success
+                    )
+                case .failure(let error):
+                    self.alert = AlertItem(
+                        title: "Delete Failed",
+                        message: error.localizedDescription,
+                        kind: .error
+                    )
+                }
+            }
+        }
+    }
+
     func isMutating(userID: String) -> Bool {
-        updatingAdminIDs.contains(userID) || updatingSupervisorIDs.contains(userID)
+        updatingAdminIDs.contains(userID) || updatingSupervisorIDs.contains(userID) || deletingUserIDs.contains(userID)
     }
 
     func runParticipantsBackfill() {

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -696,6 +696,18 @@ class FirebaseService {
         }
     }
 
+    func deleteUser(uid: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        db.collection("users").document(uid).delete { error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(()))
+                }
+            }
+        }
+    }
+
     func refreshCustomClaims(for uid: String?, completion: ((Error?) -> Void)? = nil) {
         guard let currentUser = auth.currentUser else {
             DispatchQueue.main.async {

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -210,6 +210,7 @@ struct AdminPanelView: View {
     @StateObject private var viewModel = AdminPanelViewModel()
     @StateObject private var updateViewModel = AdminUpdateViewModel()
     @State private var pendingToggle: PendingToggle?
+    @State private var pendingDeleteUser: AppUser?
     @State private var showingBackfillConfirmation = false
     @State private var pendingUpdateAction: PendingUpdateAction?
     @State private var showingLogs = false
@@ -263,6 +264,34 @@ struct AdminPanelView: View {
             }
         } message: {
             Text("This updates Firebase immediately and may change the user's access right away.")
+        }
+        .confirmationDialog(
+            "Delete user?",
+            isPresented: Binding(
+                get: { pendingDeleteUser != nil },
+                set: { newValue in
+                    if !newValue {
+                        pendingDeleteUser = nil
+                    }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let user = pendingDeleteUser {
+                Button("Delete \(user.firstName) \(user.lastName)", role: .destructive) {
+                    viewModel.deleteUser(user)
+                    pendingDeleteUser = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDeleteUser = nil
+            }
+        } message: {
+            if let user = pendingDeleteUser {
+                Text("This removes \(user.firstName) \(user.lastName) from the app roster immediately. Use this only for accounts you no longer need.")
+            } else {
+                Text("This removes the selected user from the app roster immediately.")
+            }
         }
         .confirmationDialog(
             "Run participants backfill?",
@@ -509,6 +538,14 @@ struct AdminPanelView: View {
                                 .font(.subheadline)
                         }
                         .disabled(viewModel.isMutating(userID: user.id))
+
+                        Button(role: .destructive) {
+                            pendingDeleteUser = user
+                        } label: {
+                            Label("Delete User", systemImage: "trash")
+                                .font(.subheadline)
+                        }
+                        .disabled(viewModel.isMutating(userID: user.id) || authViewModel.currentUser?.id == user.id)
                     }
                     .padding(.vertical, 8)
                 }

--- a/Job TrackerTests/AdminPanelViewModelTests.swift
+++ b/Job TrackerTests/AdminPanelViewModelTests.swift
@@ -79,6 +79,42 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertFalse(mockService.didRefreshClaims)
     }
 
+    func testDeleteUserSuccessRemovesUserFromRoster() async {
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(
+            service: mockService,
+            currentUserIDProvider: { sampleUsers[0].id },
+            initialRoster: sampleUsers
+        )
+
+        viewModel.deleteUser(sampleUsers[1])
+
+        XCTAssertTrue(viewModel.deletingUserIDs.contains(sampleUsers[1].id))
+        XCTAssertEqual(mockService.lastDeletedUserID, sampleUsers[1].id)
+
+        mockService.completeLastDelete(with: .success(()))
+        await Task.yield()
+
+        XCTAssertFalse(viewModel.deletingUserIDs.contains(sampleUsers[1].id))
+        XCTAssertFalse(viewModel.roster.contains { $0.id == sampleUsers[1].id })
+        XCTAssertEqual(viewModel.alert?.kind, .success)
+    }
+
+    func testDeleteCurrentUserIsBlocked() {
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(
+            service: mockService,
+            currentUserIDProvider: { sampleUsers[0].id },
+            initialRoster: sampleUsers
+        )
+
+        viewModel.deleteUser(sampleUsers[0])
+
+        XCTAssertNil(mockService.lastDeletedUserID)
+        XCTAssertTrue(viewModel.deletingUserIDs.isEmpty)
+        XCTAssertEqual(viewModel.alert?.title, "Delete Blocked")
+    }
+
     func testBackfillProgressAndCompletion() async {
         let mockService = MockAdminPanelService()
         let viewModel = AdminPanelViewModel(service: mockService)
@@ -105,7 +141,9 @@ final class AdminPanelViewModelTests: XCTestCase {
 
 private final class MockAdminPanelService: AdminPanelService {
     private(set) var lastUpdate: (uid: String, isAdmin: Bool, isSupervisor: Bool)?
+    private(set) var lastDeletedUserID: String?
     private var updateCompletion: ((Result<Void, Error>) -> Void)?
+    private var deleteCompletion: ((Result<Void, Error>) -> Void)?
     private var backfillProgress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?
     private var backfillCompletion: ((Result<Int, Error>) -> Void)?
     private(set) var didRefreshClaims = false
@@ -113,6 +151,11 @@ private final class MockAdminPanelService: AdminPanelService {
     func updateUserFlags(uid: String, isAdmin: Bool, isSupervisor: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
         lastUpdate = (uid, isAdmin, isSupervisor)
         updateCompletion = completion
+    }
+
+    func deleteUser(uid: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        lastDeletedUserID = uid
+        deleteCompletion = completion
     }
 
     func adminBackfillParticipantsForAllJobs(progress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?, completion: @escaping (Result<Int, Error>) -> Void) {
@@ -128,6 +171,11 @@ private final class MockAdminPanelService: AdminPanelService {
     func completeLastUpdate(with result: Result<Void, Error>) {
         updateCompletion?(result)
         updateCompletion = nil
+    }
+
+    func completeLastDelete(with result: Result<Void, Error>) {
+        deleteCompletion?(result)
+        deleteCompletion = nil
     }
 
     func sendProgress(_ progress: FirebaseService.AdminMaintenanceProgress) {


### PR DESCRIPTION
### Motivation
- Provide admins an easy way to remove test or unwanted accounts from the app roster directly from the Admin UI. 
- Ensure deletes are performed through the app service layer and surface success / error feedback to the admin. 

### Description
- Added `deleteUser(uid:completion:)` to the `AdminPanelService` protocol and implemented `FirebaseService.deleteUser(uid:completion:)` which deletes the `/users/{uid}` document in Firestore. 
- Extended `AdminPanelViewModel` with `deletingUserIDs` state, a `deleteUser(_:)` method that guards against deleting the current admin, tracks in-progress deletes, removes the user from the local `roster` on success, and sets success/error `alert`s. 
- Updated roster UI in `MainTabView` to surface a destructive `Delete User` button per row and a confirmation dialog, and disabled the action for the currently-signed-in user. 
- Added unit tests in `AdminPanelViewModelTests` for successful deletion and for blocking deletion of the current user, plus mock service support for the new API and updated `isMutating` behavior. 

### Testing
- Ran `git diff --check` to validate the working tree; no issues found. (success) 
- Added unit tests `testDeleteUserSuccessRemovesUserFromRoster` and `testDeleteCurrentUserIsBlocked` to `AdminPanelViewModelTests`, but running the iOS test suite with `xcodebuild` was not possible in this environment because `xcodebuild` is unavailable. (not executed) 
- Project contains no `Package.swift`; `swift test` is not applicable for this iOS project so package-based tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19875ada14832d87c5e6389db01a5b)