### PR TITLE
Add cable clamp tracking for OH materials

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -52,6 +52,7 @@ struct JobDetailView: View {
     @State private var selectedMaterialNid = ""
     @State private var preformCount = 0
     @State private var jHooksCount = 0
+    @State private var cableClampsCount = 0
     @State private var canFootage = ""     // CAN footage
     @State private var nidFootage = ""
 
@@ -519,6 +520,7 @@ private let jobPlacementChoices = ["OH", "UG"]
                     if CrewPosition.matches(position, .oh) {
                         preformCount = 0
                         jHooksCount = 0
+                        cableClampsCount = 0
                         parseOHMaterials(from: materials)
                     } else {
                         switch position {
@@ -738,6 +740,15 @@ extension JobDetailView {
                         .foregroundColor(.secondary)
                 }
             }
+            // Cable clamps
+            Stepper(value: $cableClampsCount, in: 0...100) {
+                HStack {
+                    Text("Cable Clamps")
+                    Spacer()
+                    Text("\(cableClampsCount)")
+                        .foregroundColor(.secondary)
+                }
+            }
             // U-Guard
             Stepper(value: $uGuardCount, in: 0...5) {
                 HStack {
@@ -906,6 +917,7 @@ extension JobDetailView {
                 }
                 if preformCount > 0 { parts.append("Preforms: \(preformCount)") }
                 if jHooksCount > 0 { parts.append("J Hooks: \(jHooksCount)") }
+                if cableClampsCount > 0 { parts.append("Cable Clamps: \(cableClampsCount)") }
                 if uGuardCount > 0 { parts.append("U-Guard: \(uGuardCount)") }
                 if storageBracket { parts.append("Storage Bracket") }
                 job.materialsUsed = parts.isEmpty ? nil : parts.joined(separator: ", ")
@@ -1006,7 +1018,7 @@ extension JobDetailView {
     // MARK: - Materials Parsing Helpers
     /// Parse an OH materials string we previously saved to restore UI state.
     private func parseOHMaterials(from text: String) {
-        // Expected tokens like: "Weatherhead" or "Rams Head", "Preforms: N", "J Hooks: N", "U-Guard: N", "Storage Bracket"
+        // Expected tokens like: "Weatherhead" or "Rams Head", "Preforms: N", "J Hooks: N", "Cable Clamps: N", "U-Guard: N", "Storage Bracket"
         selectedMaterialOH = "None"
         let lower = text.lowercased()
         if lower.contains("weatherhead") {
@@ -1021,6 +1033,7 @@ extension JobDetailView {
 
         if let n = captureInt(after: "preforms:", in: lower) { preformCount = n }
         if let n = captureInt(after: "j hooks:", in: lower) { jHooksCount = n }
+        if let n = captureInt(after: "cable clamps:", in: lower) { cableClampsCount = n }
         if let n = captureInt(after: "u-guard:", in: lower) { uGuardCount = n }
         storageBracket = lower.contains("storage bracket")
     }


### PR DESCRIPTION
### Motivation
- Allow overhead (OH) users to record and track how many cable clamps they use on a job and have that information saved with the job materials.
- Ensure counts are persisted and restored when an OH job is reopened so supervisors/crew can review clamp usage alongside other OH materials.

### Description
- Added a new state property `cableClampsCount` to `JobDetailView` for tracking cable clamps in the OH materials UI (`Job Tracker/Features/Jobs/Editor/JobDetailView.swift`).
- Inserted a stepper control labeled "Cable Clamps" into the OH materials section so OH users can increment/decrement counts in the job detail view.
- Updated the save logic to include `Cable Clamps: N` in the assembled `materialsUsed` summary when saving OH materials and to persist it to `job.materialsUsed`.
- Restored previously saved clamp counts by updating `parseOHMaterials` to capture `cable clamps:` and initializing `cableClampsCount` on view appear.

### Testing
- Ran `git diff --check` and it completed without issues.
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` but it could not be executed in this environment because `xcodebuild` is not available, so a full Xcode build/test run was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f6e07b70832d918e29cc5373c775)