### PR TITLE
Temporarily omit embedded Watch app for Xcode Cloud `build-for-testing` to avoid xcodebuild exit 70

### DIFF
--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -6,8 +6,8 @@ The repository now treats Xcode Cloud as the safety net for the full app project
 
 - The shared `Job Tracker` scheme runs `Job Tracker Safety Net.xctestplan`.
 - The safety-net test plan includes the `Job TrackerTests` XCTest bundle and collects code coverage.
-- The scheme still builds the main app target, which also builds the embedded watch app dependency through the project graph. The watch app must support both `watchos` and `watchsimulator`, and framework references must resolve from `SDKROOT` so iOS simulator test destinations can build the embedded watch app on any current Xcode Cloud image.
-- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date.
+- The checked-in project keeps the main app target wired to the embedded watch app for normal local builds and archive workflows. The watch app must support both `watchos` and `watchsimulator`, and framework references must resolve from `SDKROOT` so supported simulator builds remain portable across current Xcode Cloud images.
+- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date. During Xcode Cloud `build-for-testing` only, the script removes the host app's watch embed/dependency edges in the temporary checkout so unit-test builds do not fail destination resolution when the workflow supplies generic or unpaired iOS simulators.
 
 ## Run tests locally
 
@@ -45,7 +45,7 @@ Create or update the workflow in Xcode with these settings:
 6. Enable code coverage for the workflow.
 7. Run the workflow for pull requests and before release/archive workflows.
 
-A separate Build action is not required before the Test action because Xcode builds the app, watch dependency, and test host as part of the test action.
+A separate Build action is not required before the Test action because Xcode builds the app and test host as part of the test action. The companion watch app remains part of normal local/archive project wiring, but the pre-xcodebuild guard temporarily omits it for Xcode Cloud `build-for-testing` actions because the safety-net unit tests do not exercise the packaged watch app.
 
 ## Future-proofing rules
 

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -158,6 +158,40 @@ if errors:
     sys.exit(1)
 PY
 
+prepare_xcode_cloud_build_for_testing() {
+  # Xcode Cloud supplies the build-for-testing destinations from the workflow UI.
+  # When that list contains generic/unpaired iOS simulators, the embedded watch
+  # companion can make destination resolution fail with xcodebuild exit code 70
+  # before compilation starts. Unit tests do not exercise the packaged watch app,
+  # so remove only the app target's watch embed/dependency edges in Xcode Cloud's
+  # temporary checkout for this build-for-testing action. Archive/build actions
+  # keep the checked-in project graph unchanged and still package the watch app.
+  if [ "${CI_XCODE_CLOUD:-}" != "TRUE" ] || [ "${CI_XCODEBUILD_ACTION:-}" != "build-for-testing" ]; then
+    return 0
+  fi
+
+  log "Preparing Xcode Cloud build-for-testing project graph without embedded watch content."
+  python3 <<'PYINNER'
+from pathlib import Path
+
+project_path = Path("Job Tracker.xcodeproj/project.pbxproj")
+project = project_path.read_text()
+updated = project
+
+# Remove the companion watch app build phase from the host app target's phase list.
+updated = updated.replace('\n\t\t\t\tCD3158992E5BB5E00037DF29 /* Embed Watch Content */,', '')
+# Remove the explicit target dependency that forces watch app destination resolution.
+updated = updated.replace('\n\t\t\t\tCD1C8C802E5BBB150001CE7E /* PBXTargetDependency */,', '')
+
+if updated == project:
+    raise SystemExit("Expected to remove watch embed/dependency edges for Xcode Cloud testing, but project graph was unchanged.")
+
+project_path.write_text(updated)
+PYINNER
+}
+
+prepare_xcode_cloud_build_for_testing
+
 if command -v xcodebuild >/dev/null 2>&1; then
   log "Checking that Xcode can resolve the shared scheme."
   xcodebuild -list -project "$PROJECT_PATH" >/dev/null


### PR DESCRIPTION
### Motivation
- Xcode Cloud `build-for-testing` runs can fail early with `xcodebuild` exit code 70 when generic/unpaired iOS simulator destinations try to resolve an embedded Watch companion app. 
- The safety-net unit tests do not exercise the packaged watch app, so removing the watch embed/dependency only for Xcode Cloud test runs avoids destination-resolution failures while preserving normal local/archive behavior.

### Description
- Added `prepare_xcode_cloud_build_for_testing()` to `ci_scripts/ci_pre_xcodebuild.sh` which, when `CI_XCODE_CLOUD=TRUE` and `CI_XCODEBUILD_ACTION=build-for-testing`, edits the temporary checkout's `Job Tracker.xcodeproj/project.pbxproj` to remove the host app's `Embed Watch Content` build phase and the explicit `PBXTargetDependency` on the watch app. 
- The function runs early in the guardrail script and leaves the checked-in project unchanged for local and archive builds. 
- Updated `Documentation/XcodeCloudTesting.md` to document the temporary omission behavior and clarify that normal local/archive builds still include the companion watch app. 

### Testing
- Ran the guardrail script `ci_scripts/ci_pre_xcodebuild.sh` which executed and reported the safety-net checks (it skipped local `xcodebuild` resolution when `xcodebuild` was not present) and exited successfully. 
- Performed a shell syntax check with `sh -n ci_scripts/ci_pre_xcodebuild.sh` which passed. 
- Simulated Xcode Cloud with `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=build-for-testing` in a temporary copy and verified the `CD3158992E5BB5E00037DF29 /* Embed Watch Content */` and `CD1C8C802E5BBB150001CE7E /* PBXTargetDependency */` entries were removed from the temporary `project.pbxproj`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a45fc814c832dbb5fd833fc69e0e4)