### PR TITLE
Fix parameter summary interpolation in Siri AppIntents

### DIFF
--- a/Job Tracker/intent/SiriJobDetailsIntents.swift
+++ b/Job Tracker/intent/SiriJobDetailsIntents.swift
@@ -38,7 +38,7 @@ struct SetNearestJobAssignmentIntent: AppIntent {
     var assignment: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Set current job assignment to \(SetNearestJobAssignmentIntent.$assignment)")
+        Summary("Set current job assignment to \(\SetNearestJobAssignmentIntent.$assignment)")
     }
 
     func perform() async throws -> some ProvidesDialog {
@@ -79,7 +79,7 @@ struct SetNearestJobFootageIntent: AppIntent {
     var nidFootage: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Add CAN \(SetNearestJobFootageIntent.$canFootage) and NID \(SetNearestJobFootageIntent.$nidFootage) footage")
+        Summary("Add CAN \(\SetNearestJobFootageIntent.$canFootage) and NID \(\SetNearestJobFootageIntent.$nidFootage) footage")
     }
 
     func perform() async throws -> some ProvidesDialog {


### PR DESCRIPTION
### Motivation
- Ensure parameter placeholders render correctly in AppIntent parameter summaries for Siri/Shortcuts by correcting the string interpolation/escaping in the summary text.

### Description
- Update `parameterSummary` strings in `SetNearestJobAssignmentIntent` to correctly reference the `assignment` parameter placeholder.
- Update `parameterSummary` strings in `SetNearestJobFootageIntent` to correctly reference the `canFootage` and `nidFootage` parameter placeholders.

### Testing
- Built the project with `xcodebuild` and ran the existing automated test suite; the build succeeded and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e9344358832db0f84014026e915e)