### PR TITLE
Fix Siri intent parameter summaries

### DIFF
--- a/Job Tracker/intent/SiriJobDetailsIntents.swift
+++ b/Job Tracker/intent/SiriJobDetailsIntents.swift
@@ -38,7 +38,7 @@ struct SetNearestJobAssignmentIntent: AppIntent {
     var assignment: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Set current job assignment to \(SetNearestJobAssignmentIntent.$assignment)")
+        Summary("Set current job assignment to \(.$assignment)")
     }
 
     func perform() async throws -> some ProvidesDialog {
@@ -79,7 +79,7 @@ struct SetNearestJobFootageIntent: AppIntent {
     var nidFootage: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Add CAN \(SetNearestJobFootageIntent.$canFootage) and NID \(SetNearestJobFootageIntent.$nidFootage) footage")
+        Summary("Add CAN \(.$canFootage) and NID \(.$nidFootage) footage")
     }
 
     func perform() async throws -> some ProvidesDialog {


### PR DESCRIPTION
### Motivation
- Fix compiler errors caused by referencing AppIntent parameters via the type member key-path (e.g. `SetNearestJobAssignmentIntent.$assignment`) instead of using the instance key-path shorthand in `SiriJobDetailsIntents.swift`.

### Description
- Replace parameter summary interpolations in `Job Tracker/intent/SiriJobDetailsIntents.swift` to use the instance shorthand `\(.$assignment)`, `\(.$canFootage)`, and `\(.$nidFootage)` so the `Summary(...)` expressions compile.

### Testing
- Ran `git diff --check` which succeeded, ran `swift --version` to verify the toolchain, and attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` which could not run in this environment because `xcodebuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e9344358832db0f84014026e915e)