### PR TITLE
Restrict Xcode Cloud test destinations to iPhone

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -614,7 +614,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -639,7 +639,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Job Tracker.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Job Tracker";
 			};
 			name = Debug;
@@ -665,7 +665,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Job Tracker.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Job Tracker";
 			};
 			name = Release;

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -99,6 +99,40 @@ if watch_target_match:
 check('Platforms/WatchOS.platform/Developer/SDKs/' not in project,
       "Project must not hard-code a specific watchOS SDK path; use SDKROOT framework references for Xcode Cloud image compatibility.")
 
+# The app embeds an Apple Watch companion app. Apple Watch pairs with iPhone simulators only,
+# so keeping the host app/test bundle iPhone-only prevents Xcode Cloud from scheduling iPad
+# build-for-testing destinations that fail before compilation with xcodebuild exit code 70.
+for target_id, target_name in {
+    "CDDA111C2D579EC0007BADFF": "Job Tracker",
+    "CD7E57000000000000000106": "Job TrackerTests",
+}.items():
+    target_match = re.search(
+        rf'{target_id} /\* {re.escape(target_name)} \*/ = \{{\n\s+isa = PBXNativeTarget;(?P<body>.*?)\n\s+\}};',
+        project,
+        re.S,
+    )
+    check(target_match is not None, f"Project must keep the {target_name} target.")
+    if target_match:
+        config_list_match = re.search(r'buildConfigurationList = ([A-F0-9]{24}) /\*', target_match.group('body'))
+        check(config_list_match is not None, f"{target_name} target must have a build configuration list.")
+        if config_list_match:
+            config_list = re.search(
+                rf'^\t\t{config_list_match.group(1)} /\* .*? \*/ = \{{(?P<body>.*?)\n\s+\}};',
+                project,
+                re.S | re.M,
+            )
+            config_ids = re.findall(r'([A-F0-9]{24}) /\* (?:Debug|Release) \*/', config_list.group('body') if config_list else '')
+            check(len(config_ids) >= 2, f"{target_name} target must keep Debug and Release configurations.")
+            for config_id in config_ids:
+                config_match = re.search(
+                    rf'{config_id} /\* (?:Debug|Release) \*/ = \{{\n\s+isa = XCBuildConfiguration;(?P<body>.*?)\n\s+\}};',
+                    project,
+                    re.S,
+                )
+                if config_match:
+                    check('TARGETED_DEVICE_FAMILY = 1;' in config_match.group('body'),
+                          f"{target_name} Debug/Release configurations must stay iPhone-only while the app embeds a watch companion app.")
+
 # Future-proofing: if another XCTest target is added to the project later, require it to be added to this plan too.
 project_test_targets = {}
 for match in re.finditer(r'([A-F0-9]{24}) /\* ([^*]+) \*/ = \{\n\s+isa = PBXNativeTarget;(?P<body>.*?)\n\s+\};', project, re.S):


### PR DESCRIPTION
### Motivation
- Xcode Cloud was scheduling iPad simulator destinations that fail early with `xcodebuild` exit code 70 because the app embeds an Apple Watch companion app which pairs only with iPhone simulators.
- The change forces the app and XCTest bundle to be iPhone-only so build-for-testing destinations are compatible with the embedded watch target.

### Description
- Updated `Job Tracker.xcodeproj/project.pbxproj` to set `TARGETED_DEVICE_FAMILY = 1` (numeric iPhone-only) for the app Debug/Release and the XCTest Debug/Release configurations instead of `"1,2"`.
- Added a documented CI safety-net block to `ci_scripts/ci_pre_xcodebuild.sh` that verifies the app and test targets exist, keep Debug/Release configurations, and require `TARGETED_DEVICE_FAMILY = 1` while the watch companion app is embedded.
- The CI guard also explains why the iPhone-only constraint is required (watch pairing with iPhone simulators) to prevent regressions.

### Testing
- Ran `./ci_scripts/ci_pre_xcodebuild.sh`, which completed successfully (local `xcodebuild` was not available so the scheme-resolution step was skipped).
- Validated `Job Tracker Safety Net.xctestplan` with `python3 -m json.tool` which passed.
- Parsed the shared scheme with `xml.etree.ElementTree` which passed.
- Ran Python assertions checking the updated `TARGETED_DEVICE_FAMILY` occurrences and Debug/Release configurations which passed.
- Ran `git diff --check` to ensure no trailing whitespace or obvious issues which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a412f881c832dabe1573f8318f4cc)