### PR TITLE
Add GitHub Actions workflow for iOS build

### DIFF
--- a/.github/workflows/ios-build-and-test.yml
+++ b/.github/workflows/ios-build-and-test.yml
@@ -1,0 +1,15 @@
+name: iOS Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest # This ensures the environment has Xcode installed
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: xcodebuild build -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'platform=iOS Simulator,name=iPhone 15'


### PR DESCRIPTION
### Motivation
- Add a CI workflow to ensure the Xcode project builds on macOS and to catch iOS build regressions early.
- Run builds on PRs and pushes to `main` so failures surface before merging.

### Description
- Add new workflow file at `.github/workflows/ios-build-and-test.yml` that defines an `iOS Build` workflow.
- Configure triggers for `push` and `pull_request` events targeting the `main` branch.
- Add a `build` job that runs on `macos-latest`, checks out the repo with `actions/checkout@v4`, and invokes `xcodebuild build -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'platform=iOS Simulator,name=iPhone 15'`.

### Testing
- No automated tests were executed as part of this change; the new workflow will run on subsequent pushes and pull requests to `main`.
- The workflow file syntax is a basic GitHub Actions YAML and is expected to run on `macos-latest` with Xcode installed when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f3756bd0832dab8b44bbecde3eb2)