### PR TITLE
Add iOS Build and Test workflow

### DIFF
--- a/.github/workflows/ios-build-and-test.yml
+++ b/.github/workflows/ios-build-and-test.yml
@@ -1,0 +1,15 @@
+name: iOS Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest # This ensures the environment has Xcode installed
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and Test
+        run: xcodebuild test -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'platform=iOS Simulator,name=iPhone 15'


### PR DESCRIPTION
### Motivation
- Add automated iOS test runs for the `Job Tracker` project on pushes and pull requests to `main` using a macOS runner and iOS simulator.

### Description
- Added `.github/workflows/ios-build-and-test.yml` which defines a workflow named `iOS Build and Test` triggered on `push` and `pull_request` for the `main` branch.
- The workflow runs a single job on `macos-latest` that checks out the repository with `actions/checkout@v4` and executes `xcodebuild test -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'platform=iOS Simulator,name=iPhone 15'`.

### Testing
- Verified the workflow file parses as valid YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-build-and-test.yml"); puts "YAML OK"'`, which printed `YAML OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f3756bd0832dab8b44bbecde3eb2)