### PR TITLE
Fix safety net test build isolation

### DIFF
--- a/Job TrackerTests/AdminPanelViewModelTests.swift
+++ b/Job TrackerTests/AdminPanelViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import Combine
 @testable import Job_Tracker
 
-@MainActor
 final class AdminPanelViewModelTests: XCTestCase {
     private let sampleUsers: [AppUser] = [
         AppUser(id: "1", firstName: "Alex", lastName: "Anderson", email: "alex@example.com", position: "Tech"),
@@ -10,6 +9,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         AppUser(id: "3", firstName: "Casey", lastName: "Chambers", email: "casey@example.com", position: "Supervisor")
     ]
 
+    @MainActor
     func testRosterUpdatesFromPublisher() async {
         let subject = CurrentValueSubject<[AppUser], Never>([sampleUsers[1], sampleUsers[0]])
         let mockService = MockAdminPanelService()
@@ -28,6 +28,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.roster.map(\.id), [sampleUsers[1].id, sampleUsers[2].id])
     }
 
+    @MainActor
     func testToggleAdminSuccessUpdatesState() async {
         let user = AppUser(id: "42", firstName: "Jamie", lastName: "Quinn", email: "jamie@example.com", position: "Tech")
         let subject = CurrentValueSubject<[AppUser], Never>([user])
@@ -57,6 +58,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.alert)
     }
 
+    @MainActor
     func testToggleSupervisorFailureShowsAlert() async {
         var user = AppUser(id: "55", firstName: "Morgan", lastName: "Reeves", email: "morgan@example.com", position: "Supervisor")
         user.isSupervisor = true
@@ -79,6 +81,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertFalse(mockService.didRefreshClaims)
     }
 
+    @MainActor
     func testDeleteUserSuccessRemovesUserFromRoster() async {
         let mockService = MockAdminPanelService()
         let viewModel = AdminPanelViewModel(
@@ -100,6 +103,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.alert?.kind, .success)
     }
 
