### PR TITLE
Add committed safety‑net test plan to project and enforce scheme/project references in CI prebuild

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		CDDA111D2D579EC0007BADFF /* Job Tracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Job Tracker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDFE39FD2FA3624A00AEEAAB /* WebMaps */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WebMaps; path = "Job Tracker/Resources/WebMaps"; sourceTree = SOURCE_ROOT; };
 		CD7E57000000000000000101 /* Job TrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Job TrackerTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD7E5700000000000000010D /* Job Tracker Safety Net.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Job Tracker Safety Net.xctestplan"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -142,6 +143,7 @@
 		CDDA11142D579EC0007BADFF = {
 			isa = PBXGroup;
 			children = (
+				CD7E5700000000000000010D /* Job Tracker Safety Net.xctestplan */,
 				CDDA111F2D579EC0007BADFF /* Job Tracker */,
 				CD1C8C782E5BBB140001CE7E /* Job Tracker Companion Watch App */,
 				CD7E57000000000000000102 /* Job TrackerTests */,

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -38,14 +38,23 @@ scheme = Path("Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
 plan_path = Path("Job Tracker Safety Net.xctestplan")
 plan = json.loads(plan_path.read_text())
 
+# The shared scheme is resolved from the repository/workspace root in Xcode Cloud.
+# Keep this path in sync with the committed repository-root test plan file.
+expected_plan_reference = "container:Job Tracker Safety Net.xctestplan"
+
 errors = []
 
 def check(condition, message):
     if not condition:
         errors.append(message)
 
-check('reference = "container:Job Tracker Safety Net.xctestplan"' in scheme,
-      "Shared Job Tracker scheme must use the safety-net test plan.")
+check(f'reference = "{expected_plan_reference}"' in scheme,
+      "Shared Job Tracker scheme must use the committed safety-net test plan.")
+resolved_plan_reference = Path(expected_plan_reference.removeprefix("container:")).resolve()
+check(resolved_plan_reference == plan_path.resolve() and resolved_plan_reference.exists(),
+      f"Shared Job Tracker scheme test-plan reference must resolve to {plan_path}.")
+check('/* Job Tracker Safety Net.xctestplan */ = {isa = PBXFileReference;' in project,
+      "Project navigator must include the safety-net test plan file so Xcode Cloud can load it from the shared scheme.")
 check('codeCoverageEnabled = "YES"' in scheme,
       "Shared Job Tracker scheme must keep code coverage enabled for tests.")
 check('BlueprintName = "Job TrackerTests"' in scheme and 'skipped = "NO"' in scheme,


### PR DESCRIPTION
### Motivation
- Ensure Xcode Cloud uses the committed safety‑net test plan and that the shared scheme and project include and resolve that plan so tests and coverage run reliably.

### Description
- Add `Job Tracker Safety Net.xctestplan` as a `PBXFileReference` and include it in the main project group in `Job Tracker.xcodeproj/project.pbxproj`.
- Strengthen `ci_scripts/ci_pre_xcodebuild.sh` Python checks by introducing `expected_plan_reference` and validating the scheme contains the `container:` reference, that the container reference resolves to `Job Tracker Safety Net.xctestplan` and exists, and that the project contains a `PBXFileReference` entry for the plan.
- Preserve existing checks for `codeCoverageEnabled`, inclusion of `Job TrackerTests`, test plan `version == 1`, default code coverage option, variable expansion target name, and the mapping for the `Job TrackerTests` target.
- Improve error messages to make failures for scheme/test‑plan/project mismatches clearer.

### Testing
- Ran the updated `ci_scripts/ci_pre_xcodebuild.sh` (Python checks) against the repository files and the script completed with no errors.
- Verified the `project.pbxproj` now contains the `PBXFileReference` entry for `Job Tracker Safety Net.xctestplan` and that the file reference is present in the project group.
- No unit tests were changed and existing CI checks that use the pre‑build script will now enforce the new assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a42f2be84832d906bc54bdb325e69)