### PR TITLE
Gate admin update demo behind DEBUG; wire forced-update to Firestore remote config; add tests

### DIFF
--- a/Documentation/Features/Admin.md
+++ b/Documentation/Features/Admin.md
@@ -30,3 +30,9 @@ The Admin module exposes elevated controls for supervisors and company administr
 - The admin panel should only be reachable for users whose `AuthViewModel` exposes `isAdmin == true`.
 - Ensure Cloud Functions and Firestore security rules validate that only admins can invoke the maintenance endpoints described above.
 - When adding new admin maintenance tasks, expose them through `AdminPanelService` so the existing dependency injection remains intact for testing.
+
+## App Update Policy
+
+- Production iOS releases are managed through App Store/TestFlight. The app does not download, verify, or apply executable update packages from the admin panel in production builds.
+- Production forced-update behavior is driven by the trusted Firestore remote config document at `app_config/ios_version`, which is observed by `ForceUpdateViewModel` at launch. Admins can set `latestVersion`, `minimumRequiredVersion`, `latestBuild`, `minimumRequiredBuild`, `updateURL`, `releaseNotes`, and `forceUpdateEnabled` to block outdated clients until they install the approved release.
+- The admin package-update screen is a debug/development demo only. It is compiled behind `#if DEBUG`, labeled as a demo in the admin UI, and must not be used as a production enterprise distribution or rollback mechanism.

--- a/Job Tracker/Features/Admin/AdminUpdateViewModel.swift
+++ b/Job Tracker/Features/Admin/AdminUpdateViewModel.swift
@@ -1,5 +1,51 @@
 import Foundation
 
