### PR TITLE
Fix Xcode Cloud prebuild script path

### DIFF
--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -3,6 +3,10 @@
 # Fails fast when future project changes leave the shared scheme/test plan behind.
 set -eu
 
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPOSITORY_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)
+cd "$REPOSITORY_ROOT"
+
 PROJECT_PATH="Job Tracker.xcodeproj"
 SCHEME_PATH="$PROJECT_PATH/xcshareddata/xcschemes/Job Tracker.xcscheme"
 TEST_PLAN_PATH="Job Tracker Safety Net.xctestplan"


### PR DESCRIPTION
### Motivation
- Ensure the pre-build safety-net script reliably finds the Xcode project and test plan when invoked from different working directories so it doesn't fail with "Missing required file" in Xcode Cloud.

### Description
- Add resolution of `SCRIPT_DIR` and `REPOSITORY_ROOT` and `cd` into the repository root at the start of `ci_scripts/ci_pre_xcodebuild.sh` so subsequent `require_file` checks run against the correct project paths.

### Testing
- Ran `sh -n ci_scripts/ci_pre_xcodebuild.sh`, `ci_scripts/ci_pre_xcodebuild.sh`, and `(cd ci_scripts && ./ci_pre_xcodebuild.sh)`, and all completed successfully with the safety-net validation passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3c7f8230832d8970bc82a874933d)