### PR TITLE
Fix safety net test plan reference

### DIFF
--- a/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
+++ b/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
@@ -30,7 +30,7 @@
       codeCoverageEnabled = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Job Tracker Safety Net.xctestplan"
+            reference = "container:../Job Tracker Safety Net.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -38,14 +38,22 @@ scheme = Path("Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
 plan_path = Path("Job Tracker Safety Net.xctestplan")
 plan = json.loads(plan_path.read_text())
 
+# Shared schemes live under Job Tracker.xcodeproj/xcshareddata/xcschemes.
+# Xcode resolves TestPlanReference container paths from the .xcodeproj bundle,
+# so the repository-root plan must be referenced with ../.
+expected_plan_reference = "container:../Job Tracker Safety Net.xctestplan"
+
 errors = []
 
 def check(condition, message):
     if not condition:
         errors.append(message)
 
-check('reference = "container:Job Tracker Safety Net.xctestplan"' in scheme,
-      "Shared Job Tracker scheme must use the safety-net test plan.")
+check(f'reference = "{expected_plan_reference}"' in scheme,
+      "Shared Job Tracker scheme must use the safety-net test plan via a path relative to the .xcodeproj container.")
+resolved_plan_reference = (Path("Job Tracker.xcodeproj") / expected_plan_reference.removeprefix("container:")).resolve()
+check(resolved_plan_reference == plan_path.resolve() and resolved_plan_reference.exists(),
+      f"Shared Job Tracker scheme test-plan reference must resolve to {plan_path}.")
 check('codeCoverageEnabled = "YES"' in scheme,
       "Shared Job Tracker scheme must keep code coverage enabled for tests.")
 check('BlueprintName = "Job TrackerTests"' in scheme and 'skipped = "NO"' in scheme,


### PR DESCRIPTION
### Motivation
- Resolve xcodebuild failures where the test plan could not be read by ensuring the shared scheme references the repository-root `.xctestplan` file using a project-container-relative path. 
- Make the CI guardrail stricter so the pre-build check verifies the scheme's test-plan reference actually resolves to the committed plan file.

### Description
- Change the shared scheme `Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme` to use `reference = "container:../Job Tracker Safety Net.xctestplan"` for the TestPlanReference. 
- Update `ci_scripts/ci_pre_xcodebuild.sh` to set `expected_plan_reference = "container:../Job Tracker Safety Net.xctestplan"`, require that string in the scheme, and verify the resolved path equals and exists as `Job Tracker Safety Net.xctestplan`. 
- Add explanatory comments to the guardrail script explaining that Xcode resolves `TestPlanReference` container paths from the `.xcodeproj` bundle.

### Testing
- Ran `ci_scripts/ci_pre_xcodebuild.sh`, which returned success and printed the safety-net validation message (the local `xcodebuild` scheme-resolution step was skipped because `xcodebuild` is not present). 
- Validated the test plan JSON with `python3 -m json.tool 'Job Tracker Safety Net.xctestplan'`, which succeeded. 
- Confirmed the shared scheme contains `container:../Job Tracker Safety Net.xctestplan` and that resolving that container-relative path points to the committed `Job Tracker Safety Net.xctestplan` file, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a42f2be84832d906bc54bdb325e69)