+#if DEBUG
+protocol AdminUpdateService {
+    func checkForUpdates(currentVersion: String) async throws -> AdminUpdateViewModel.UpdateManifest?
+    func downloadUpdate(version: String, progress: @escaping @MainActor (Double) -> Void) async throws -> AdminUpdateViewModel.DownloadedPackage
+    func verifyDownload(_ package: AdminUpdateViewModel.DownloadedPackage, progress: @escaping @MainActor (Double) -> Void) async throws
+    func applyUpdate(_ package: AdminUpdateViewModel.DownloadedPackage) async throws
+    func rollback(to version: String) async throws
+}
+
+struct DevelopmentAdminUpdateService: AdminUpdateService {
+    func checkForUpdates(currentVersion: String) async throws -> AdminUpdateViewModel.UpdateManifest? {
+        try await Task.sleep(nanoseconds: 300_000_000)
+        return AdminUpdateViewModel.UpdateManifest(
+            version: "2.5.0-dev-demo",
+            changelog: [
+                "Debug-only update workflow demo",
+                "Production distribution remains App Store/TestFlight managed",
+                "Forced-update gates are controlled by trusted Firestore remote config"
+            ]
+        )
+    }
+
+    func downloadUpdate(version: String, progress: @escaping @MainActor (Double) -> Void) async throws -> AdminUpdateViewModel.DownloadedPackage {
+        for step in 1...10 {
+            try await Task.sleep(nanoseconds: 75_000_000)
+            await progress(Double(step) / 10)
+        }
+        return AdminUpdateViewModel.DownloadedPackage(version: version, checksum: "debug-demo-")
+    }
+
+    func verifyDownload(_ package: AdminUpdateViewModel.DownloadedPackage, progress: @escaping @MainActor (Double) -> Void) async throws {
+        for step in 1...5 {
+            try await Task.sleep(nanoseconds: 75_000_000)
+            await progress(Double(step) / 5)
+        }
+    }
+
+    func applyUpdate(_ package: AdminUpdateViewModel.DownloadedPackage) async throws {
+        try await Task.sleep(nanoseconds: 250_000_000)
+    }
+
+    func rollback(to version: String) async throws {
+        try await Task.sleep(nanoseconds: 250_000_000)
+    }
+}
+
 @MainActor
 final class AdminUpdateViewModel: ObservableObject {
     enum ActionState: String {
@@ -42,6 +88,16 @@ final class AdminUpdateViewModel: ObservableObject {
         let fractionComplete: Double?
     }
 
+    struct UpdateManifest: Equatable {
+        let version: String
+        let changelog: [String]
+    }
+
+    struct DownloadedPackage: Equatable {
+        let version: String
+        let checksum: String
+    }
+
     @Published var currentVersion: String
     @Published var availableVersion: String?
     @Published var changelog: [String] = []
@@ -54,49 +110,57 @@ final class AdminUpdateViewModel: ObservableObject {
     @Published var logs: [String] = []
     @Published var lastCheckDate: Date?
 
+    private let service: AdminUpdateService
+    private var downloadedPackage: DownloadedPackage?
     private var lastStableVersion: String?
 
-    init(bundle: Bundle = .main) {
+    init(bundle: Bundle = .main, service: AdminUpdateService = DevelopmentAdminUpdateService()) {
         if let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
             currentVersion = version
         } else {
             currentVersion = "Unknown"
         }
+        self.service = service
         lastStableVersion = currentVersion
+        log("Debug-only admin update demo initialized. Production updates use App Store/TestFlight plus forced-update remote config.")
     }
 
     var hasAvailableUpdate: Bool { availableVersion != nil }
-    var hasDownloadedUpdate: Bool { downloadedVersion != nil }
+    var hasDownloadedUpdate: Bool { downloadedPackage != nil }
     var isBusy: Bool { actionState != .idle }
     var canApplyUpdate: Bool { verificationStatus.isVerified && hasDownloadedUpdate && maintenanceModeEnabled }
 
     func checkForUpdates() {
         guard startAction(.checking) else { return }
         errorReason = nil
-        progress = ProgressState(title: "Checking for updates", message: "Reaching update server…", fractionComplete: nil)
-        log("Started checking for updates")
+        progress = ProgressState(title: "Checking for debug demo update", message: "Reading development update service…", fractionComplete: nil)
+        log("Started debug update check")
 
-        Task {
-            try? await Task.sleep(nanoseconds: 800_000_000)
-            let sampleVersion = "2.5.0"
-            let newChangelog = [
-                "Security hardening for admin workflows",
-                "Performance improvements for sync service",
-                "Improved logging around update application"
-            ]
-            await MainActor.run {
-                availableVersion = sampleVersion
-                changelog = newChangelog
+        Task { @MainActor [service, currentVersion] in
+            do {
+                let manifest = try await service.checkForUpdates(currentVersion: currentVersion)
+                if let manifest {
+                    availableVersion = manifest.version
+                    changelog = manifest.changelog
+                    log("Debug demo update v\(manifest.version) is available")
+                } else {
+                    availableVersion = nil
+                    changelog = []
+                    log("No debug demo update available")
+                }
+                downloadedPackage = nil
+                downloadedVersion = nil
+                verificationStatus = .notVerified
                 lastCheckDate = Date()
-                progress = nil
                 finishAction()
-                log("Update v\(sampleVersion) is available")
+            } catch {
+                failCurrentAction("Update check failed: \(error.localizedDescription)")
             }
         }
     }
 
     func downloadUpdate() {
-        guard hasAvailableUpdate else {
+        guard let availableVersion else {
             errorReason = "No update available to download."
             log("Download skipped: no available version")
             return
@@ -104,31 +168,32 @@ final class AdminUpdateViewModel: ObservableObject {
         guard startAction(.downloading) else { return }
         errorReason = nil
         verificationStatus = .notVerified
-        progress = ProgressState(title: "Downloading", message: "Fetching package…", fractionComplete: 0)
-        log("Downloading update v\(availableVersion ?? "?")")
+        downloadedPackage = nil
+        downloadedVersion = nil
+        progress = ProgressState(title: "Downloading debug package", message: "Fetching development package…", fractionComplete: 0)
+        log("Downloading debug demo update v\(availableVersion)")
 
-        Task {
-            for step in 1...10 {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                await MainActor.run {
-                    progress = ProgressState(
-                        title: "Downloading",
-                        message: "Fetching package…",
-                        fractionComplete: Double(step) / 10
+        Task { @MainActor [service] in
+            do {
+                let package = try await service.downloadUpdate(version: availableVersion) { fraction in
+                    self.progress = ProgressState(
+                        title: "Downloading debug package",
+                        message: "Fetching development package…",
+                        fractionComplete: fraction
                     )
                 }
-            }
-            await MainActor.run {
-                downloadedVersion = availableVersion
-                progress = nil
+                downloadedPackage = package
+                downloadedVersion = package.version
                 finishAction()
-                log("Download completed for v\(availableVersion ?? "?")")
+                log("Download completed for debug demo v\(package.version)")
+            } catch {
+                failCurrentAction("Download failed: \(error.localizedDescription)")
             }
         }
     }
 
     func verifyDownload() {
-        guard hasDownloadedUpdate else {
+        guard let downloadedPackage else {
             errorReason = "Download an update before verifying."
             log("Verification blocked: no downloaded package")
             return
@@ -136,51 +201,53 @@ final class AdminUpdateViewModel: ObservableObject {
         guard startAction(.verifying) else { return }
         errorReason = nil
         verificationStatus = .verifying
-        progress = ProgressState(title: "Verifying", message: "Checking signatures…", fractionComplete: 0)
-        log("Started verification for v\(downloadedVersion ?? "?")")
+        progress = ProgressState(title: "Verifying debug package", message: "Checking development package signature…", fractionComplete: 0)
+        log("Started verification for debug demo v\(downloadedPackage.version)")
 
-        Task {
-            for step in 1...5 {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                await MainActor.run {
-                    progress = ProgressState(
-                        title: "Verifying",
-                        message: "Checking signatures…",
-                        fractionComplete: Double(step) / 5
+        Task { @MainActor [service] in
+            do {
+                try await service.verifyDownload(downloadedPackage) { fraction in
+                    self.progress = ProgressState(
+                        title: "Verifying debug package",
+                        message: "Checking development package signature…",
+                        fractionComplete: fraction
                     )
                 }
-            }
-            await MainActor.run {
                 verificationStatus = .verified
-                progress = nil
                 finishAction()
-                log("Package verified for v\(downloadedVersion ?? "?")")
+                log("Debug demo package verified for v\(downloadedPackage.version)")
+            } catch {
+                verificationStatus = .failed(error.localizedDescription)
+                failCurrentAction("Verification failed: \(error.localizedDescription)")
             }
         }
     }
 
     func applyUpdate() {
-        guard canApplyUpdate else {
+        guard canApplyUpdate, let downloadedPackage else {
             errorReason = "Enable maintenance mode and verify the package before applying."
             log("Apply blocked: guardrails not satisfied")
             return
         }
         guard startAction(.applying) else { return }
         errorReason = nil
-        progress = ProgressState(title: "Applying update", message: "Switching traffic to maintenance mode…", fractionComplete: nil)
-        log("Applying update v\(downloadedVersion ?? "?")")
+        progress = ProgressState(title: "Applying debug update", message: "Simulating development update activation…", fractionComplete: nil)
+        log("Applying debug demo update v\(downloadedPackage.version)")
 
-        Task {
-            try? await Task.sleep(nanoseconds: 800_000_000)
-            await MainActor.run {
+        Task { @MainActor [service] in
+            do {
+                try await service.applyUpdate(downloadedPackage)
                 lastStableVersion = currentVersion
-                currentVersion = downloadedVersion ?? currentVersion
+                currentVersion = downloadedPackage.version
                 availableVersion = nil
+                changelog = []
+                self.downloadedPackage = nil
                 downloadedVersion = nil
                 verificationStatus = .notVerified
-                progress = nil
                 finishAction()
-                log("Update applied; now running v\(currentVersion)")
+                log("Debug demo update applied; now showing v\(currentVersion)")
+            } catch {
+                failCurrentAction("Apply failed: \(error.localizedDescription)")
             }
         }
     }
@@ -193,19 +260,22 @@ final class AdminUpdateViewModel: ObservableObject {
         }
         guard startAction(.rollingBack) else { return }
         errorReason = nil
-        progress = ProgressState(title: "Rolling back", message: "Restoring stable build…", fractionComplete: nil)
-        log("Rolling back to v\(stable)")
+        progress = ProgressState(title: "Rolling back debug update", message: "Restoring previous development state…", fractionComplete: nil)
+        log("Rolling back debug demo to v\(stable)")
 
-        Task {
-            try? await Task.sleep(nanoseconds: 700_000_000)
-            await MainActor.run {
+        Task { @MainActor [service] in
+            do {
+                try await service.rollback(to: stable)
                 currentVersion = stable
                 availableVersion = nil
+                changelog = []
+                downloadedPackage = nil
                 downloadedVersion = nil
                 verificationStatus = .notVerified
-                progress = nil
                 finishAction()
-                log("Rollback complete; running v\(stable)")
+                log("Rollback complete; showing v\(stable)")
+            } catch {
+                failCurrentAction("Rollback failed: \(error.localizedDescription)")
             }
         }
     }
@@ -231,6 +301,12 @@ final class AdminUpdateViewModel: ObservableObject {
         progress = nil
     }
 
+    private func failCurrentAction(_ message: String) {
+        errorReason = message
+        finishAction()
+        log(message)
+    }
+
     private func log(_ message: String) {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss"
@@ -238,3 +314,4 @@ final class AdminUpdateViewModel: ObservableObject {
         logs.insert("[\(timestamp)] \(message)", at: 0)
     }
 }
+#endif

--- a/Job Tracker/Features/Shared/AppUpdate/ForceUpdateView.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/ForceUpdateView.swift
@@ -1,11 +1,48 @@
 import SwiftUI
 
+struct ForceUpdateViewContent: Equatable {
+    let title: String
+    let message: String
+    let installedText: String
+    let availableText: String
+    let releaseNotes: String?
+    let buttonTitle: String
+    let isUpdateButtonEnabled: Bool
+    let missingUpdateURLMessage: String?
+    let accessibilityIdentifier: String
+
+    init(requirement: AppUpdateRequirement, currentVersion: String, currentBuild: String) {
+        title = "Update Required"
+        message = "A newer version of Job Tracker is available. Please update to continue using the app."
+        installedText = "Installed: \(currentVersion) (\(currentBuild))"
+        if let latestBuild = requirement.latestBuild {
+            availableText = "Available: \(requirement.latestVersion) (\(latestBuild))"
+        } else {
+            availableText = "Available: \(requirement.latestVersion)"
+        }
+        let trimmedNotes = requirement.releaseNotes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        releaseNotes = trimmedNotes?.isEmpty == false ? trimmedNotes : nil
+        buttonTitle = "Update Now"
+        isUpdateButtonEnabled = requirement.updateURL != nil
+        missingUpdateURLMessage = requirement.updateURL == nil ? "Ask your administrator for the latest install link." : nil
+        accessibilityIdentifier = "ForceUpdateView"
+    }
+}
+
 struct ForceUpdateView: View {
     let requirement: AppUpdateRequirement
     let currentVersion: String
     let currentBuild: String
 
     @Environment(\.openURL) private var openURL
+
+    private var content: ForceUpdateViewContent {
+        ForceUpdateViewContent(
+            requirement: requirement,
+            currentVersion: currentVersion,
+            currentBuild: currentBuild
+        )
+    }
 
     var body: some View {
         ZStack {
@@ -23,22 +60,22 @@ struct ForceUpdateView: View {
                     .shadow(radius: 8)
 
                 VStack(spacing: 10) {
-                    Text("Update Required")
+                    Text(content.title)
                         .font(.largeTitle.bold())
                         .foregroundStyle(.white)
                         .multilineTextAlignment(.center)
 
-                    Text("A newer version of Job Tracker is available. Please update to continue using the app.")
+                    Text(content.message)
                         .font(.body)
                         .foregroundStyle(.white.opacity(0.9))
                         .multilineTextAlignment(.center)
                 }
 
                 VStack(alignment: .leading, spacing: 12) {
-                    Label("Installed: \(currentVersion) (\(currentBuild))", systemImage: "iphone")
-                    Label("Available: \(requirement.latestVersion)\(availableBuildText)", systemImage: "sparkles")
+                    Label(content.installedText, systemImage: "iphone")
+                    Label(content.availableText, systemImage: "sparkles")
 
-                    if let releaseNotes = requirement.releaseNotes, !releaseNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    if let releaseNotes = content.releaseNotes {
                         Divider()
                         Text(releaseNotes)
                             .font(.callout)
@@ -52,17 +89,18 @@ struct ForceUpdateView: View {
                 .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
 
                 Button(action: openUpdateURL) {
-                    Text("Update Now")
+                    Text(content.buttonTitle)
                         .font(.headline)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
-                .disabled(requirement.updateURL == nil)
+                .disabled(!content.isUpdateButtonEnabled)
+                .accessibilityIdentifier("ForceUpdateView.UpdateNowButton")
 
-                if requirement.updateURL == nil {
-                    Text("Ask your administrator for the latest install link.")
+                if let missingUpdateURLMessage = content.missingUpdateURLMessage {
+                    Text(missingUpdateURLMessage)
                         .font(.footnote)
                         .foregroundStyle(.white.opacity(0.85))
                         .multilineTextAlignment(.center)
@@ -72,12 +110,7 @@ struct ForceUpdateView: View {
             .frame(maxWidth: 520)
         }
         .interactiveDismissDisabled(true)
-        .accessibilityIdentifier("ForceUpdateView")
-    }
-
-    private var availableBuildText: String {
-        guard let latestBuild = requirement.latestBuild else { return "" }
-        return " (\(latestBuild))"
+        .accessibilityIdentifier(content.accessibilityIdentifier)
     }
 
     private func openUpdateURL() {

--- a/Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift
@@ -7,6 +7,71 @@ protocol AppUpdateRequirementProviding {
     func observeRequirement(_ onChange: @escaping (Result<AppUpdateRequirement?, Error>) -> Void) -> ListenerRegistration?
 }
 
+struct AppUpdateRemoteConfigDocument: Equatable {
+    static let collection = "app_config"
+    static let documentID = "ios_version"
+    static let trustedSourceDescription = "Firestore app_config/ios_version"
+
+    let latestVersion: String
+    let minimumRequiredVersion: String?
+    let latestBuild: String?
+    let minimumRequiredBuild: String?
+    let updateURLString: String?
+    let releaseNotes: String?
+    let forceUpdateEnabled: Bool
+
+    init(
+        latestVersion: String,
+        minimumRequiredVersion: String? = nil,
+        latestBuild: String? = nil,
+        minimumRequiredBuild: String? = nil,
+        updateURLString: String? = nil,
+        releaseNotes: String? = nil,
+        forceUpdateEnabled: Bool = true
+    ) {
+        self.latestVersion = latestVersion
+        self.minimumRequiredVersion = minimumRequiredVersion
+        self.latestBuild = latestBuild
+        self.minimumRequiredBuild = minimumRequiredBuild
+        self.updateURLString = updateURLString
+        self.releaseNotes = releaseNotes
+        self.forceUpdateEnabled = forceUpdateEnabled
+    }
+
+    init(data: [String: Any]) {
+        self.init(
+            latestVersion: data["latestVersion"] as? String ?? data["minimumRequiredVersion"] as? String ?? "0",
+            minimumRequiredVersion: data["minimumRequiredVersion"] as? String,
+            latestBuild: data["latestBuild"] as? String,
+            minimumRequiredBuild: data["minimumRequiredBuild"] as? String,
+            updateURLString: data["updateURL"] as? String,
+            releaseNotes: data["releaseNotes"] as? String,
+            forceUpdateEnabled: data["forceUpdateEnabled"] as? Bool ?? true
+        )
+    }
+
+    var requirement: AppUpdateRequirement {
+        AppUpdateRequirement(
+            latestVersion: latestVersion,
+            minimumRequiredVersion: minimumRequiredVersion,
+            latestBuild: latestBuild,
+            minimumRequiredBuild: minimumRequiredBuild,
+            updateURL: trustedUpdateURL,
+            releaseNotes: releaseNotes,
+            isEnabled: forceUpdateEnabled
+        )
+    }
+
+    private var trustedUpdateURL: URL? {
+        guard let updateURLString else { return nil }
+        let trimmed = updateURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed), ["https", "itms-apps"].contains(url.scheme?.lowercased()) else {
+            return nil
+        }
+        return url
+    }
+}
+
 final class FirestoreAppUpdateRequirementProvider: AppUpdateRequirementProviding {
     private let db: Firestore
     private let collection: String
@@ -14,8 +79,8 @@ final class FirestoreAppUpdateRequirementProvider: AppUpdateRequirementProviding
 
     init(
         db: Firestore = Firestore.firestore(),
-        collection: String = "app_config",
-        documentID: String = "ios_version"
+        collection: String = AppUpdateRemoteConfigDocument.collection,
+        documentID: String = AppUpdateRemoteConfigDocument.documentID
     ) {
         self.db = db
         self.collection = collection
@@ -35,45 +100,42 @@ final class FirestoreAppUpdateRequirementProvider: AppUpdateRequirementProviding
                 return
             }
 
-            let updateURL: URL?
-            if let urlString = data["updateURL"] as? String {
-                updateURL = URL(string: urlString)
-            } else {
-                updateURL = nil
-            }
-
-            let requirement = AppUpdateRequirement(
-                latestVersion: data["latestVersion"] as? String ?? data["minimumRequiredVersion"] as? String ?? "0",
-                minimumRequiredVersion: data["minimumRequiredVersion"] as? String,
-                latestBuild: data["latestBuild"] as? String,
-                minimumRequiredBuild: data["minimumRequiredBuild"] as? String,
-                updateURL: updateURL,
-                releaseNotes: data["releaseNotes"] as? String,
-                isEnabled: data["forceUpdateEnabled"] as? Bool ?? true
-            )
-            onChange(.success(requirement))
+            let remoteConfig = AppUpdateRemoteConfigDocument(data: data)
+            onChange(.success(remoteConfig.requirement))
         }
     }
+}
+
+enum ForceUpdateMonitoringState: Equatable {
+    case idle
+    case monitoring(source: String)
+    case upToDate(source: String)
+    case updateRequired(source: String)
+    case failed(source: String, message: String)
 }
 
 @MainActor
 final class ForceUpdateViewModel: ObservableObject {
     @Published private(set) var decision: AppUpdateDecision = .upToDate
     @Published private(set) var lastErrorMessage: String?
+    @Published private(set) var monitoringState: ForceUpdateMonitoringState = .idle
 
     private let provider: AppUpdateRequirementProviding
     private let currentVersionProvider: () -> String
     private let currentBuildProvider: () -> String
+    private let trustedConfigSource: String
     private var listener: ListenerRegistration?
 
     init(
         provider: AppUpdateRequirementProviding = FirestoreAppUpdateRequirementProvider(),
         currentVersionProvider: @escaping () -> String = { Bundle.main.appShortVersion },
-        currentBuildProvider: @escaping () -> String = { Bundle.main.appBuildVersion }
+        currentBuildProvider: @escaping () -> String = { Bundle.main.appBuildVersion },
+        trustedConfigSource: String = AppUpdateRemoteConfigDocument.trustedSourceDescription
     ) {
         self.provider = provider
         self.currentVersionProvider = currentVersionProvider
         self.currentBuildProvider = currentBuildProvider
+        self.trustedConfigSource = trustedConfigSource
     }
 
     deinit {
@@ -82,6 +144,7 @@ final class ForceUpdateViewModel: ObservableObject {
 
     func startMonitoring() {
         guard listener == nil else { return }
+        monitoringState = .monitoring(source: trustedConfigSource)
 
         listener = provider.observeRequirement { [weak self] result in
             Task { @MainActor in
@@ -90,13 +153,22 @@ final class ForceUpdateViewModel: ObservableObject {
                 switch result {
                 case let .success(requirement):
                     self.lastErrorMessage = nil
-                    self.decision = AppVersionComparator.decision(
+                    let decision = AppVersionComparator.decision(
                         currentVersion: self.currentVersionProvider(),
                         currentBuild: self.currentBuildProvider(),
                         requirement: requirement
                     )
+                    self.decision = decision
+                    switch decision {
+                    case .upToDate:
+                        self.monitoringState = .upToDate(source: self.trustedConfigSource)
+                    case .updateRequired:
+                        self.monitoringState = .updateRequired(source: self.trustedConfigSource)
+                    }
                 case let .failure(error):
-                    self.lastErrorMessage = error.localizedDescription
+                    let message = error.localizedDescription
+                    self.lastErrorMessage = message
+                    self.monitoringState = .failed(source: self.trustedConfigSource, message: message)
                 }
             }
         }

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -208,7 +208,9 @@ struct AdminPanelView: View {
     @EnvironmentObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var usersViewModel: UsersViewModel
     @StateObject private var viewModel = AdminPanelViewModel()
+    #if DEBUG
     @StateObject private var updateViewModel = AdminUpdateViewModel()
+    #endif
     @State private var pendingToggle: PendingToggle?
     @State private var pendingDeleteUser: AppUser?
     @State private var showingBackfillConfirmation = false
@@ -308,8 +310,9 @@ struct AdminPanelView: View {
         } message: {
             Text("Merges legacy job creators and assignees into each job's participants array. Only run when you understand the impact.")
         }
+        #if DEBUG
         .confirmationDialog(
-            pendingUpdateAction == .apply ? "Apply update?" : "Rollback to previous version?",
+            pendingUpdateAction == .apply ? "Apply debug update?" : "Rollback debug update?",
             isPresented: Binding(
                 get: { pendingUpdateAction != nil },
                 set: { newValue in
@@ -321,12 +324,12 @@ struct AdminPanelView: View {
             if let action = pendingUpdateAction {
                 switch action {
                 case .apply:
-                    Button("Apply Update", role: .destructive) {
+                    Button("Apply Debug Update", role: .destructive) {
                         updateViewModel.applyUpdate()
                         pendingUpdateAction = nil
                     }
                 case .rollback:
-                    Button("Rollback", role: .destructive) {
+                    Button("Rollback Debug Update", role: .destructive) {
                         updateViewModel.rollbackUpdate()
                         pendingUpdateAction = nil
                     }
@@ -338,9 +341,9 @@ struct AdminPanelView: View {
             }
         } message: {
             if pendingUpdateAction == .apply {
-                Text("Applies the downloaded build while in maintenance mode. Services may restart during the process.")
+                Text("This is a debug-only simulation. Production releases are distributed through App Store/TestFlight and gated by remote forced-update config.")
             } else {
-                Text("Restores the last stable build. Use only if the new update is failing health checks.")
+                Text("Restores the previous debug demo version. This does not roll back a production App Store build.")
             }
         }
         .sheet(isPresented: $showingLogs) {
@@ -348,6 +351,7 @@ struct AdminPanelView: View {
                 AdminUpdateLogsView(logs: updateViewModel.logs)
             }
         }
+        #endif
         .onAppear {
             viewModel.attach(usersViewModel: usersViewModel)
             viewModel.refreshRosterSnapshot()
@@ -364,9 +368,16 @@ struct AdminPanelView: View {
     @ViewBuilder
     private var updatesSection: some View {
         Section("App Updates") {
+            #if DEBUG
             VStack(alignment: .leading, spacing: 12) {
+                Label("Debug-only update demo", systemImage: "ladybug")
+                    .font(.headline)
+                Text("Production iOS updates are released through App Store/TestFlight. The live forced-update gate is controlled by trusted Firestore remote config and shown to users automatically when required.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
                 HStack {
-                    Label("Current version", systemImage: "info.circle")
+                    Label("Current demo version", systemImage: "info.circle")
                     Spacer()
                     Text(updateViewModel.currentVersion)
                         .font(.subheadline.monospaced())
@@ -374,13 +385,13 @@ struct AdminPanelView: View {
 
                 if let available = updateViewModel.availableVersion {
                     VStack(alignment: .leading, spacing: 4) {
-                        Label("Update available", systemImage: "arrow.down.circle")
+                        Label("Demo update available", systemImage: "arrow.down.circle")
                             .font(.subheadline)
                         Text("Version \(available)")
                             .font(.subheadline.weight(.semibold))
                         if !updateViewModel.changelog.isEmpty {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text("Changelog")
+                                Text("Demo changelog")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                                 ForEach(updateViewModel.changelog, id: \.self) { item in
@@ -396,7 +407,7 @@ struct AdminPanelView: View {
                     }
                 } else {
                     VStack(alignment: .leading, spacing: 4) {
-                        Label("No pending updates", systemImage: "checkmark.seal")
+                        Label("No pending demo updates", systemImage: "checkmark.seal")
                             .font(.subheadline)
                         if let lastCheck = updateViewModel.lastCheckDate {
                             Text("Last checked at \(lastCheck.formatted(date: .abbreviated, time: .shortened))")
@@ -407,7 +418,7 @@ struct AdminPanelView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Package status")
+                    Text("Demo package status")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Text(updateViewModel.verificationStatus.message)
@@ -417,8 +428,8 @@ struct AdminPanelView: View {
 
                 Toggle(isOn: $updateViewModel.maintenanceModeEnabled) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Maintenance mode")
-                        Text("Required to apply or rollback updates.")
+                        Text("Demo maintenance mode")
+                        Text("Required before applying the debug-only simulated update.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -455,7 +466,7 @@ struct AdminPanelView: View {
                     Button {
                         updateViewModel.checkForUpdates()
                     } label: {
-                        Label("Check for Updates", systemImage: "arrow.clockwise")
+                        Label("Check Demo Updates", systemImage: "arrow.clockwise")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
@@ -464,7 +475,7 @@ struct AdminPanelView: View {
                     Button {
                         updateViewModel.downloadUpdate()
                     } label: {
-                        Label("Download Update", systemImage: "tray.and.arrow.down")
+                        Label("Download Demo Package", systemImage: "tray.and.arrow.down")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)
@@ -473,7 +484,7 @@ struct AdminPanelView: View {
                     Button {
                         updateViewModel.verifyDownload()
                     } label: {
-                        Label("Verify Package", systemImage: "checkmark.shield")
+                        Label("Verify Demo Package", systemImage: "checkmark.shield")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
@@ -482,7 +493,7 @@ struct AdminPanelView: View {
                     Button(role: .destructive) {
                         pendingUpdateAction = .apply
                     } label: {
-                        Label("Apply Update", systemImage: "hammer")
+                        Label("Apply Demo Update", systemImage: "hammer")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
@@ -491,7 +502,7 @@ struct AdminPanelView: View {
                     Button {
                         pendingUpdateAction = .rollback
                     } label: {
-                        Label("Rollback", systemImage: "arrow.uturn.backward")
+                        Label("Rollback Demo", systemImage: "arrow.uturn.backward")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
@@ -500,13 +511,23 @@ struct AdminPanelView: View {
                     Button {
                         showingLogs = true
                     } label: {
-                        Label("View Logs", systemImage: "doc.text.magnifyingglass")
+                        Label("View Demo Logs", systemImage: "doc.text.magnifyingglass")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderless)
                 }
             }
             .padding(.vertical, 4)
+            #else
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Release management", systemImage: "shippingbox")
+                    .font(.headline)
+                Text("Production builds do not include the admin package update demo. Ship releases through App Store/TestFlight, and use the trusted Firestore app_config/ios_version document to force users below the required version to update.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+            #endif
         }
     }
 

--- a/Job TrackerTests/AdminUpdateViewModelTests.swift
+++ b/Job TrackerTests/AdminUpdateViewModelTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import Job_Tracker
+
+#if DEBUG
+@MainActor
+final class AdminUpdateViewModelTests: XCTestCase {
+    func testDebugUpdateHappyPathAndRollback() async {
+        let service = MockAdminUpdateService()
+        let viewModel = AdminUpdateViewModel(bundle: .main, service: service)
+        let originalVersion = viewModel.currentVersion
+
+        viewModel.checkForUpdates()
+        await waitForIdle(viewModel)
+        XCTAssertEqual(viewModel.availableVersion, "9.9.0-debug")
+        XCTAssertEqual(viewModel.changelog, ["Test release"])
+
+        viewModel.downloadUpdate()
+        await waitForIdle(viewModel)
+        XCTAssertEqual(viewModel.downloadedVersion, "9.9.0-debug")
+        XCTAssertTrue(viewModel.hasDownloadedUpdate)
+
+        viewModel.verifyDownload()
+        await waitForIdle(viewModel)
+        XCTAssertEqual(viewModel.verificationStatus, .verified)
+
+        viewModel.applyUpdate()
+        await waitForIdle(viewModel)
+        XCTAssertEqual(viewModel.errorReason, "Enable maintenance mode and verify the package before applying.")
+        XCTAssertEqual(viewModel.currentVersion, originalVersion)
+
+        viewModel.resetError()
+        viewModel.maintenanceModeEnabled = true
+        viewModel.applyUpdate()
+        await waitForIdle(viewModel)
+        XCTAssertEqual(viewModel.currentVersion, "9.9.0-debug")
+        XCTAssertNil(viewModel.downloadedVersion)
+        XCTAssertEqual(viewModel.verificationStatus, .notVerified)
+
+        viewModel.rollbackUpdate()
+        await waitForIdle(viewModel)
+        XCTAssertEqual(viewModel.currentVersion, originalVersion)
+        XCTAssertNil(viewModel.errorReason)
+    }
+
+    func testFailureStatesAreReportedAndResetBusyState() async {
+        let service = MockAdminUpdateService(error: TestError.offline)
+        let viewModel = AdminUpdateViewModel(bundle: .main, service: service)
+
+        viewModel.checkForUpdates()
+        await waitForIdle(viewModel)
+
+        XCTAssertEqual(viewModel.actionState, .idle)
+        XCTAssertEqual(viewModel.errorReason, "Update check failed: offline")
+        XCTAssertFalse(viewModel.logs.isEmpty)
+    }
+
+    func testVerificationFailureMarksPackageFailed() async {
+        let service = MockAdminUpdateService(verificationError: TestError.badSignature)
+        let viewModel = AdminUpdateViewModel(bundle: .main, service: service)
+
+        viewModel.checkForUpdates()
+        await waitForIdle(viewModel)
+        viewModel.downloadUpdate()
+        await waitForIdle(viewModel)
+        viewModel.verifyDownload()
+        await waitForIdle(viewModel)
+
+        XCTAssertEqual(viewModel.verificationStatus, .failed("bad signature"))
+        XCTAssertEqual(viewModel.errorReason, "Verification failed: bad signature")
+        XCTAssertFalse(viewModel.canApplyUpdate)
+    }
+
+    private func waitForIdle(_ viewModel: AdminUpdateViewModel) async {
+        for _ in 0..<25 where viewModel.actionState != .idle {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+}
+
+private final class MockAdminUpdateService: AdminUpdateService {
+    private let error: Error?
+    private let verificationError: Error?
+
+    init(error: Error? = nil, verificationError: Error? = nil) {
+        self.error = error
+        self.verificationError = verificationError
+    }
+
+    func checkForUpdates(currentVersion: String) async throws -> AdminUpdateViewModel.UpdateManifest? {
+        if let error { throw error }
+        return AdminUpdateViewModel.UpdateManifest(version: "9.9.0-debug", changelog: ["Test release"])
+    }
+
+    func downloadUpdate(version: String, progress: @escaping @MainActor (Double) -> Void) async throws -> AdminUpdateViewModel.DownloadedPackage {
+        if let error { throw error }
+        await progress(1)
+        return AdminUpdateViewModel.DownloadedPackage(version: version, checksum: "checksum")
+    }
+
+    func verifyDownload(_ package: AdminUpdateViewModel.DownloadedPackage, progress: @escaping @MainActor (Double) -> Void) async throws {
+        if let verificationError { throw verificationError }
+        if let error { throw error }
+        await progress(1)
+    }
+
+    func applyUpdate(_ package: AdminUpdateViewModel.DownloadedPackage) async throws {
+        if let error { throw error }
+    }
+
+    func rollback(to version: String) async throws {
+        if let error { throw error }
+    }
+}
+
+private enum TestError: LocalizedError {
+    case offline
+    case badSignature
+
+    var errorDescription: String? {
+        switch self {
+        case .offline: return "offline"
+        case .badSignature: return "bad signature"
+        }
+    }
+}
+#endif

--- a/Job TrackerTests/ForceUpdateViewModelTests.swift
+++ b/Job TrackerTests/ForceUpdateViewModelTests.swift
@@ -61,6 +61,70 @@ final class ForceUpdateViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.lastErrorMessage, "offline")
     }
 
+
+    @MainActor
+    func testMonitoringStateTracksTrustedRemoteConfigSourceAndRequiredUI() async {
+        let provider = MockAppUpdateRequirementProvider()
+        let viewModel = ForceUpdateViewModel(
+            provider: provider,
+            currentVersionProvider: { "2.1.0" },
+            currentBuildProvider: { "10" },
+            trustedConfigSource: "test trusted source"
+        )
+        let requirement = AppUpdateRequirement(
+            latestVersion: "2.3.0",
+            latestBuild: "20",
+            updateURL: URL(string: "https://apps.apple.com/app/job-tracker"),
+            releaseNotes: "Security fix"
+        )
+
+        viewModel.startMonitoring()
+        XCTAssertEqual(viewModel.monitoringState, .monitoring(source: "test trusted source"))
+        provider.publish(.success(requirement))
+        await Task.yield()
+
+        XCTAssertEqual(viewModel.monitoringState, .updateRequired(source: "test trusted source"))
+        let content = ForceUpdateViewContent(requirement: requirement, currentVersion: "2.1.0", currentBuild: "10")
+        XCTAssertEqual(content.title, "Update Required")
+        XCTAssertEqual(content.installedText, "Installed: 2.1.0 (10)")
+        XCTAssertEqual(content.availableText, "Available: 2.3.0 (20)")
+        XCTAssertEqual(content.releaseNotes, "Security fix")
+        XCTAssertTrue(content.isUpdateButtonEnabled)
+        XCTAssertEqual(content.accessibilityIdentifier, "ForceUpdateView")
+    }
+
+    @MainActor
+    func testForcedUpdateUIExplainsMissingUpdateURL() {
+        let requirement = AppUpdateRequirement(latestVersion: "2.3.0", updateURL: nil, releaseNotes: "   ")
+        let content = ForceUpdateViewContent(requirement: requirement, currentVersion: "2.1.0", currentBuild: "10")
+
+        XCTAssertEqual(content.availableText, "Available: 2.3.0")
+        XCTAssertNil(content.releaseNotes)
+        XCTAssertFalse(content.isUpdateButtonEnabled)
+        XCTAssertEqual(content.missingUpdateURLMessage, "Ask your administrator for the latest install link.")
+    }
+
+    func testRemoteConfigDocumentParsesTrustedFirestorePayloadAndRejectsUntrustedURLScheme() {
+        let document = AppUpdateRemoteConfigDocument(data: [
+            "latestVersion": "2.4.0",
+            "minimumRequiredVersion": "2.3.0",
+            "latestBuild": "30",
+            "minimumRequiredBuild": "25",
+            "updateURL": "javascript:alert(1)",
+            "releaseNotes": "Required security update",
+            "forceUpdateEnabled": true
+        ])
+
+        let requirement = document.requirement
+        XCTAssertEqual(requirement.latestVersion, "2.4.0")
+        XCTAssertEqual(requirement.minimumRequiredVersion, "2.3.0")
+        XCTAssertEqual(requirement.latestBuild, "30")
+        XCTAssertEqual(requirement.minimumRequiredBuild, "25")
+        XCTAssertNil(requirement.updateURL)
+        XCTAssertEqual(requirement.releaseNotes, "Required security update")
+        XCTAssertTrue(requirement.isEnabled)
+    }
+
     @MainActor
     func testStartMonitoringOnlyRegistersOneProviderListener() {
         let provider = MockAppUpdateRequirementProvider()


### PR DESCRIPTION
### Motivation
- Production updates should be managed via App Store/TestFlight with forced-update gating from a trusted remote config, and the in-app admin package-download/apply flow must not run in production. 
- The admin update UI is intended as a development/demo surface for debugging the workflow only and must be hidden from release builds. 

### Description
- Gate the admin package workflow behind `#if DEBUG` by making `AdminUpdateViewModel` compile only in DEBUG and introducing an injectable `AdminUpdateService` plus `DevelopmentAdminUpdateService` to simulate `checkForUpdates`, `downloadUpdate`, `verifyDownload`, `applyUpdate`, and `rollback` in development builds. 
- Hide and clearly label the admin update controls in `AdminPanelView`/`MainTabView` when not `DEBUG`, and change button labels/confirmation text to indicate the feature is a debug-only demo. 
- Connect production forced-update behavior to a trusted Firestore remote config by adding `AppUpdateRemoteConfigDocument` parsing (with URL-scheme validation) and an explicit `monitoringState` to `ForceUpdateViewModel`, and factor forced-update presentation into `ForceUpdateViewContent` for testable UI strings and button enablement. 
- Add unit tests: a new `AdminUpdateViewModelTests` (DEBUG-only) covering check/download/verify/apply/rollback, failure and verification-failure states, and extensions to `ForceUpdateViewModelTests` validating remote-config parsing, monitoring-state transitions, and forced-update UI content; update docs to describe the chosen policy. 

### Testing
- `git diff --check` ran with no whitespace errors. 
- Attempted `xcodebuild test -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' ...` for the new/updated iOS tests but `xcodebuild` is not available in this environment so the test run was not executed. 
- Attempted `swift test` but the repository has no `Package.swift`, so SwiftPM tests were not executed here. 
- Note: unit tests were added (`Job TrackerTests/AdminUpdateViewModelTests.swift` and updated `ForceUpdateViewModelTests.swift`) and are expected to run in CI / a macOS environment with Xcode available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b190168a4832d90fde03c0940a048)