### PR TITLE
Implement Siri intents for current/nearest job (assignment & footage)

### DIFF
--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -506,11 +506,22 @@ class FirebaseService {
     }
 
     /// NOTE: Do not modify 'participants' here; historical access is preserved even if users unpair later.
-    /// Update only the status field of a job document.
-    func updateJobStatus(jobId: String, newStatus: String, completion: @escaping (Error?) -> Void) {
-        db.collection("jobs").document(jobId).updateData(["status": newStatus]) { error in
+    /// Update only the provided editable fields on a job document.
+    func updateJobFields(jobId: String, fields: [String: Any], completion: @escaping (Error?) -> Void) {
+        guard !fields.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        db.collection("jobs").document(jobId).updateData(fields) { error in
             completion(error)
         }
+    }
+
+    /// NOTE: Do not modify 'participants' here; historical access is preserved even if users unpair later.
+    /// Update only the status field of a job document.
+    func updateJobStatus(jobId: String, newStatus: String, completion: @escaping (Error?) -> Void) {
+        updateJobFields(jobId: jobId, fields: ["status": newStatus], completion: completion)
     }
 
     /// Remove the current user from a job's participants (soft delete for non-creators).
@@ -932,13 +943,18 @@ extension FirebaseService {
         }
     }
 
-    /// Async: update job status
-    func updateJobStatusAsync(jobId: String, newStatus: String) async throws {
+    /// Async: update editable job fields
+    func updateJobFieldsAsync(jobId: String, fields: [String: Any]) async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            self.updateJobStatus(jobId: jobId, newStatus: newStatus) { error in
+            self.updateJobFields(jobId: jobId, fields: fields) { error in
                 if let error = error { cont.resume(throwing: error) }
                 else { cont.resume(returning: ()) }
             }
         }
+    }
+
+    /// Async: update job status
+    func updateJobStatusAsync(jobId: String, newStatus: String) async throws {
+        try await updateJobFieldsAsync(jobId: jobId, fields: ["status": newStatus])
     }
 }

--- a/Job Tracker/intent/AppShortcuts.swift
+++ b/Job Tracker/intent/AppShortcuts.swift
@@ -60,6 +60,55 @@ struct JobTrackerShortcuts: AppShortcutsProvider {
                 shortTitle: "Next Job Address",
                 systemImageName: "mappin.and.ellipse"
             )
+            ,
+            AppShortcut(
+                intent: GetNearestJobAssignmentIntent(),
+                phrases: [
+                    "What's the assignment for my job in \(.applicationName)",
+                    "What is my current job assignment in \(.applicationName)",
+                    "Get my job assignment with \(.applicationName)"
+                ],
+                shortTitle: "Current Assignment",
+                systemImageName: "list.number"
+            ),
+            AppShortcut(
+                intent: SetNearestJobAssignmentIntent(),
+                phrases: [
+                    "Add assignment to my job in \(.applicationName)",
+                    "Set my current job assignment with \(.applicationName)"
+                ],
+                shortTitle: "Set Assignment",
+                systemImageName: "square.and.pencil"
+            ),
+            AppShortcut(
+                intent: SetNearestJobFootageIntent(),
+                phrases: [
+                    "Add CAN and NID footage in \(.applicationName)",
+                    "Add footage to my current job with \(.applicationName)",
+                    "Save CAN and NID footage with \(.applicationName)"
+                ],
+                shortTitle: "Add Footage",
+                systemImageName: "ruler"
+            ),
+            AppShortcut(
+                intent: GetNearestJobFootageIntent(),
+                phrases: [
+                    "What's the footage for my job in \(.applicationName)",
+                    "Get my current job footage with \(.applicationName)"
+                ],
+                shortTitle: "Current Footage",
+                systemImageName: "ruler.fill"
+            ),
+            AppShortcut(
+                intent: GetNearestJobSummaryIntent(),
+                phrases: [
+                    "What's my current job in \(.applicationName)",
+                    "Tell me about my job with \(.applicationName)",
+                    "Current job details in \(.applicationName)"
+                ],
+                shortTitle: "Current Job",
+                systemImageName: "briefcase"
+            )
         ]
     }
 }

