### PR TITLE
Add safety‑net tests, wire Job TrackerTests into shared scheme, and add testing docs

### DIFF
--- a/Documentation/TestingSafetyNet.md
+++ b/Documentation/TestingSafetyNet.md
@@ -1,0 +1,35 @@
+# Testing Safety Net
+
+This project uses the shared `Job Tracker` scheme and `Job Tracker Safety Net.xctestplan` as the default unit-test safety net for local development and Xcode Cloud.
+
+## Coverage map
+
+The `Job TrackerTests` bundle should keep fast, deterministic XCTest coverage around the areas that are most likely to break core workflows:
+
+- **User and role modeling**: `AppUserTests`, `CrewPositionTests`, and related model tests cover decoding defaults, fallback display helpers, and crew-position normalization for current and legacy labels.
+- **App update gating**: `AppVersionComparatorTests` and `ForceUpdateViewModelTests` cover version/build comparisons, disabled update requirements, provider errors, and forced-update decisions.
+- **Admin and maintenance workflows**: `AdminPanelViewModelTests`, `PackageUpdateServiceTests`, and admin update tests cover privileged mutations, package retention, and safe apply-window gates without touching production Firebase data.
+- **Job intake, sharing, and search**: Deep-link, shared-payload, parser, and search-matcher tests cover import/export payloads and matching heuristics that affect daily job routing.
+- **Dashboard and recent crew jobs**: View-model tests cover summaries and detail sheets that crew members use to understand current work.
+- **Help and tutorial flows**: Tutorial stage tests protect onboarding guidance from accidental regressions.
+
+## Minimum expectations for future work
+
+Add or update tests in the same pull request when a change affects any of these behaviors:
+
+1. Decoding or encoding app models that come from Firebase, links, files, or JSON payloads.
+2. Crew-position, job-status, search, or matching normalization logic.
+3. View models with business decisions, especially admin, update, dashboard, job list, timesheet, yellow sheet, and sharing workflows.
+4. App update requirements, version comparisons, package downloads, package retention, or safe-apply conditions.
+5. Deep links, shared job payloads, imported job sheets, or parsing of externally supplied data.
+6. Bug fixes where a regression test can reproduce the failing case.
+
+Prefer small unit tests with mocks, fakes, in-memory data, and injected closures. Do not depend on production Firebase documents, physical devices, wall-clock timing, or external network services in the safety-net plan. Slow integration tests should live in a separate plan or workflow so the main pull-request test action remains reliable.
+
+## Keeping the safety net wired
+
+- Keep `Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme` shared.
+- Keep the scheme's Test action pointed at `Job Tracker Safety Net.xctestplan`.
+- Keep code coverage enabled in both the shared scheme and the test plan.
+- Add every new XCTest or UI-test target to `Job Tracker Safety Net.xctestplan` unless it is intentionally isolated in a separate documented workflow.
+- Run `ci_scripts/ci_pre_xcodebuild.sh` after changing the Xcode project, shared scheme, or test plan. The script fails when the scheme no longer references the plan, coverage is disabled, or an XCTest target is missing from the plan.

