### PR TITLE
Prevent self-admin demotion and improve participants backfill

### DIFF
--- a/Job Tracker/Features/Admin/AdminPanelViewModel.swift
+++ b/Job Tracker/Features/Admin/AdminPanelViewModel.swift
@@ -227,6 +227,15 @@ final class AdminPanelViewModel: ObservableObject {
         changedFlag: ChangedFlag
     ) {
         let userID = user.id
+        if changedFlag == .admin, admin == false, currentUserIDProvider() == userID {
+            alert = AlertItem(
+                title: "Update Blocked",
+                message: "You cannot remove your own admin access from this screen.",
+                kind: .error
+            )
+            return
+        }
+
         if updatingAdminIDs.contains(userID) || updatingSupervisorIDs.contains(userID) {
             return
         }

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -27,6 +27,21 @@ class FirebaseService {
         let total: Int
         let message: String
     }
+
+    static func participantsBackfillPayload(for data: [String: Any]) -> [String: Any]? {
+        var participants = Set((data["participants"] as? [String] ?? []).filter { !$0.isEmpty })
+        let originalParticipants = participants
+
+        if let creator = data["createdBy"] as? String, !creator.isEmpty {
+            participants.insert(creator)
+        }
+        if let assignee = data["assignedTo"] as? String, !assignee.isEmpty {
+            participants.insert(assignee)
+        }
+
+        guard !participants.isEmpty, participants != originalParticipants else { return nil }
+        return ["participants": Array(participants).sorted()]
+    }
     
     // MARK: - Authentication
     
@@ -747,14 +762,9 @@ class FirebaseService {
             let docs = snapshot?.documents ?? []
             var updates: [(DocumentReference, [String: Any])] = []
             for doc in docs {
-                let data = doc.data()
-                let existing = (data["participants"] as? [String]) ?? []
-                if !existing.isEmpty { continue }
-                var ps = Set<String>()
-                if let c = data["createdBy"] as? String, !c.isEmpty { ps.insert(c) }
-                if let a = data["assignedTo"] as? String, !a.isEmpty { ps.insert(a) }
-                if ps.isEmpty { continue }
-                updates.append((doc.reference, ["participants": Array(ps)]))
+                if let payload = FirebaseService.participantsBackfillPayload(for: doc.data()) {
+                    updates.append((doc.reference, payload))
+                }
             }
             if updates.isEmpty {
                 DispatchQueue.main.async {

--- a/Job TrackerTests/AdminPanelViewModelTests.swift
+++ b/Job TrackerTests/AdminPanelViewModelTests.swift
@@ -115,6 +115,45 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.alert?.title, "Delete Blocked")
     }
 
+
+    func testRemovingCurrentUsersAdminAccessIsBlocked() {
+        var user = AppUser(id: "admin-1", firstName: "Riley", lastName: "Admin", email: "riley@example.com", position: "Admin")
+        user.isAdmin = true
+        let mockService = MockAdminPanelService()
+        let viewModel = AdminPanelViewModel(
+            service: mockService,
+            currentUserIDProvider: { user.id },
+            initialRoster: [user]
+        )
+
+        viewModel.setAdmin(false, for: user)
+
+        XCTAssertNil(mockService.lastUpdate)
+        XCTAssertTrue(viewModel.updatingAdminIDs.isEmpty)
+        XCTAssertEqual(viewModel.alert?.title, "Update Blocked")
+    }
+
+    func testParticipantsBackfillPayloadMergesMissingLegacyUsers() {
+        let payload = FirebaseService.participantsBackfillPayload(for: [
+            "participants": ["existing"],
+            "createdBy": "creator",
+            "assignedTo": "existing"
+        ])
+
+        let participants = payload?["participants"] as? [String]
+        XCTAssertEqual(participants, ["creator", "existing"])
+    }
+
+    func testParticipantsBackfillPayloadSkipsAlreadyCompleteParticipants() {
+        let payload = FirebaseService.participantsBackfillPayload(for: [
+            "participants": ["assignee", "creator"],
+            "createdBy": "creator",
+            "assignedTo": "assignee"
+        ])
+
+        XCTAssertNil(payload)
+    }
+
     func testBackfillProgressAndCompletion() async {
         let mockService = MockAdminPanelService()
         let viewModel = AdminPanelViewModel(service: mockService)


### PR DESCRIPTION
### Motivation
- Prevent administrators from accidentally removing their own admin access from the Admin panel, matching the existing self-delete guard. 
- Make the participants backfill more robust by merging legacy `createdBy`/`assignedTo` IDs into documents rather than skipping documents with partial `participants` data. 
- Add unit tests to cover the self-demotion guard and the backfill payload logic.

### Description
- Add a guard in `AdminPanelViewModel.updateFlags(...)` that blocks removing the `isAdmin` flag for the current user and surfaces an `AlertItem` titled `"Update Blocked"` instead of sending the mutation to the service. 
- Extract and add `FirebaseService.participantsBackfillPayload(for:)` to compute a normalized `participants` payload that merges existing participants with `createdBy`/`assignedTo` and returns `nil` if no change is required. 
- Update `adminBackfillParticipantsForAllJobs(...)` to use the new helper and only queue documents that actually need updates. 
- Add unit tests in `AdminPanelViewModelTests`: `testRemovingCurrentUsersAdminAccessIsBlocked`, `testParticipantsBackfillPayloadMergesMissingLegacyUsers`, and `testParticipantsBackfillPayloadSkipsAlreadyCompleteParticipants`.

### Testing
- Ran a syntax/parse check with `swiftc -parse` on the modified files (`AdminPanelViewModel.swift`, `FirebaseService.swift`, and `AdminPanelViewModelTests.swift`), which succeeded. 
- Ran a repository diff/format check (no issues reported). 
- Attempted `swift test`, but it could not be executed in this environment because there is no `Package.swift` in the workspace. 
- Attempted `xcodebuild -list` in the container but `xcodebuild` is not available here, so full Xcode test runs were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a0f1470c832d8a806d143e8a5818)