### PR TITLE
Qualify AppIntent parameter key paths in Siri job intents

### DIFF
--- a/Job Tracker/intent/SiriJobDetailsIntents.swift
+++ b/Job Tracker/intent/SiriJobDetailsIntents.swift
@@ -38,7 +38,7 @@ struct SetNearestJobAssignmentIntent: AppIntent {
     var assignment: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Set current job assignment to \(.$assignment)")
+        Summary("Set current job assignment to \(\SetNearestJobAssignmentIntent.$assignment)")
     }
 
     func perform() async throws -> some ProvidesDialog {
@@ -79,7 +79,7 @@ struct SetNearestJobFootageIntent: AppIntent {
     var nidFootage: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Add CAN \(.$canFootage) and NID \(.$nidFootage) footage")
+        Summary("Add CAN \(\SetNearestJobFootageIntent.$canFootage) and NID \(\SetNearestJobFootageIntent.$nidFootage) footage")
     }
 
     func perform() async throws -> some ProvidesDialog {


### PR DESCRIPTION
### Motivation
- Fix compiler errors like `Cannot infer contextual base in reference to member '$assignment'` and `Cannot convert value of type 'String' to expected argument type '() -> [PartialKeyPath<...>]` by ensuring the AppIntent parameter key paths are unambiguously referenced.

### Description
- In `Job Tracker/intent/SiriJobDetailsIntents.swift` qualify the parameter summaries so they use fully qualified key-paths: `\SetNearestJobAssignmentIntent.$assignment` and `\SetNearestJobFootageIntent.$canFootage` / `\SetNearestJobFootageIntent.$nidFootage` instead of the ambiguous `.$assignment` / `.$canFootage` forms.

### Testing
- Attempted to run an Xcode build listing (`xcodebuild -list -project 'Job Tracker.xcodeproj'`) but `xcodebuild` is not available in this environment so no automated build or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ee5eb5b0832da6dcb8df3a919a6f)