### PR TITLE
Handle Xcode Cloud Test actions when stripping embedded watch content

### DIFF
--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -7,7 +7,7 @@ The repository now treats Xcode Cloud as the safety net for the full app project
 - The shared `Job Tracker` scheme runs `Job Tracker Safety Net.xctestplan`.
 - The safety-net test plan includes the `Job TrackerTests` XCTest bundle and collects code coverage.
 - The checked-in project keeps the main app target wired to the embedded watch app for normal local builds and archive workflows. The watch app must support both `watchos` and `watchsimulator`, and framework references must resolve from `SDKROOT` so supported simulator builds remain portable across current Xcode Cloud images.
-- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date. During Xcode Cloud `build-for-testing` only, the script removes the host app's watch embed/dependency edges in the temporary checkout so unit-test builds do not fail destination resolution when the workflow supplies generic or unpaired iOS simulators.
+- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date. During Xcode Cloud Test actions (`build-for-testing`, `test`, or `test-without-building`), the script removes the host app's watch embed/dependency edges in the temporary checkout so unit-test builds do not fail destination resolution when the workflow supplies generic or unpaired iOS simulators.
 
 ## Run tests locally
 
@@ -45,7 +45,7 @@ Create or update the workflow in Xcode with these settings:
 6. Enable code coverage for the workflow.
 7. Run the workflow for pull requests and before release/archive workflows.
 
-A separate Build action is not required before the Test action because Xcode builds the app and test host as part of the test action. The companion watch app remains part of normal local/archive project wiring, but the pre-xcodebuild guard temporarily omits it for Xcode Cloud `build-for-testing` actions because the safety-net unit tests do not exercise the packaged watch app.
+A separate Build action is not required before the Test action because Xcode builds the app and test host as part of the test action. The companion watch app remains part of normal local/archive project wiring, but the pre-xcodebuild guard temporarily omits it for Xcode Cloud Test actions because the safety-net unit tests do not exercise the packaged watch app. Archive and Build actions keep the embedded watch app intact.
 
 ## Future-proofing rules
 

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -158,19 +158,32 @@ if errors:
     sys.exit(1)
 PY
 
-prepare_xcode_cloud_build_for_testing() {
-  # Xcode Cloud supplies the build-for-testing destinations from the workflow UI.
-  # When that list contains generic/unpaired iOS simulators, the embedded watch
-  # companion can make destination resolution fail with xcodebuild exit code 70
-  # before compilation starts. Unit tests do not exercise the packaged watch app,
-  # so remove only the app target's watch embed/dependency edges in Xcode Cloud's
-  # temporary checkout for this build-for-testing action. Archive/build actions
-  # keep the checked-in project graph unchanged and still package the watch app.
-  if [ "${CI_XCODE_CLOUD:-}" != "TRUE" ] || [ "${CI_XCODEBUILD_ACTION:-}" != "build-for-testing" ]; then
+prepare_xcode_cloud_test_build() {
+  # Xcode Cloud supplies the simulator destinations from the workflow UI. During a
+  # Test action, Xcode first invokes build-for-testing and then runs the products
+  # with test-without-building. The CI_XCODEBUILD_ACTION value names the workflow
+  # action Xcode Cloud is preparing, so accept the observed test-action values
+  # instead of requiring the literal xcodebuild subcommand. When the destination
+  # list contains generic/unpaired iOS simulators, the embedded watch companion can
+  # make destination resolution fail with xcodebuild exit code 70 before
+  # compilation starts. Unit tests do not exercise the packaged watch app, so
+  # remove only the app target's watch embed/dependency edges in Xcode Cloud's
+  # temporary checkout for test actions. Archive/build actions keep the checked-in
+  # project graph unchanged and still package the watch app.
+  if [ "${CI_XCODE_CLOUD:-}" != "TRUE" ]; then
     return 0
   fi
 
-  log "Preparing Xcode Cloud build-for-testing project graph without embedded watch content."
+  case "${CI_XCODEBUILD_ACTION:-}" in
+    build-for-testing|test|test-without-building)
+      ;;
+    *)
+      log "Keeping embedded watch content for Xcode Cloud action '${CI_XCODEBUILD_ACTION:-unknown}'."
+      return 0
+      ;;
+  esac
+
+  log "Preparing Xcode Cloud test project graph without embedded watch content."
   python3 <<'PYINNER'
 from pathlib import Path
 
@@ -190,7 +203,7 @@ project_path.write_text(updated)
 PYINNER
 }
 
-prepare_xcode_cloud_build_for_testing
+prepare_xcode_cloud_test_build
 
 if command -v xcodebuild >/dev/null 2>&1; then
   log "Checking that Xcode can resolve the shared scheme."


### PR DESCRIPTION
### Motivation
- Xcode Cloud Test workflows can present as `build-for-testing`, `test`, or `test-without-building`, and the embedded Watch app can cause `xcodebuild` to fail early with exit code 70 when generic/unpaired iOS simulators are used. 
- The previous guard only matched the literal `build-for-testing` subcommand, leaving other Test action values unhandled and causing destination-resolution failures. 

### Description
- Broadened the pre-Xcode Cloud guard in `ci_scripts/ci_pre_xcodebuild.sh` by renaming and updating the function to run for `build-for-testing|test|test-without-building` instead of only `build-for-testing`, while still skipping when `CI_XCODE_CLOUD` is not `TRUE`. 
- Kept the temporary project mutation that removes the host app's `Embed Watch Content` build phase and the explicit `PBXTargetDependency` only for Test actions, and preserved archive/build behavior to leave the embedded watch app intact. 
- Updated `Documentation/XcodeCloudTesting.md` to explain that Test actions may appear as `build-for-testing`, `test`, or `test-without-building` and that Build/Archive actions continue to package the watch app. 

### Testing
- Ran `bash -n ci_scripts/ci_pre_xcodebuild.sh` and executed the script locally, which passed the syntax check and printed the safety-net validation. 
- Verified that `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=test-without-building ci_scripts/ci_pre_xcodebuild.sh` and `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=build-for-testing ci_scripts/ci_pre_xcodebuild.sh` both mutate `Job Tracker.xcodeproj/project.pbxproj` to remove the watch embed/dependency edges (asserted with a Python check). 
- Verified that `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=archive ci_scripts/ci_pre_xcodebuild.sh` leaves the project graph unchanged (asserted by comparing backups). 
- Noted that `xcodebuild` is unavailable in this Linux environment (`xcodebuild: command not found`), so final verification should run in Xcode Cloud or a macOS runner with Xcode installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a4af4e340832dad13d6212b50af19)