### PR TITLE
Improve location handling for intents and add detailed fallback reasons

### DIFF
--- a/Job Tracker/intent/JobIntentSupport.swift
+++ b/Job Tracker/intent/JobIntentSupport.swift
@@ -41,9 +41,42 @@ enum JobIntentFormatter {
 }
 
 @available(iOS 16.0, *)
+enum JobIntentLocationResult {
+    case success(CLLocation)
+    case locationServicesDisabled
+    case permissionDenied
+    case permissionRestricted
+    case permissionNotDetermined
+    case timedOut
+    case failed(String)
+
+    var fallbackReason: String {
+        switch self {
+        case .success:
+            return ""
+        case .locationServicesDisabled:
+            return "Location Services are turned off, so I used your next job for today."
+        case .permissionDenied:
+            return "Job Tracker doesn't have permission to use your location, so I used your next job for today."
+        case .permissionRestricted:
+            return "Location access is restricted on this device, so I used your next job for today."
+        case .permissionNotDetermined:
+            return "Job Tracker needs location permission before Siri can find your current job, so I used your next job for today."
+        case .timedOut:
+            return "I couldn't get your current location within 10 seconds, so I used your next job for today."
+        case .failed(let message):
+            if message.isEmpty {
+                return "I couldn't get your current location, so I used your next job for today."
+            }
+            return "I couldn't get your current location because \(message), so I used your next job for today."
+        }
+    }
+}
+
+@available(iOS 16.0, *)
 final class JobIntentLocationProvider: NSObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
-    private var continuation: CheckedContinuation<CLLocation?, Never>?
+    private var continuation: CheckedContinuation<JobIntentLocationResult, Never>?
     private var timeoutTask: Task<Void, Never>?
 
     override init() {
@@ -52,37 +85,52 @@ final class JobIntentLocationProvider: NSObject, CLLocationManagerDelegate {
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
     }
 
-    func currentLocation() async -> CLLocation? {
+    func currentLocation() async -> JobIntentLocationResult {
+        guard CLLocationManager.locationServicesEnabled() else {
+            return .locationServicesDisabled
+        }
+
         let status = manager.authorizationStatus
         guard status == .authorizedAlways || status == .authorizedWhenInUse else {
-            if status == .notDetermined {
+            switch status {
+            case .notDetermined:
                 manager.requestWhenInUseAuthorization()
+                return .permissionNotDetermined
+            case .denied:
+                return .permissionDenied
+            case .restricted:
+                return .permissionRestricted
+            default:
+                return .failed("")
             }
-            return nil
         }
 
         return await withCheckedContinuation { continuation in
             self.continuation = continuation
             manager.requestLocation()
             timeoutTask = Task { [weak self] in
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
-                await MainActor.run { self?.finish(with: nil) }
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                await MainActor.run { self?.finish(with: .timedOut) }
             }
         }
     }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        finish(with: locations.last)
+        guard let location = locations.last else {
+            finish(with: .failed("Core Location returned no location updates"))
+            return
+        }
+        finish(with: .success(location))
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        finish(with: nil)
+        finish(with: .failed(error.localizedDescription))
     }
 
-    private func finish(with location: CLLocation?) {
+    private func finish(with result: JobIntentLocationResult) {
         timeoutTask?.cancel()
         timeoutTask = nil
-        continuation?.resume(returning: location)
+        continuation?.resume(returning: result)
         continuation = nil
     }
 }
@@ -104,8 +152,10 @@ enum JobIntentResolver {
         guard !jobs.isEmpty else { return nil }
 
         let locationProvider = JobIntentLocationProvider()
-        let currentLocation = await locationProvider.currentLocation()
-        if let currentLocation {
+        let locationResult = await locationProvider.currentLocation()
+        let fallbackReason: String
+        switch locationResult {
+        case .success(let currentLocation):
             let locatedJobs = jobs.compactMap { job -> (job: Job, distance: CLLocationDistance)? in
                 guard let jobLocation = job.clLocation else { return nil }
                 return (job, jobLocation.distance(from: currentLocation))
@@ -119,6 +169,10 @@ enum JobIntentResolver {
                     fallbackReason: nil
                 )
             }
+
+            fallbackReason = "I got your location, but today's jobs don't have map locations saved, so I used your next job for today."
+        default:
+            fallbackReason = locationResult.fallbackReason
         }
 
         let fallback = jobs
@@ -134,7 +188,7 @@ enum JobIntentResolver {
             job: fallback,
             locationWasUsed: false,
             distanceInMeters: nil,
-            fallbackReason: "I couldn't use your current location, so I used your next job for today."
+            fallbackReason: fallbackReason
         )
     }
 


### PR DESCRIPTION
### Motivation
- Provide explicit, structured results from location requests so the intent flow can give clearer fallback messages to users.
- Replace ambiguous `nil` location returns with typed outcomes to surface permission, timeout, and error reasons.
- Make location retrieval more tolerant by increasing the request timeout and by handling common error states explicitly.

### Description
- Add a new `JobIntentLocationResult` enum with cases for success, various permission states, timeout, and failure, and a `fallbackReason` computed property for user-facing messages.
- Change `JobIntentLocationProvider.currentLocation()` to return `JobIntentLocationResult`, add an early `CLLocationManager.locationServicesEnabled()` check, map authorization statuses to result cases, and request authorization when appropriate.
- Update `CLLocationManager` delegate callbacks to resume the continuation with `.success` or `.failed(String)`, and increase the location request timeout from 3 seconds to 10 seconds returning `.timedOut` on expiry.
- Update `JobIntentResolver.nearestTodayJob()` to handle the new `JobIntentLocationResult`, compute nearest job when location succeeds, and use the result's `fallbackReason` when falling back to the next job.

### Testing
- The project was built after the changes to ensure Swift compilation succeeded without errors.
- Automated unit tests in the project were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a0e134c84832da0175596fe3b5e63)