### PR TITLE
Fix test plan scheme reference

### DIFF
--- a/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
+++ b/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
@@ -30,7 +30,7 @@
       codeCoverageEnabled = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:../Job Tracker Safety Net.xctestplan"
+            reference = "container:Job Tracker Safety Net.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>


### PR DESCRIPTION
### Motivation
- Ensure the shared Xcode scheme locates the in-project test plan by removing the parent-directory container path from the `<TestPlanReference>` so Xcode resolves `Job Tracker Safety Net.xctestplan` correctly.

### Description
- Edited `Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme` and replaced `reference = "container:../Job Tracker Safety Net.xctestplan"` with `reference = "container:Job Tracker Safety Net.xctestplan"`.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1868d208832d869f696c8627bbbd)