--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -29,6 +29,10 @@ You can also run the configuration guardrail locally:
 ci_scripts/ci_pre_xcodebuild.sh
 ```
 
+## Safety-net expectations
+
+The `Job TrackerTests` bundle is intentionally part of the shared `Job Tracker` scheme so Xcode Cloud and local developers run the same tests. See [Testing Safety Net](TestingSafetyNet.md) for the coverage map and the minimum expectations for future changes.
+
 ## Recommended Xcode Cloud workflow
 
 Create or update the workflow in Xcode with these settings:

--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		CDDA116C2D579F85007BADFF /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA116B2D579F85007BADFF /* FirebaseCore */; };
 		CDDA116E2D579F85007BADFF /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA116D2D579F85007BADFF /* FirebaseDatabase */; };
 		CDDA11702D579F85007BADFF /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA116F2D579F85007BADFF /* FirebaseFirestore */; };
+		CD7E5700000000000000010C /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA116F2D579F85007BADFF /* FirebaseFirestore */; };
 		CDDA11722D579F85007BADFF /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA11712D579F85007BADFF /* FirebaseStorage */; };
 		CDFE39FE2FA3624A00AEEAAB /* WebMaps in Resources */ = {isa = PBXBuildFile; fileRef = CDFE39FD2FA3624A00AEEAAB /* WebMaps */; };
 /* End PBXBuildFile section */
@@ -113,6 +114,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD7E5700000000000000010C /* FirebaseFirestore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -232,6 +234,7 @@
 			);
 			name = "Job TrackerTests";
 			packageProductDependencies = (
+				CDDA116F2D579F85007BADFF /* FirebaseFirestore */,
 			);
 			productName = "Job TrackerTests";
 			productReference = CD7E57000000000000000101 /* Job TrackerTests.xctest */;

--- a/Job TrackerTests/AppUserTests.swift
+++ b/Job TrackerTests/AppUserTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Job_Tracker
+
+final class AppUserTests: XCTestCase {
+    func testInitialsUseFirstAndLastNameUppercased() {
+        let user = AppUser(
+            id: "user-1",
+            firstName: "quinton",
+            lastName: "thompson",
+            email: "quinton@example.com",
+            position: "OH"
+        )
+
+        XCTAssertEqual(user.initials, "QT")
+    }
+
+    func testInitialsHandleMissingNameParts() {
+        let firstOnly = AppUser(firstName: "Alex", lastName: "", email: "alex@example.com", position: "UG")
+        let lastOnly = AppUser(firstName: "", lastName: "Rivera", email: "rivera@example.com", position: "Can")
+
+        XCTAssertEqual(firstOnly.initials, "A")
+        XCTAssertEqual(lastOnly.initials, "R")
+    }
+
+    func testDecodingDefaultsMissingOptionalAndAccessFields() throws {
+        let json = """
+        {
+          "id": "user-2",
+          "firstName": "Blair",
+          "lastName": "Stone",
+          "email": "blair@example.com",
+          "position": "Aerial"
+        }
+        """.data(using: .utf8)!
+
+        let user = try JSONDecoder().decode(AppUser.self, from: json)
+
+        XCTAssertEqual(user.id, "user-2")
+        XCTAssertEqual(user.firstName, "Blair")
+        XCTAssertEqual(user.lastName, "Stone")
+        XCTAssertEqual(user.email, "blair@example.com")
+        XCTAssertEqual(user.position, "Aerial")
+        XCTAssertNil(user.profilePictureURL)
+        XCTAssertFalse(user.isAdmin)
+        XCTAssertFalse(user.isSupervisor)
+        XCTAssertEqual(user.normalizedPosition, "OH")
+    }
+
+    func testDecodingGeneratesIDWhenMissing() throws {
+        let json = """
+        {
+          "firstName": "Casey",
+          "lastName": "Nguyen",
+          "email": "casey@example.com",
+          "position": "Nid",
+          "isAdmin": true,
+          "isSupervisor": true
+        }
+        """.data(using: .utf8)!
+
+        let user = try JSONDecoder().decode(AppUser.self, from: json)
+
+        XCTAssertFalse(user.id.isEmpty)
+        XCTAssertTrue(user.isAdmin)
+        XCTAssertTrue(user.isSupervisor)
+    }
+}

--- a/Job TrackerTests/CrewPositionTests.swift
+++ b/Job TrackerTests/CrewPositionTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Job_Tracker
+
+final class CrewPositionTests: XCTestCase {
+    func testLegacyOHAliasesDisplayAsOH() {
+        XCTAssertEqual(CrewPosition.positionDisplayName(from: "Aerial"), "OH")
+        XCTAssertEqual(CrewPosition.positionDisplayName(from: " ariel "), "OH")
+        XCTAssertEqual(CrewPosition.positionDisplayName(from: "Arial"), "OH")
+        XCTAssertEqual(CrewPosition.positionDisplayName(from: "Overhead"), "OH")
+    }
+
+    func testNormalizedKeyCollapsesKnownCrewPositions() {
+        XCTAssertEqual(CrewPosition.normalizedKey(from: " underground "), "UG")
+        XCTAssertEqual(CrewPosition.normalizedKey(from: "ug"), "UG")
+        XCTAssertEqual(CrewPosition.normalizedKey(from: "can"), "Can")
+        XCTAssertEqual(CrewPosition.normalizedKey(from: "nid"), "Nid")
+        XCTAssertEqual(CrewPosition.normalizedKey(from: nil), "")
+    }
+
+    func testMatchesComparesRawValuesAgainstNormalizedCrewPosition() {
+        XCTAssertTrue(CrewPosition.matches("aerial", .oh))
+        XCTAssertTrue(CrewPosition.matches("Underground", .ug))
+        XCTAssertTrue(CrewPosition.matches(" CAN ", .can))
+        XCTAssertFalse(CrewPosition.matches("Nid", .oh))
+    }
+
+    func testStatusNormalizationKeepsNeedsOHConsistent() {
+        XCTAssertEqual(CrewPosition.normalizedStatusForSaving("Needs Aerial"), "Needs OH")
+        XCTAssertEqual(CrewPosition.statusDisplayName(from: " needs overhead "), "Needs OH")
+        XCTAssertEqual(CrewPosition.normalizedStatusForSaving("Complete"), "Complete")
+    }
+}

--- a/Job TrackerTests/ForceUpdateViewModelTests.swift
+++ b/Job TrackerTests/ForceUpdateViewModelTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import FirebaseFirestore
+@testable import Job_Tracker
+
+@MainActor
+final class ForceUpdateViewModelTests: XCTestCase {
+    func testStartMonitoringRequiresUpdateWhenProviderPublishesNewerMinimumVersion() async {
+        let provider = MockAppUpdateRequirementProvider()
+        let viewModel = ForceUpdateViewModel(
+            provider: provider,
+            currentVersionProvider: { "2.1.0" },
+            currentBuildProvider: { "10" }
+        )
+
+        viewModel.startMonitoring()
+        provider.publish(.success(AppUpdateRequirement(latestVersion: "2.2.0", minimumRequiredVersion: "2.1.1")))
+        await Task.yield()
+
+        guard case let .updateRequired(requirement) = viewModel.decision else {
+            return XCTFail("Expected updateRequired decision")
+        }
+        XCTAssertEqual(requirement.latestVersion, "2.2.0")
+        XCTAssertNil(viewModel.lastErrorMessage)
+    }
+
+    func testStartMonitoringLeavesCurrentAppUpToDateWhenRequirementIsDisabled() async {
+        let provider = MockAppUpdateRequirementProvider()
+        let viewModel = ForceUpdateViewModel(
+            provider: provider,
+            currentVersionProvider: { "2.1.0" },
+            currentBuildProvider: { "10" }
+        )
+
+        viewModel.startMonitoring()
+        provider.publish(.success(AppUpdateRequirement(latestVersion: "9.0.0", isEnabled: false)))
+        await Task.yield()
+
+        XCTAssertEqual(viewModel.decision, .upToDate)
+        XCTAssertNil(viewModel.lastErrorMessage)
+    }
+
+    func testStartMonitoringStoresErrorWithoutChangingLastDecision() async {
+        let provider = MockAppUpdateRequirementProvider()
+        let viewModel = ForceUpdateViewModel(
+            provider: provider,
+            currentVersionProvider: { "2.1.0" },
+            currentBuildProvider: { "10" }
+        )
+        let requirement = AppUpdateRequirement(latestVersion: "2.2.0")
+        let error = NSError(domain: "ForceUpdateViewModelTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "offline"])
+
+        viewModel.startMonitoring()
+        provider.publish(.success(requirement))
+        await Task.yield()
+        provider.publish(.failure(error))
+        await Task.yield()
+
+        XCTAssertEqual(viewModel.decision, .updateRequired(requirement))
+        XCTAssertEqual(viewModel.lastErrorMessage, "offline")
+    }
+
+    func testStartMonitoringOnlyRegistersOneProviderListener() {
+        let provider = MockAppUpdateRequirementProvider()
+        let viewModel = ForceUpdateViewModel(provider: provider)
+
+        viewModel.startMonitoring()
+        viewModel.startMonitoring()
+
+        XCTAssertEqual(provider.observeCallCount, 1)
+    }
+}
+
+private final class MockAppUpdateRequirementProvider: AppUpdateRequirementProviding {
+    private var onChange: ((Result<AppUpdateRequirement?, Error>) -> Void)?
+    private(set) var observeCallCount = 0
+
+    @discardableResult
+    func observeRequirement(_ onChange: @escaping (Result<AppUpdateRequirement?, Error>) -> Void) -> ListenerRegistration? {
+        observeCallCount += 1
+        self.onChange = onChange
+        return nil
+    }
+
+    func publish(_ result: Result<AppUpdateRequirement?, Error>) {
+        onChange?(result)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Automated tests live under `Job TrackerTests`. The suite exercises:
 - Deep link routing and job share payload parsing.
 - Job search matching heuristics and crew job summaries.
 - Yellow sheet and timesheet PDF generation pipelines.
+- App user decoding, crew-position normalization, and forced-update gating.
+
+The shared `Job Tracker` scheme includes the `Job TrackerTests` bundle through `Job Tracker Safety Net.xctestplan`, which is the baseline for local CI and Xcode Cloud. See [Testing Safety Net](Documentation/TestingSafetyNet.md) for the coverage map and future testing expectations.
 
 Run the full suite from Xcode (`⌘U`) or via command line:
 


### PR DESCRIPTION
### Motivation
- Make unit tests buildable and runnable by Xcode Cloud and local CI by adding a test target and coverage for common model and view‑model gates. 
- Ensure the repository has a documented safety‑net and recommended workflow so future test/target changes are surfaced by CI guardrails. 

### Description
- Add three new XCTest files under `Job TrackerTests`: `AppUserTests.swift`, `CrewPositionTests.swift`, and `ForceUpdateViewModelTests.swift` (includes a small `MockAppUpdateRequirementProvider`).
- Wire the `Job TrackerTests` target into the project so it can run under the shared `Job Tracker` scheme by adding `FirebaseFirestore` to the test target frameworks and package product dependencies in `Job Tracker.xcodeproj/project.pbxproj`.
- Add testing documentation `Documentation/TestingSafetyNet.md` describing coverage map and minimum expectations, and update `Documentation/XcodeCloudTesting.md` with safety‑net expectations.
- Update `README.md` to mention the `Job TrackerTests` bundle and link to the new testing docs.

### Testing
- Ran the safety‑net guard script `ci_scripts/ci_pre_xcodebuild.sh`, which passed validation; local `xcodebuild` resolution was skipped because `xcodebuild` is not available in this environment. 
- Linted the Xcode project file with `plutil` and validated the test plan JSON with `python3 -m json.tool`, both of which succeeded. 
- Note: the new XCTest files were added but full `xcodebuild test` runs were not executed here because `xcodebuild` was unavailable in the environment; the repo is prepared for running the suite locally or on Xcode Cloud using the shared `Job Tracker` scheme and `Job Tracker Safety Net` test plan (`xcodebuild test -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -testPlan "Job Tracker Safety Net" -destination 'platform=iOS Simulator,name=iPhone 15'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a399831cc832db0b5d5a251b4f708)