--- a/Job Tracker/intent/JobIntentSupport.swift
+++ b/Job Tracker/intent/JobIntentSupport.swift
@@ -1,0 +1,147 @@
+import AppIntents
+import CoreLocation
+import Foundation
+
+@available(iOS 16.0, *)
+struct JobIntentTarget {
+    let job: Job
+    let locationWasUsed: Bool
+    let distanceInMeters: CLLocationDistance?
+    let fallbackReason: String?
+}
+
+@available(iOS 16.0, *)
+enum JobIntentFormatter {
+    static func shortAddress(_ full: String) -> String {
+        if let comma = full.firstIndex(of: ",") { return String(full[..<comma]) }
+        return full
+    }
+
+    static func spokenValue(_ value: String?) -> String? {
+        let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func footageLabel(_ rawValue: String?) -> String? {
+        guard let value = spokenValue(rawValue) else { return nil }
+        let lower = value.lowercased()
+        if lower.contains("foot") || lower.contains("feet") || lower.contains("'") { return value }
+        return "\(value) feet"
+    }
+
+    static func jobContext(_ target: JobIntentTarget) -> String {
+        let address = shortAddress(target.job.address)
+        if let distance = target.distanceInMeters, target.locationWasUsed {
+            if distance < 80 { return "the job you're at, \(address)" }
+            let miles = distance / 1609.344
+            return String(format: "the closest job, %@, %.1f miles away", address, miles)
+        }
+        return address
+    }
+}
+
+@available(iOS 16.0, *)
+final class JobIntentLocationProvider: NSObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation?, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+    }
+
+    func currentLocation() async -> CLLocation? {
+        let status = manager.authorizationStatus
+        guard status == .authorizedAlways || status == .authorizedWhenInUse else {
+            if status == .notDetermined {
+                manager.requestWhenInUseAuthorization()
+            }
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            manager.requestLocation()
+            timeoutTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                await MainActor.run { self?.finish(with: nil) }
+            }
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        finish(with: locations.last)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        finish(with: nil)
+    }
+
+    private func finish(with location: CLLocation?) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        continuation?.resume(returning: location)
+        continuation = nil
+    }
+}
+
+@available(iOS 16.0, *)
+enum JobIntentResolution {
+    case success(JobIntentTarget)
+    case failure(IntentDialog)
+}
+
+@available(iOS 16.0, *)
+enum JobIntentResolver {
+    static func todayJobs() async throws -> [Job] {
+        try await FirebaseService.shared.fetchJobsAsync(for: Date())
+    }
+
+    static func nearestTodayJob() async throws -> JobIntentTarget? {
+        let jobs = try await todayJobs()
+        guard !jobs.isEmpty else { return nil }
+
+        let locationProvider = JobIntentLocationProvider()
+        let currentLocation = await locationProvider.currentLocation()
+        if let currentLocation {
+            let locatedJobs = jobs.compactMap { job -> (job: Job, distance: CLLocationDistance)? in
+                guard let jobLocation = job.clLocation else { return nil }
+                return (job, jobLocation.distance(from: currentLocation))
+            }
+
+            if let nearest = locatedJobs.min(by: { $0.distance < $1.distance }) {
+                return JobIntentTarget(
+                    job: nearest.job,
+                    locationWasUsed: true,
+                    distanceInMeters: nearest.distance,
+                    fallbackReason: nil
+                )
+            }
+        }
+
+        let fallback = jobs
+            .sorted { lhs, rhs in
+                if lhs.status.lowercased() == "done" && rhs.status.lowercased() != "done" { return false }
+                if lhs.status.lowercased() != "done" && rhs.status.lowercased() == "done" { return true }
+                return lhs.date < rhs.date
+            }
+            .first
+
+        guard let fallback else { return nil }
+        return JobIntentTarget(
+            job: fallback,
+            locationWasUsed: false,
+            distanceInMeters: nil,
+            fallbackReason: "I couldn't use your current location, so I used your next job for today."
+        )
+    }
+
+    static func nearestJobOrDialog() async throws -> JobIntentResolution {
+        guard let target = try await nearestTodayJob() else {
+            return .failure(IntentDialog("You don't have any jobs scheduled for today."))
+        }
+        return .success(target)
+    }
+}

