### PR TITLE
Strengthen Xcode Cloud safety net

### DIFF
--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -1,34 +1,58 @@
 # Xcode Cloud Testing Setup
 
-The `Job Tracker` shared scheme is wired to run the `Job TrackerTests` XCTest bundle. That means local Xcode test runs and Xcode Cloud test actions use the same target and scheme.
+The repository now treats Xcode Cloud as the safety net for the full app project instead of a single one-off test target hookup.
+
+## What is wired together
+
+- The shared `Job Tracker` scheme runs `Job Tracker Safety Net.xctestplan`.
+- The safety-net test plan includes the `Job TrackerTests` XCTest bundle and collects code coverage.
+- The scheme still builds the main app target, which also builds the embedded watch app dependency through the project graph.
+- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, or XCTest target coverage drifts out of date.
 
 ## Run tests locally
 
 From Xcode, select the `Job Tracker` scheme and press `⌘U`.
 
-From Terminal on a Mac with Xcode installed, run:
+From Terminal on a Mac with Xcode installed, run the same test plan Xcode Cloud uses:
 
 ```sh
-xcodebuild test -scheme "Job Tracker" -destination 'platform=iOS Simulator,name=iPhone 15'
+xcodebuild test \
+  -project "Job Tracker.xcodeproj" \
+  -scheme "Job Tracker" \
+  -testPlan "Job Tracker Safety Net" \
+  -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+You can also run the configuration guardrail locally:
+
+```sh
+ci_scripts/ci_pre_xcodebuild.sh
 ```
 
 ## Recommended Xcode Cloud workflow
 
-Create a workflow in Xcode with these settings:
+Create or update the workflow in Xcode with these settings:
 
-1. Open **Product → Xcode Cloud → Create Workflow**.
+1. Open **Product → Xcode Cloud → Create Workflow** or edit the existing workflow.
 2. Use the repository's shared `Job Tracker` scheme.
 3. Add a **Test** action.
-4. Choose an iOS Simulator destination, such as a current iPhone simulator.
-5. Enable the workflow for pull requests once the suite is stable.
+4. Select the `Job Tracker Safety Net` test plan.
+5. Choose a current iOS Simulator destination that Xcode Cloud supports.
+6. Enable code coverage for the workflow.
+7. Run the workflow for pull requests and before release/archive workflows.
 
-A separate Build action is not required before the Test action because Xcode builds the app for testing as part of the test action.
+A separate Build action is not required before the Test action because Xcode builds the app, watch dependency, and test host as part of the test action.
 
-## What belongs in this suite
+## Future-proofing rules
 
-Keep pull-request tests fast and deterministic:
+Keep this setup as the default safety net when the project grows:
 
-- Prefer unit tests for parsing, search matching, version comparison, routing, and view model logic.
-- Use mocks or in-memory fakes for Firebase, location, map search, and network-backed services.
-- Avoid tests that write to production Firebase data.
-- Move slow or device-sensitive tests into a separate workflow or test plan later if needed.
+- Add every new XCTest or UI-test bundle to `Job Tracker Safety Net.xctestplan` before merging it.
+- Keep the `Job Tracker` scheme shared and pointed at the safety-net test plan.
+- Keep code coverage enabled in both the scheme and the test plan.
+- Prefer deterministic unit tests for parsing, search matching, app-update checks, routing, view models, PDF helpers, import/export payloads, and admin logic.
+- Use mocks or in-memory fakes for Firebase, location, map search, filesystem, and network-backed services.
+- Avoid tests that write to production Firebase data or depend on physical devices.
+- Move slow, flaky, device-only, or external-integration checks into an additional workflow/test plan instead of weakening this one.
+
+The guardrail script intentionally detects new XCTest targets in the project and fails the workflow if they are not listed in the safety-net test plan. That makes future test bundles opt-out by exception instead of accidentally invisible to Xcode Cloud.

--- a/Job Tracker Safety Net.xctestplan
+++ b/Job Tracker Safety Net.xctestplan
@@ -1,0 +1,26 @@
+{
+  "configurations" : [
+    {
+      "id" : "1C2DD7E4-8DA2-44E6-9751-1F5C6E28B9E0",
+      "name" : "Safety Net"
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Job Tracker.xcodeproj",
+      "identifier" : "CDDA111C2D579EC0007BADFF",
+      "name" : "Job Tracker"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Job Tracker.xcodeproj",
+        "identifier" : "CD7E57000000000000000106",
+        "name" : "Job TrackerTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
+++ b/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
@@ -26,7 +26,14 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Job Tracker Safety Net.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Xcode Cloud safety-net guardrails.
+# Fails fast when future project changes leave the shared scheme/test plan behind.
+set -eu
+
+PROJECT_PATH="Job Tracker.xcodeproj"
+SCHEME_PATH="$PROJECT_PATH/xcshareddata/xcschemes/Job Tracker.xcscheme"
+TEST_PLAN_PATH="Job Tracker Safety Net.xctestplan"
+log() {
+  printf '[xcode-cloud-safety-net] %s\n' "$1"
+}
+
+fail() {
+  printf '[xcode-cloud-safety-net] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+require_file() {
+  [ -f "$1" ] || fail "Missing required file: $1"
+}
+
+require_file "$PROJECT_PATH/project.pbxproj"
+require_file "$SCHEME_PATH"
+require_file "$TEST_PLAN_PATH"
+
+python3 <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+project = Path("Job Tracker.xcodeproj/project.pbxproj").read_text()
+scheme = Path("Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme").read_text()
+plan_path = Path("Job Tracker Safety Net.xctestplan")
+plan = json.loads(plan_path.read_text())
+
+errors = []
+
+def check(condition, message):
+    if not condition:
+        errors.append(message)
+
+check('reference = "container:Job Tracker Safety Net.xctestplan"' in scheme,
+      "Shared Job Tracker scheme must use the safety-net test plan.")
+check('codeCoverageEnabled = "YES"' in scheme,
+      "Shared Job Tracker scheme must keep code coverage enabled for tests.")
+check('BlueprintName = "Job TrackerTests"' in scheme and 'skipped = "NO"' in scheme,
+      "Shared Job Tracker scheme must include the Job TrackerTests bundle and keep it enabled.")
+
+check(plan.get("version") == 1, "Test plan version must remain 1 for broad Xcode compatibility.")
+check(plan.get("defaultOptions", {}).get("codeCoverage") is True,
+      "Safety-net test plan must collect code coverage.")
+expansion_target = plan.get("defaultOptions", {}).get("targetForVariableExpansion", {})
+check(expansion_target.get("name") == "Job Tracker",
+      "Safety-net test plan must expand variables against the app target.")
+
+plan_targets = {
+    target.get("target", {}).get("identifier"): target.get("target", {}).get("name")
+    for target in plan.get("testTargets", [])
+}
+check(plan_targets.get("CD7E57000000000000000106") == "Job TrackerTests",
+      "Safety-net test plan must include the Job TrackerTests target.")
+
+# Future-proofing: if another XCTest target is added to the project later, require it to be added to this plan too.
+project_test_targets = {}
+for match in re.finditer(r'([A-F0-9]{24}) /\* ([^*]+) \*/ = \{\n\s+isa = PBXNativeTarget;(?P<body>.*?)\n\s+\};', project, re.S):
+    identifier, name, body = match.group(1), match.group(2), match.group('body')
+    if 'productType = "com.apple.product-type.bundle.unit-test";' in body or 'productType = "com.apple.product-type.bundle.ui-testing";' in body:
+        project_test_targets[identifier] = name
+
+missing = {identifier: name for identifier, name in project_test_targets.items() if plan_targets.get(identifier) != name}
+check(not missing,
+      "Safety-net test plan is missing XCTest targets from the project: " + ", ".join(f"{name} ({identifier})" for identifier, name in missing.items()))
+
+if errors:
+    for error in errors:
+        print(f"[xcode-cloud-safety-net] ERROR: {error}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+if command -v xcodebuild >/dev/null 2>&1; then
+  log "Checking that Xcode can resolve the shared scheme."
+  xcodebuild -list -project "$PROJECT_PATH" >/dev/null
+else
+  log "xcodebuild is not available; skipped local scheme-resolution check. Xcode Cloud will run it."
+fi
+
+log "Safety-net configuration is valid."


### PR DESCRIPTION
### Motivation

- Treat Xcode Cloud as the project-wide safety net so tests remain reliable as the project grows.  
- Prevent future changes from accidentally leaving XCTest bundles out of coverage or the shared scheme.  
- Make the verification fast and automatable in Xcode Cloud by failing early when wiring drifts.

### Description

- Add `Job Tracker Safety Net.xctestplan` that enables code coverage and registers the `Job TrackerTests` bundle against the `Job Tracker` app target.  
- Update the shared `Job Tracker` scheme to enable code coverage and reference the safety-net test plan.  
- Add an executable guardrail script `ci_scripts/ci_pre_xcodebuild.sh` that validates the presence of the project, shared scheme, and test plan, enforces coverage settings, and fails if new XCTest/UI-test targets are added without being included in the plan.  
- Update `Documentation/XcodeCloudTesting.md` with the test-plan local `xcodebuild` command, guardrail instructions, recommended workflow settings, and future-proofing rules.

### Testing

- Ran `./ci_scripts/ci_pre_xcodebuild.sh`, which completed successfully and emitted a note that `xcodebuild` is not available locally (expected in this environment).  
- Validated `Job Tracker Safety Net.xctestplan` JSON with `python3 -m json.tool`, which succeeded.  
- Parsed the updated scheme XML with `python3` (`xml.etree.ElementTree`) which succeeded.  
- Performed a shell syntax check with `sh -n ci_scripts/ci_pre_xcodebuild.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3681fd00832db054a15ef890a0cd)