+    @MainActor
     func testDeleteCurrentUserIsBlocked() {
         let mockService = MockAdminPanelService()
         let viewModel = AdminPanelViewModel(
@@ -116,6 +120,7 @@ final class AdminPanelViewModelTests: XCTestCase {
     }
 
 
+    @MainActor
     func testRemovingCurrentUsersAdminAccessIsBlocked() {
         var user = AppUser(id: "admin-1", firstName: "Riley", lastName: "Admin", email: "riley@example.com", position: "Admin")
         user.isAdmin = true
@@ -133,6 +138,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.alert?.title, "Update Blocked")
     }
 
+    @MainActor
     func testParticipantsBackfillPayloadMergesMissingLegacyUsers() {
         let payload = FirebaseService.participantsBackfillPayload(for: [
             "participants": ["existing"],
@@ -144,6 +150,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertEqual(participants, ["creator", "existing"])
     }
 
+    @MainActor
     func testParticipantsBackfillPayloadSkipsAlreadyCompleteParticipants() {
         let payload = FirebaseService.participantsBackfillPayload(for: [
             "participants": ["assignee", "creator"],
@@ -154,6 +161,7 @@ final class AdminPanelViewModelTests: XCTestCase {
         XCTAssertNil(payload)
     }
 
+    @MainActor
     func testBackfillProgressAndCompletion() async {
         let mockService = MockAdminPanelService()
         let viewModel = AdminPanelViewModel(service: mockService)

--- a/Job TrackerTests/FiberMapViewModelTests.swift
+++ b/Job TrackerTests/FiberMapViewModelTests.swift
@@ -3,7 +3,6 @@ import CoreLocation
 import Combine
 @testable import Job_Tracker
 
-@MainActor
 final class FiberMapViewModelTests: XCTestCase {
     private var dataService: MockFiberAssetSyncService!
 
@@ -17,6 +16,7 @@ final class FiberMapViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func testPersistenceAcrossViewModelInstances() {
         let viewModel = FiberMapViewModel(dataService: dataService, searchProvider: MockMapSearchProvider())
         waitForInitialLoad(of: viewModel)
@@ -49,6 +49,7 @@ final class FiberMapViewModelTests: XCTestCase {
         XCTAssertTrue(reloadedViewModel.poles.contains(where: { $0.id == newPole.id }))
     }
 
+    @MainActor
     func testSearchResultsUpdateAndPersistCenter() async throws {
         let expectedResult = MapSearchResult(
             title: "Test Location",
@@ -95,6 +96,7 @@ final class FiberMapViewModelTests: XCTestCase {
         XCTAssertEqual(reloadedViewModel.mapCamera.longitude, expectedResult.coordinate.longitude, accuracy: 0.0001)
     }
 
+    @MainActor
     func testPendingCenterCommandUpdatesWhenLocationServicePublishes() {
         let service = MockLocationService()
         let viewModel = FiberMapViewModel(dataService: dataService, searchProvider: MockMapSearchProvider())
@@ -117,6 +119,7 @@ final class FiberMapViewModelTests: XCTestCase {
         cancellable.cancel()
     }
 
+    @MainActor
     func testLocateUserFallsBackToAuthorizationFlow() {
         let service = MockLocationService()
         let viewModel = FiberMapViewModel(dataService: dataService, searchProvider: MockMapSearchProvider())
@@ -130,6 +133,7 @@ final class FiberMapViewModelTests: XCTestCase {
         XCTAssertEqual(service.startUpdatesCallCount, 1)
     }
 
+    @MainActor
     private func waitForInitialLoad(of viewModel: FiberMapViewModel, timeout: TimeInterval = 1.0) {
         guard viewModel.isLoadingSnapshot else { return }
 
@@ -147,6 +151,7 @@ final class FiberMapViewModelTests: XCTestCase {
         cancellable?.cancel()
     }
 
+    @MainActor
     func testLocateButtonAccessibilityLabel() {
         XCTAssertEqual(MapsView.Accessibility.locateButtonLabel, "Show my location")
     }

--- a/Job TrackerTests/ForceUpdateViewModelTests.swift
+++ b/Job TrackerTests/ForceUpdateViewModelTests.swift
@@ -2,8 +2,8 @@ import XCTest
 import FirebaseFirestore
 @testable import Job_Tracker
 
-@MainActor
 final class ForceUpdateViewModelTests: XCTestCase {
+    @MainActor
     func testStartMonitoringRequiresUpdateWhenProviderPublishesNewerMinimumVersion() async {
         let provider = MockAppUpdateRequirementProvider()
         let viewModel = ForceUpdateViewModel(
@@ -23,6 +23,7 @@ final class ForceUpdateViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.lastErrorMessage)
     }
 
+    @MainActor
     func testStartMonitoringLeavesCurrentAppUpToDateWhenRequirementIsDisabled() async {
         let provider = MockAppUpdateRequirementProvider()
         let viewModel = ForceUpdateViewModel(
@@ -39,6 +40,7 @@ final class ForceUpdateViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.lastErrorMessage)
     }
 
+    @MainActor
     func testStartMonitoringStoresErrorWithoutChangingLastDecision() async {
         let provider = MockAppUpdateRequirementProvider()
         let viewModel = ForceUpdateViewModel(
@@ -59,6 +61,7 @@ final class ForceUpdateViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.lastErrorMessage, "offline")
     }
 
+    @MainActor
     func testStartMonitoringOnlyRegistersOneProviderListener() {
         let provider = MockAppUpdateRequirementProvider()
         let viewModel = ForceUpdateViewModel(provider: provider)

--- a/Job TrackerTests/InteractiveTutorialStagesTests.swift
+++ b/Job TrackerTests/InteractiveTutorialStagesTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Job_Tracker
 
 final class InteractiveTutorialStagesTests: XCTestCase {
+    @MainActor
     func testAuthStageCompletesAfterVisitingAllSteps() {
         let model = AuthTutorialStageModel()
         XCTAssertFalse(model.isActionComplete)
@@ -13,6 +14,7 @@ final class InteractiveTutorialStagesTests: XCTestCase {
         XCTAssertTrue(model.isActionComplete)
     }
 
+    @MainActor
     func testDashboardStageRequiresStatusChangeAndShare() {
         let model = DashboardTutorialStageModel()
         guard let firstJob = model.jobs.first else {
@@ -29,6 +31,7 @@ final class InteractiveTutorialStagesTests: XCTestCase {
         XCTAssertTrue(model.isActionComplete)
     }
 
+    @MainActor
     func testCreateJobStageRequiresValidSubmission() {
         let model = CreateJobTutorialStageModel()
         XCTAssertFalse(model.isActionComplete)
@@ -41,6 +44,7 @@ final class InteractiveTutorialStagesTests: XCTestCase {
         XCTAssertTrue(model.isActionComplete)
     }
 
+    @MainActor
     func testTimesheetStageCompletesAfterEditingHours() {
         let model = TimesheetTutorialStageModel()
         guard let entry = model.entries.first else {

--- a/Job TrackerTests/SharedJobServiceTests.swift
+++ b/Job TrackerTests/SharedJobServiceTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import CoreLocation
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 @testable import Job_Tracker
 
 final class SharedJobServiceTests: XCTestCase {


### PR DESCRIPTION
### Motivation
- Tests were being isolated at the XCTestCase class level with `@MainActor`, which can interfere with XCTest runtime and main‑actor access for view models; the intent is to preserve correct main‑thread isolation for tests that touch main‑actor view models while avoiding class-level isolation that can break the safety‑net test build.
- A leftover `import FirebaseFirestoreSwift` in a test file created an unnecessary dependency; the intent is to rely on the already-linked `FirebaseFirestore` module for test encoding/decoding checks.

### Description
- Removed `@MainActor` from several `XCTestCase` subclasses and applied `@MainActor` to the individual test methods that require main‑actor isolation in `AdminPanelViewModelTests`, `FiberMapViewModelTests`, `ForceUpdateViewModelTests`, and `InteractiveTutorialStagesTests`.
- Marked the `waitForInitialLoad` helper in `FiberMapViewModelTests` as `@MainActor` so it may safely observe `FiberMapViewModel` published state.
- Removed the redundant `import FirebaseFirestoreSwift` from `Job TrackerTests/SharedJobServiceTests.swift` so tests use the linked `FirebaseFirestore` module instead of requiring the SwiftPM overlay import.
- Committed the changes (commit `be1ca4c`) and opened this PR titled "Fix safety net test build isolation".

### Testing
- Ran the repository safety-net preflight script with `bash ci_scripts/ci_pre_xcodebuild.sh`, which completed successfully.
- Ran `git diff --check` to validate the changes; no whitespace or diff issues were reported.
- Attempted to run the full XCTest suite with `xcodebuild test ...` but it could not be executed in this environment because `xcodebuild` is not installed (local reproduction skipped); the change is targeted to fix runtime/test isolation failures observed when running the Safety Net in Xcode/Xcode Cloud.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ad87401e0832da6a04ea9dedc5328)