### PR TITLE
Fix watch simulator test builds

### DIFF
--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -6,8 +6,8 @@ The repository now treats Xcode Cloud as the safety net for the full app project
 
 - The shared `Job Tracker` scheme runs `Job Tracker Safety Net.xctestplan`.
 - The safety-net test plan includes the `Job TrackerTests` XCTest bundle and collects code coverage.
-- The scheme still builds the main app target, which also builds the embedded watch app dependency through the project graph.
-- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, or XCTest target coverage drifts out of date.
+- The scheme still builds the main app target, which also builds the embedded watch app dependency through the project graph. The watch app must support both `watchos` and `watchsimulator`, and framework references must resolve from `SDKROOT` so iOS simulator test destinations can build the embedded watch app on any current Xcode Cloud image.
+- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date.
 
 ## Run tests locally
 

--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -62,7 +62,7 @@
 
 /* Begin PBXFileReference section */
 		CD1C8C652E5BB9390001CE7E /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
-		CD1C8C672E5BB9490001CE7E /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.5.sdk/System/Library/Frameworks/WatchConnectivity.framework; sourceTree = DEVELOPER_DIR; };
+		CD1C8C672E5BB9490001CE7E /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		CD1C8C772E5BBB140001CE7E /* Job Tracker Companion Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Job Tracker Companion Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDA531392E6CDE5400F5E950 /* Messages.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Messages.framework; path = System/Library/Frameworks/Messages.framework; sourceTree = SDKROOT; };
 		CDDA111D2D579EC0007BADFF /* Job Tracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Job Tracker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -370,6 +370,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -398,6 +399,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -65,6 +65,40 @@ plan_targets = {
 check(plan_targets.get("CD7E57000000000000000106") == "Job TrackerTests",
       "Safety-net test plan must include the Job TrackerTests target.")
 
+watch_target_match = re.search(
+    r'CD1C8C762E5BBB140001CE7E /\* Job Tracker Companion Watch App \*/ = \{\n\s+isa = PBXNativeTarget;(?P<body>.*?)\n\s+\};',
+    project,
+    re.S,
+)
+check(watch_target_match is not None,
+      "Project must keep the companion watch app target wired into the app target graph.")
+if watch_target_match:
+    config_list_match = re.search(r'buildConfigurationList = ([A-F0-9]{24}) /\*', watch_target_match.group('body'))
+    check(config_list_match is not None,
+          "Watch app target must have a build configuration list.")
+    if config_list_match:
+        config_list = re.search(
+            rf'^\t\t{config_list_match.group(1)} /\* .*? \*/ = \{{(?P<body>.*?)\n\s+\}};',
+            project,
+            re.S | re.M,
+        )
+        watch_config_ids = re.findall(r'([A-F0-9]{24}) /\* (?:Debug|Release) \*/', config_list.group('body') if config_list else '')
+        check(len(watch_config_ids) >= 2,
+              "Watch app target must keep Debug and Release configurations.")
+        for config_id in watch_config_ids:
+            config_match = re.search(
+                rf'{config_id} /\* (?:Debug|Release) \*/ = \{{\n\s+isa = XCBuildConfiguration;(?P<body>.*?)\n\s+\}};',
+                project,
+                re.S,
+            )
+            if config_match:
+                body = config_match.group('body')
+                check('SUPPORTED_PLATFORMS = "watchos watchsimulator";' in body,
+                      "Watch app Debug/Release configurations must support watchsimulator so iOS simulator test destinations can build the embedded watch app.")
+
+check('Platforms/WatchOS.platform/Developer/SDKs/' not in project,
+      "Project must not hard-code a specific watchOS SDK path; use SDKROOT framework references for Xcode Cloud image compatibility.")
+
 # Future-proofing: if another XCTest target is added to the project later, require it to be added to this plan too.
 project_test_targets = {}
 for match in re.finditer(r'([A-F0-9]{24}) /\* ([^*]+) \*/ = \{\n\s+isa = PBXNativeTarget;(?P<body>.*?)\n\s+\};', project, re.S):


### PR DESCRIPTION
### Motivation
- iOS-simulator `build-for-testing` runs were failing because the embedded companion Watch app referenced a hard-coded watchOS SDK path and its build configurations did not advertise `watchsimulator` support, preventing the iOS simulator from building the watch dependency.
- The CI guardrail and docs needed to assert watch simulator compatibility so regressions are caught early.

### Description
- Replaced a hard-coded WatchOS SDK framework path with an `SDKROOT`-relative `WatchConnectivity.framework` reference in `Job Tracker.xcodeproj/project.pbxproj` to avoid image-specific SDK path failures.
- Added `SUPPORTED_PLATFORMS = "watchos watchsimulator"` to the companion Watch app Debug and Release build configurations so iOS simulator test destinations can build the embedded watch app.
- Extended `ci_scripts/ci_pre_xcodebuild.sh` to verify the companion watch target exists, that it has a build configuration list with Debug/Release, that those configurations include `SUPPORTED_PLATFORMS = "watchos watchsimulator"`, and that the project does not hard-code specific watchOS SDK paths.
- Updated `Documentation/XcodeCloudTesting.md` to document watch simulator and `SDKROOT` requirements for Xcode Cloud and local test runs.

### Testing
- Ran `git diff --check`, which reported no issues and succeeded.
- Ran the updated guardrail `ci_scripts/ci_pre_xcodebuild.sh`, which completed and reported the safety-net configuration as valid (the local `xcodebuild` check was skipped because `xcodebuild` is not installed in this Linux environment).
- No local `xcodebuild` invocation was possible in this environment, so a full Xcode build/test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3e29e674832db2c056ea0405032a)