--- a/Job Tracker/intent/SiriJobDetailsIntents.swift
+++ b/Job Tracker/intent/SiriJobDetailsIntents.swift
@@ -1,0 +1,179 @@
+import AppIntents
+import Foundation
+
+@available(iOS 16.0, *)
+struct GetNearestJobAssignmentIntent: AppIntent {
+    static var openAppWhenRun: Bool = false
+    static var title: LocalizedStringResource = "Get Current Job Assignment"
+    static var description = IntentDescription("Reads the assignment for the job you are at or closest to today.")
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Get the current job assignment")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        switch try await JobIntentResolver.nearestJobOrDialog() {
+        case .failure(let dialog):
+            return .result(dialog: dialog)
+        case .success(let target):
+            let context = JobIntentFormatter.jobContext(target)
+            guard let assignment = JobIntentFormatter.spokenValue(target.job.assignments) else {
+                let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+                return .result(dialog: IntentDialog("\(prefix)There isn't an assignment saved for \(context)."))
+            }
+
+            let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+            return .result(dialog: IntentDialog("\(prefix)The assignment for \(context) is \(assignment)."))
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct SetNearestJobAssignmentIntent: AppIntent {
+    static var openAppWhenRun: Bool = false
+    static var title: LocalizedStringResource = "Set Current Job Assignment"
+    static var description = IntentDescription("Saves an assignment code on the job you are at or closest to today.")
+
+    @Parameter(title: "Assignment", requestValueDialog: "What assignment should I save?")
+    var assignment: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Set current job assignment to \(SetNearestJobAssignmentIntent.$assignment)")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        switch try await JobIntentResolver.nearestJobOrDialog() {
+        case .failure(let dialog):
+            return .result(dialog: dialog)
+        case .success(let target):
+            let trimmedAssignment = assignment.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedAssignment.isEmpty else {
+                return .result(dialog: IntentDialog("Please tell me the assignment to save."))
+            }
+
+            do {
+                try await FirebaseService.shared.updateJobFieldsAsync(
+                    jobId: target.job.id,
+                    fields: ["assignments": trimmedAssignment]
+                )
+            } catch {
+                return .result(dialog: IntentDialog("I couldn't save the assignment: \(error.localizedDescription)"))
+            }
+
+            let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+            return .result(dialog: IntentDialog("\(prefix)Saved assignment \(trimmedAssignment) for \(JobIntentFormatter.jobContext(target))."))
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct SetNearestJobFootageIntent: AppIntent {
+    static var openAppWhenRun: Bool = false
+    static var title: LocalizedStringResource = "Add Current Job Footage"
+    static var description = IntentDescription("Adds CAN and NID footage to the job you are at or closest to today.")
+
+    @Parameter(title: "CAN Footage", requestValueDialog: "What is the CAN footage?")
+    var canFootage: String
+
+    @Parameter(title: "NID Footage", requestValueDialog: "What is the NID footage?")
+    var nidFootage: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add CAN \(SetNearestJobFootageIntent.$canFootage) and NID \(SetNearestJobFootageIntent.$nidFootage) footage")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        switch try await JobIntentResolver.nearestJobOrDialog() {
+        case .failure(let dialog):
+            return .result(dialog: dialog)
+        case .success(let target):
+            let can = canFootage.trimmingCharacters(in: .whitespacesAndNewlines)
+            let nid = nidFootage.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !can.isEmpty || !nid.isEmpty else {
+                return .result(dialog: IntentDialog("Please tell me the CAN footage, the NID footage, or both."))
+            }
+
+            var fields: [String: Any] = [:]
+            if !can.isEmpty { fields["canFootage"] = can }
+            if !nid.isEmpty { fields["nidFootage"] = nid }
+
+            do {
+                try await FirebaseService.shared.updateJobFieldsAsync(jobId: target.job.id, fields: fields)
+            } catch {
+                return .result(dialog: IntentDialog("I couldn't save the footage: \(error.localizedDescription)"))
+            }
+
+            var pieces: [String] = []
+            if let canLabel = JobIntentFormatter.footageLabel(can) { pieces.append("CAN \(canLabel)") }
+            if let nidLabel = JobIntentFormatter.footageLabel(nid) { pieces.append("NID \(nidLabel)") }
+            let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+            return .result(dialog: IntentDialog("\(prefix)Saved \(pieces.joined(separator: " and ")) for \(JobIntentFormatter.jobContext(target))."))
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct GetNearestJobFootageIntent: AppIntent {
+    static var openAppWhenRun: Bool = false
+    static var title: LocalizedStringResource = "Get Current Job Footage"
+    static var description = IntentDescription("Reads the saved CAN and NID footage for the job you are at or closest to today.")
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Get current job footage")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        switch try await JobIntentResolver.nearestJobOrDialog() {
+        case .failure(let dialog):
+            return .result(dialog: dialog)
+        case .success(let target):
+            let can = JobIntentFormatter.footageLabel(target.job.canFootage)
+            let nid = JobIntentFormatter.footageLabel(target.job.nidFootage)
+            guard can != nil || nid != nil else {
+                let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+                return .result(dialog: IntentDialog("\(prefix)There isn't any CAN or NID footage saved for \(JobIntentFormatter.jobContext(target))."))
+            }
+
+            var pieces: [String] = []
+            if let can { pieces.append("CAN \(can)") }
+            if let nid { pieces.append("NID \(nid)") }
+            let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+            return .result(dialog: IntentDialog("\(prefix)For \(JobIntentFormatter.jobContext(target)), \(pieces.joined(separator: " and "))."))
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct GetNearestJobSummaryIntent: AppIntent {
+    static var openAppWhenRun: Bool = false
+    static var title: LocalizedStringResource = "Get Current Job Details"
+    static var description = IntentDescription("Summarizes the job you are at or closest to today, including status, assignment, and footage.")
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Get current job details")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        switch try await JobIntentResolver.nearestJobOrDialog() {
+        case .failure(let dialog):
+            return .result(dialog: dialog)
+        case .success(let target):
+            var details = ["status \(target.job.displayStatus)"]
+            if let assignment = JobIntentFormatter.spokenValue(target.job.assignments) {
+                details.append("assignment \(assignment)")
+            }
+            if let can = JobIntentFormatter.footageLabel(target.job.canFootage) {
+                details.append("CAN \(can)")
+            }
+            if let nid = JobIntentFormatter.footageLabel(target.job.nidFootage) {
+                details.append("NID \(nid)")
+            }
+            if let jobNumber = JobIntentFormatter.spokenValue(target.job.jobNumber) {
+                details.append("job number \(jobNumber)")
+            }
+
+            let prefix = target.fallbackReason.map { "\($0) " } ?? ""
+            return .result(dialog: IntentDialog("\(prefix)For \(JobIntentFormatter.jobContext(target)): \(details.joined(separator: ", "))."))
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose powerful Siri/App Intents so users can ask about or update the job they are at (or closest to) using natural voice like “Siri, what’s the assignment for my job?”.
- Allow voice-driven saving of CAN and NID footage and assignment codes directly to the correct job without exposing or modifying participants.
- Provide a robust nearest-job resolution that prefers current location but falls back to the next non-done job for today when location is unavailable.

### Description
- Added reusable nearest-job targeting and location helper in `Job Tracker/intent/JobIntentSupport.swift` that fetches today’s jobs, attempts to use Core Location to find the nearest job, and falls back to the next non-done job for today (includes friendly spoken context and formatting helpers).
- Implemented Siri/App Intents in `Job Tracker/intent/SiriJobDetailsIntents.swift` for: `GetNearestJobAssignmentIntent`, `SetNearestJobAssignmentIntent`, `SetNearestJobFootageIntent`, `GetNearestJobFootageIntent`, and `GetNearestJobSummaryIntent` which read and save assignment, CAN, and NID footage and summarize job details.
- Registered new App Shortcuts and Siri discovery phrases in `Job Tracker/intent/AppShortcuts.swift` for the new intents (examples: “What’s the assignment for my job…”, “Add CAN and NID footage…”, “What’s my current job…”).
- Extended Firestore helpers in `Job Tracker/Features/Shared/Services/FirebaseService.swift` by adding `updateJobFields` / `updateJobFieldsAsync` and wiring `updateJobStatus` / `updateJobStatusAsync` to reuse the generic field-updater so intents can update specific editable fields (e.g., `assignments`, `canFootage`, `nidFootage`) without modifying `participants`.
- Small adjustments to parameter summaries and intent wiring to ensure Shortcuts discovery strings include the new intents.

### Testing
- Ran `git diff --check` (no whitespace errors) and committed the changes successfully.
- Performed `swiftc -parse` on the modified intent/Firebase source files in this environment to validate basic Swift syntax; parsing succeeded for the changes in this environment.
- Attempted `swiftc -typecheck` and `xcodebuild -list` but full typechecking and Xcode build listing could not be completed here because the environment lacks Apple’s `AppIntents` module and `xcodebuild` (warnings noted in the test log).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e25171c0832dab8777b5171c0229)