### PR TITLE
Add safety-net UI tests, integration smoke tests, and Firebase emulator scaffolding

### DIFF
--- a/.xcode-cloud/smoke-test-checklist.md
+++ b/.xcode-cloud/smoke-test-checklist.md
@@ -1,0 +1,17 @@
+# Xcode Cloud Smoke-Test Checklist
+
+Run this checklist on pull requests and release candidates after the safety-net XCTest plan passes:
+
+1. Build and test the iOS app target with the shared `Job Tracker` scheme and `Job Tracker Safety Net` plan.
+2. Build the `Job Tracker Companion Watch App` target for a watchOS Simulator destination.
+3. Build the iMessage extension target when the project target is present; until then, validate that `imessage cs/` remains checked in and compiles when re-added to the project.
+4. Confirm the host app still embeds the watch app for archive/build workflows.
+5. Confirm UI-test launch arguments use seeded data only in UI-test runs (`JT_UI_TESTING=1`) and never in Release archive actions.
+
+Suggested local command set on macOS:
+
+```sh
+ci_scripts/ci_pre_xcodebuild.sh
+xcodebuild test -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -testPlan "Job Tracker Safety Net" -destination 'platform=iOS Simulator,name=iPhone 15'
+xcodebuild build -project "Job Tracker.xcodeproj" -target "Job Tracker Companion Watch App" -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
+```

--- a/Documentation/TestingSafetyNet.md
+++ b/Documentation/TestingSafetyNet.md
@@ -12,6 +12,9 @@ The `Job TrackerTests` bundle should keep fast, deterministic XCTest coverage ar
 - **Job intake, sharing, and search**: Deep-link, shared-payload, parser, and search-matcher tests cover import/export payloads and matching heuristics that affect daily job routing.
 - **Dashboard and recent crew jobs**: View-model tests cover summaries and detail sheets that crew members use to understand current work.
 - **Help and tutorial flows**: Tutorial stage tests protect onboarding guidance from accidental regressions.
+- **Seeded UI flows**: `Job TrackerUITests` launches with `JT_UI_TESTING=1` and deterministic seed data to cover authentication validation, dashboard job flow, create/detail/delete controls, search, timesheets, yellow sheets, settings, and admin-only navigation without writing to production Firebase.
+- **Integration smoke tests**: `ServiceIntegrationSmokeTests` covers PDF generation, job-photo slot mapping, arrival-alert inactive state, and watch sync payload filtering; `AppIntentEntryPointTests` protects App Intent discoverability and fallback messaging.
+- **Firebase rules emulator tests**: `firebase-emulator-tests/firestore-storage.rules.test.js` is wired through `npm run test:firebase-rules` and intentionally skips until both `firestore.rules` and `storage.rules` are present.
 
 ## Minimum expectations for future work
 
@@ -24,7 +27,9 @@ Add or update tests in the same pull request when a change affects any of these 
 5. Deep links, shared job payloads, imported job sheets, or parsing of externally supplied data.
 6. Bug fixes where a regression test can reproduce the failing case.
 
-Prefer small unit tests with mocks, fakes, in-memory data, and injected closures. Do not depend on production Firebase documents, physical devices, wall-clock timing, or external network services in the safety-net plan. Slow integration tests should live in a separate plan or workflow so the main pull-request test action remains reliable.
+Prefer small unit tests with mocks, fakes, in-memory data, injected closures, or the UI-test seed harness. Do not depend on production Firebase documents, physical devices, wall-clock timing, or external network services in the safety-net plan. Slow integration tests should live in a separate plan or workflow so the main pull-request test action remains reliable.
+
+When Firestore or Storage rules files are added, keep `firebase-emulator-tests/firestore-storage.rules.test.js` passing under `npm run test:firebase-rules` and expand the cases for each new collection or Storage prefix.
 
 ## Keeping the safety net wired
 
@@ -33,3 +38,4 @@ Prefer small unit tests with mocks, fakes, in-memory data, and injected closures
 - Keep code coverage enabled in both the shared scheme and the test plan.
 - Add every new XCTest or UI-test target to `Job Tracker Safety Net.xctestplan` unless it is intentionally isolated in a separate documented workflow.
 - Run `ci_scripts/ci_pre_xcodebuild.sh` after changing the Xcode project, shared scheme, or test plan. The script fails when the scheme no longer references the plan, coverage is disabled, or an XCTest target is missing from the plan.
+- Follow `.xcode-cloud/smoke-test-checklist.md` for the lightweight Xcode Cloud/manual build smoke checks that cover the iOS app, watch app, and iMessage extension surface.

--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -5,7 +5,7 @@ The repository now treats Xcode Cloud as the safety net for the full app project
 ## What is wired together
 
 - The shared `Job Tracker` scheme runs `Job Tracker Safety Net.xctestplan`.
-- The safety-net test plan includes the `Job TrackerTests` XCTest bundle and collects code coverage.
+- The safety-net test plan includes the `Job TrackerTests` XCTest bundle, the seeded `Job TrackerUITests` UI-test bundle, and collects code coverage.
 - The checked-in project keeps the main app target wired to the embedded watch app for normal local builds and archive workflows. The watch app must support both `watchos` and `watchsimulator`, and framework references must resolve from `SDKROOT` so supported simulator builds remain portable across current Xcode Cloud images.
 - `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date. During Xcode Cloud Test actions (`build-for-testing`, `test`, or `test-without-building`), the script removes the host app's watch embed/dependency edges in the temporary checkout so unit-test builds do not fail destination resolution when the workflow supplies generic or unpaired iOS simulators.
 
@@ -33,6 +33,10 @@ ci_scripts/ci_pre_xcodebuild.sh
 
 The `Job TrackerTests` bundle is intentionally part of the shared `Job Tracker` scheme so Xcode Cloud and local developers run the same tests. See [Testing Safety Net](TestingSafetyNet.md) for the coverage map and the minimum expectations for future changes.
 
+## Build smoke-test checklist
+
+Use `.xcode-cloud/smoke-test-checklist.md` as the small PR/release checklist for building the iOS app, companion watch app, and iMessage extension surface in addition to running the XCTest plan.
+
 ## Recommended Xcode Cloud workflow
 
 Create or update the workflow in Xcode with these settings:
@@ -52,6 +56,7 @@ A separate Build action is not required before the Test action because Xcode bui
 Keep this setup as the default safety net when the project grows:
 
 - Add every new XCTest or UI-test bundle to `Job Tracker Safety Net.xctestplan` before merging it.
+- Keep the UI-test seed harness (`JT_UI_TESTING=1`) deterministic and isolated from production Firebase.
 - Keep the `Job Tracker` scheme shared and pointed at the safety-net test plan.
 - Keep code coverage enabled in both the scheme and the test plan.
 - Prefer deterministic unit tests for parsing, search matching, app-update checks, routing, view models, PDF helpers, import/export payloads, and admin logic.

--- a/Job Tracker Safety Net.xctestplan
+++ b/Job Tracker Safety Net.xctestplan
@@ -1,26 +1,33 @@
 {
-  "configurations" : [
+  "configurations": [
     {
-      "id" : "1C2DD7E4-8DA2-44E6-9751-1F5C6E28B9E0",
-      "name" : "Safety Net"
+      "id": "1C2DD7E4-8DA2-44E6-9751-1F5C6E28B9E0",
+      "name": "Safety Net"
     }
   ],
-  "defaultOptions" : {
-    "codeCoverage" : true,
-    "targetForVariableExpansion" : {
-      "containerPath" : "container:Job Tracker.xcodeproj",
-      "identifier" : "CDDA111C2D579EC0007BADFF",
-      "name" : "Job Tracker"
+  "defaultOptions": {
+    "codeCoverage": true,
+    "targetForVariableExpansion": {
+      "containerPath": "container:Job Tracker.xcodeproj",
+      "identifier": "CDDA111C2D579EC0007BADFF",
+      "name": "Job Tracker"
     }
   },
-  "testTargets" : [
+  "testTargets": [
     {
-      "target" : {
-        "containerPath" : "container:Job Tracker.xcodeproj",
-        "identifier" : "CD7E57000000000000000106",
-        "name" : "Job TrackerTests"
+      "target": {
+        "containerPath": "container:Job Tracker.xcodeproj",
+        "identifier": "CD7E57000000000000000106",
+        "name": "Job TrackerTests"
+      }
+    },
+    {
+      "target": {
+        "containerPath": "container:Job Tracker.xcodeproj",
+        "identifier": "CD9A00000000000000000006",
+        "name": "Job TrackerUITests"
       }
     }
   ],
-  "version" : 1
+  "version": 1
 }

--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -34,6 +34,13 @@
 			remoteGlobalIDString = CDDA111C2D579EC0007BADFF;
 			remoteInfo = "Job Tracker";
 		};
+		CD9A00000000000000000007 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CDDA11152D579EC0007BADFF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CDDA111C2D579EC0007BADFF;
+			remoteInfo = "Job Tracker";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -68,6 +75,7 @@
 		CDDA111D2D579EC0007BADFF /* Job Tracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Job Tracker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDFE39FD2FA3624A00AEEAAB /* WebMaps */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WebMaps; path = "Job Tracker/Resources/WebMaps"; sourceTree = SOURCE_ROOT; };
 		CD7E57000000000000000101 /* Job TrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Job TrackerTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD9A00000000000000000001 /* Job TrackerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Job TrackerUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -84,6 +92,11 @@
 		CD7E57000000000000000102 /* Job TrackerTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Job TrackerTests";
+			sourceTree = "<group>";
+		};
+		CD9A00000000000000000002 /* Job TrackerUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Job TrackerUITests";
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -118,6 +131,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CD9A00000000000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -145,6 +165,7 @@
 				CDDA111F2D579EC0007BADFF /* Job Tracker */,
 				CD1C8C782E5BBB140001CE7E /* Job Tracker Companion Watch App */,
 				CD7E57000000000000000102 /* Job TrackerTests */,
+				CD9A00000000000000000002 /* Job TrackerUITests */,
 				CD1C8C642E5BB9390001CE7E /* Frameworks */,
 				CDDA111E2D579EC0007BADFF /* Products */,
 				CDD73CEB2FC6A28F00909B7D /* Recovered References */,
@@ -157,6 +178,7 @@
 				CDDA111D2D579EC0007BADFF /* Job Tracker.app */,
 				CD1C8C772E5BBB140001CE7E /* Job Tracker Companion Watch App.app */,
 				CD7E57000000000000000101 /* Job TrackerTests.xctest */,
+				CD9A00000000000000000001 /* Job TrackerUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -240,6 +262,29 @@
 			productReference = CD7E57000000000000000101 /* Job TrackerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		CD9A00000000000000000006 /* Job TrackerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CD9A0000000000000000000B /* Build configuration list for PBXNativeTarget "Job TrackerUITests" */;
+			buildPhases = (
+				CD9A00000000000000000005 /* Sources */,
+				CD9A00000000000000000003 /* Frameworks */,
+				CD9A00000000000000000004 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CD9A00000000000000000008 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CD9A00000000000000000002 /* Job TrackerUITests */,
+			);
+			name = "Job TrackerUITests";
+			packageProductDependencies = (
+			);
+			productName = "Job TrackerUITests";
+			productReference = CD9A00000000000000000001 /* Job TrackerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -257,6 +302,10 @@
 						CreatedOnToolsVersion = 16.2;
 					};
 					CD7E57000000000000000106 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = CDDA111C2D579EC0007BADFF;
+					};
+					CD9A00000000000000000006 = {
 						CreatedOnToolsVersion = 16.4;
 						TestTargetID = CDDA111C2D579EC0007BADFF;
 					};
@@ -282,6 +331,7 @@
 				CDDA111C2D579EC0007BADFF /* Job Tracker */,
 				CD1C8C762E5BBB140001CE7E /* Job Tracker Companion Watch App */,
 				CD7E57000000000000000106 /* Job TrackerTests */,
+				CD9A00000000000000000006 /* Job TrackerUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -303,6 +353,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD7E57000000000000000104 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD9A00000000000000000004 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -333,6 +390,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CD9A00000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -345,6 +409,11 @@
 			isa = PBXTargetDependency;
 			target = CDDA111C2D579EC0007BADFF /* Job Tracker */;
 			targetProxy = CD7E57000000000000000107 /* PBXContainerItemProxy */;
+		};
+		CD9A00000000000000000008 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CDDA111C2D579EC0007BADFF /* Job Tracker */;
+			targetProxy = CD9A00000000000000000007 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -670,6 +739,46 @@
 			};
 			name = Release;
 		};
+		CD9A00000000000000000009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Z2Z5T47373;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25UITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = "Job Tracker";
+			};
+			name = Debug;
+		};
+		CD9A0000000000000000000A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Z2Z5T47373;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25UITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = "Job Tracker";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -705,6 +814,15 @@
 			buildConfigurations = (
 				CD7E57000000000000000109 /* Debug */,
 				CD7E5700000000000000010A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CD9A0000000000000000000B /* Build configuration list for PBXNativeTarget "Job TrackerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD9A00000000000000000009 /* Debug */,
+				CD9A0000000000000000000A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
+++ b/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
@@ -46,6 +46,17 @@
                ReferencedContainer = "container:Job Tracker.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD9A00000000000000000006"
+               BuildableName = "Job TrackerUITests.xctest"
+               BlueprintName = "Job TrackerUITests"
+               ReferencedContainer = "container:Job Tracker.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Job Tracker/AppDelegate.swift
+++ b/Job Tracker/AppDelegate.swift
@@ -19,14 +19,16 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        if FirebaseApp.app() == nil {
+        if !ProcessInfo.processInfo.isJobTrackerUITesting, FirebaseApp.app() == nil {
             FirebaseApp.configure()
         }
         #if canImport(GooglePlaces)
         GMSPlacesClient.provideAPIKey("AIzaSyABtSWf7_UPKKD-O83BYmhUlslXZHdp7U0")
         #endif
 
-        configureNotifications()
+        if !ProcessInfo.processInfo.isJobTrackerUITesting {
+            configureNotifications()
+        }
         return true
     }
 

--- a/Job Tracker/Features/Authentication/AuthViewModel.swift
+++ b/Job Tracker/Features/Authentication/AuthViewModel.swift
@@ -20,7 +20,21 @@ class AuthViewModel: ObservableObject {
     private var observedCurrentUserID: String?
 
     init() {
-        checkAuthState()
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            let isAdmin = ProcessInfo.processInfo.shouldUseAdminJobTrackerUITestUser
+            var user = AppUser(
+                id: "ui-test-user",
+                firstName: isAdmin ? "Admin" : "Crew",
+                lastName: "Tester",
+                email: isAdmin ? "admin-ui@example.com" : "crew-ui@example.com",
+                position: isAdmin ? "Supervisor" : "Technician"
+            )
+            user.isAdmin = isAdmin
+            user.isSupervisor = isAdmin
+            applyUser(user)
+        } else {
+            checkAuthState()
+        }
     }
 
     deinit {
@@ -35,6 +49,10 @@ class AuthViewModel: ObservableObject {
     }
 
     func checkAuthState() {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            return
+        }
+
         if FirebaseService.shared.currentUserID() != nil {
             startCurrentUserListener()
         } else {
@@ -125,6 +143,11 @@ class AuthViewModel: ObservableObject {
     }
 
     func signOut() {
+        if ProcessInfo.processInfo.isJobTrackerUITesting {
+            applyUser(nil)
+            return
+        }
+
         do {
             stopCurrentUserListener()
             try FirebaseService.shared.signOutUser()

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -195,7 +195,9 @@ struct DashboardView: View {
             .onAppear {
                 viewModel.configureIfNeeded(jobsViewModel: jobsViewModel)
                 viewModel.updateNearestJob(with: jobsViewModel.jobs, currentLocation: locationService.current)
-                JobPhotoUploadQueue.shared.publishCurrentSyncState()
+                if !ProcessInfo.processInfo.isJobTrackerUITesting {
+                    JobPhotoUploadQueue.shared.publishCurrentSyncState()
+                }
             }
             .onReceive(locationService.$current) { location in
                 viewModel.updateNearestJob(with: jobsViewModel.jobs, currentLocation: location)

--- a/Job Tracker/Features/Jobs/JobsViewModel.swift
+++ b/Job Tracker/Features/Jobs/JobsViewModel.swift
@@ -34,6 +34,9 @@ class JobsViewModel: ObservableObject {
     }
 
     init() {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            seedUITestJobs()
+        }
         // No initial fetch in init()
     }
 
@@ -104,7 +107,50 @@ class JobsViewModel: ObservableObject {
 
     // MARK: - Fetch
 
+    private func seedUITestJobs() {
+        let now = Date()
+        jobs = [
+            Job(
+                id: "ui-test-job-1",
+                address: "100 Safety Net Lane",
+                date: now,
+                status: "Pending",
+                assignedTo: "ui-test-user",
+                createdBy: "ui-test-user",
+                notes: "Seeded UI test dashboard job",
+                jobNumber: "UI-100",
+                locationNumber: "491320",
+                assignments: "42.7.1",
+                materialsUsed: "Fiber Cable",
+                participants: ["ui-test-user"],
+                nidFootage: "150",
+                canFootage: "200"
+            ),
+            Job(
+                id: "ui-test-job-2",
+                address: "200 Completed Avenue",
+                date: now,
+                status: "Done",
+                assignedTo: "ui-test-user",
+                createdBy: "ui-test-user",
+                notes: "Completed seeded UI test job",
+                jobNumber: "UI-200",
+                participants: ["ui-test-user"]
+            )
+        ]
+        searchJobs = jobs.map(JobSearchIndexEntry.init(job:))
+        hasLoadedInitialJobs = true
+        rebuildSearchIndexEntries()
+    }
+
     func fetchJobs(startDate: Date? = nil, endDate: Date? = nil) {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            hasLoadedInitialJobs = true
+            rebuildSearchIndexEntries()
+            notifyJobsChanged()
+            return
+        }
+
         listenerRegistration?.remove()
 
         hasLoadedInitialJobs = false
@@ -201,6 +247,11 @@ class JobsViewModel: ObservableObject {
     /// Begin listening to a lightweight representation of every job so search can span the entire
     /// database (subject to Firestore rules). Safe to call multiple times; it will only attach once.
     func startSearchIndexForAllJobs() {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            rebuildSearchIndexEntries()
+            return
+        }
+
         if searchListenerRegistration != nil { return }
 
         // The dedicated `jobsSearch` collection previously mirrored global job metadata, but in
@@ -276,6 +327,16 @@ class JobsViewModel: ObservableObject {
     // MARK: - Create
 
     func createJob(_ job: Job, completion: @escaping (Bool) -> Void = { _ in }) {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            var newJob = job
+            newJob.id = "ui-test-created-\(jobs.count + 1)"
+            jobs.append(newJob)
+            rebuildSearchIndexEntries()
+            notifyJobsChanged()
+            completion(true)
+            return
+        }
+
         // Pre-generate the doc ID so it exists locally while offline & UI can show pending state
         let docRef = db.collection("jobs").document()
         var newJob = job
@@ -303,6 +364,15 @@ class JobsViewModel: ObservableObject {
     // MARK: - Update
 
     func updateJob(_ job: Job, documentID: String) {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            if let index = jobs.firstIndex(where: { $0.id == documentID }) {
+                jobs[index] = job
+                rebuildSearchIndexEntries()
+                notifyJobsChanged()
+            }
+            return
+        }
+
         let ref = db.collection("jobs").document(documentID)
 
         // 1) Read current participants so we never drop them during an update
@@ -378,6 +448,15 @@ class JobsViewModel: ObservableObject {
 
     /// Update only the status; fast local feedback + safe offline queueing.
     func updateJobStatus(job: Job, newStatus: String) {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            if let index = jobs.firstIndex(where: { $0.id == job.id }) {
+                jobs[index].status = newStatus
+                rebuildSearchIndexEntries()
+                notifyJobsChanged()
+            }
+            return
+        }
+
         let docID = job.id
 
         // Optimistic local update for snappy UI
@@ -407,6 +486,14 @@ class JobsViewModel: ObservableObject {
     // MARK: - Delete
 
     func deleteJob(documentID: String, completion: @escaping (Bool) -> Void = { _ in }) {
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            jobs.removeAll { $0.id == documentID }
+            rebuildSearchIndexEntries()
+            notifyJobsChanged()
+            completion(true)
+            return
+        }
+
         FirebaseService.shared.deleteJobRespectingPairing(jobId: documentID) { result in
             DispatchQueue.main.async {
                 switch result {

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -294,14 +294,18 @@ struct WeeklyTimesheetView: View {
                 }
             }
             .onAppear {
-                if let me = authViewModel.currentUser?.id {
+                if ProcessInfo.processInfo.isJobTrackerUITesting {
+                    self.partnerUid = nil
+                } else if let me = authViewModel.currentUser?.id {
                     FirebaseService.shared.fetchPartnerId(for: me) { pid in
                         DispatchQueue.main.async { self.partnerUid = pid }
                     }
                 } else {
                     self.partnerUid = nil
                 }
-                loadTimesheet()
+                if !ProcessInfo.processInfo.isJobTrackerUITesting {
+                    loadTimesheet()
+                }
             }
             .onChange(of: selectedDate) { _ in
                 loadTimesheet()

--- a/Job Tracker/Features/YellowSheet/YellowSheetView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetView.swift
@@ -89,7 +89,9 @@ struct YellowSheetView: View {
             .navigationTitle("     ")
             .jtNavigationBarStyle()
             .onAppear {
-                if let me = authViewModel.currentUser?.id {
+                if ProcessInfo.processInfo.isJobTrackerUITesting {
+                    self.partnerUid = nil
+                } else if let me = authViewModel.currentUser?.id {
                     FirebaseService.shared.fetchPartnerId(for: me) { pid in
                         DispatchQueue.main.async { self.partnerUid = pid }
                     }
@@ -102,7 +104,9 @@ struct YellowSheetView: View {
                 jobsViewModel.fetchJobsForWeek(selectedDate)
             }
             .onReceive(authViewModel.$currentUser) { _ in
-                if let me = authViewModel.currentUser?.id {
+                if ProcessInfo.processInfo.isJobTrackerUITesting {
+                    self.partnerUid = nil
+                } else if let me = authViewModel.currentUser?.id {
                     FirebaseService.shared.fetchPartnerId(for: me) { pid in
                         DispatchQueue.main.async { self.partnerUid = pid }
                     }

--- a/Job Tracker/Job_TrackerApp.swift
+++ b/Job Tracker/Job_TrackerApp.swift
@@ -12,6 +12,13 @@ import FirebaseFirestore
 import UIKit
 import WatchConnectivity
 
+private struct UITestAppUpdateRequirementProvider: AppUpdateRequirementProviding {
+    func observeRequirement(_ onChange: @escaping (Result<AppUpdateRequirement?, Error>) -> Void) -> ListenerRegistration? {
+        onChange(.success(nil))
+        return nil
+    }
+}
+
 @main
 struct JobTrackerApp: App {
     // Ensure Firebase is configured before any view models are created
@@ -26,14 +33,40 @@ struct JobTrackerApp: App {
             db.settings = settings
         }
     }
+    private static var isUITesting: Bool {
+        ProcessInfo.processInfo.isJobTrackerUITesting
+    }
+
     private static func makeAuthVM() -> AuthViewModel {
-        ensureFirebaseConfigured(); return AuthViewModel()
+        if !isUITesting { ensureFirebaseConfigured() }
+        return AuthViewModel()
     }
     private static func makeJobsVM() -> JobsViewModel {
-        ensureFirebaseConfigured(); return JobsViewModel()
+        if !isUITesting { ensureFirebaseConfigured() }
+        return JobsViewModel()
     }
     private static func makeUsersVM() -> UsersViewModel {
-        ensureFirebaseConfigured(); return UsersViewModel()
+        if !isUITesting { ensureFirebaseConfigured() }
+        if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
+            var user = AppUser(
+                id: "ui-test-user",
+                firstName: ProcessInfo.processInfo.shouldUseAdminJobTrackerUITestUser ? "Admin" : "Crew",
+                lastName: "Tester",
+                email: ProcessInfo.processInfo.shouldUseAdminJobTrackerUITestUser ? "admin-ui@example.com" : "crew-ui@example.com",
+                position: ProcessInfo.processInfo.shouldUseAdminJobTrackerUITestUser ? "Supervisor" : "Technician"
+            )
+            user.isAdmin = ProcessInfo.processInfo.shouldUseAdminJobTrackerUITestUser
+            user.isSupervisor = ProcessInfo.processInfo.shouldUseAdminJobTrackerUITestUser
+            return UsersViewModel(shouldListen: false, seedUsers: [user.id: user])
+        }
+        return UsersViewModel()
+    }
+    private static func makeForceUpdateVM() -> ForceUpdateViewModel {
+        if isUITesting {
+            return ForceUpdateViewModel(provider: UITestAppUpdateRequirementProvider())
+        }
+        ensureFirebaseConfigured()
+        return ForceUpdateViewModel()
     }
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -44,7 +77,7 @@ struct JobTrackerApp: App {
     @StateObject private var usersViewModel = JobTrackerApp.makeUsersVM()
     @StateObject private var navigationViewModel = AppNavigationViewModel()
     @StateObject private var themeManager = JTThemeManager.shared
-    @StateObject private var forceUpdateViewModel = ForceUpdateViewModel()
+    @StateObject private var forceUpdateViewModel = JobTrackerApp.makeForceUpdateVM()
     @AppStorage("arrivalAlertsEnabledToday") private var arrivalAlertsEnabledToday = true
     @State private var showSplash: Bool = true
     @State private var showImportSuccess: Bool = false
@@ -71,6 +104,8 @@ struct JobTrackerApp: App {
                     ContentView()
                     // Activate WCSession + push snapshot when main UI appears
                         .onAppear {
+                            guard !ProcessInfo.processInfo.isJobTrackerUITesting else { return }
+
                             if !didWireWatchBridge {
                                 PhoneWatchSyncManager.shared.configure(jobsViewModel: jobsViewModel)
                                 didWireWatchBridge = true

--- a/Job Tracker/TestingSupport.swift
+++ b/Job Tracker/TestingSupport.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension ProcessInfo {
+    var isJobTrackerUITesting: Bool {
+        environment["JT_UI_TESTING"] == "1"
+    }
+
+    var shouldSeedJobTrackerUITestData: Bool {
+        environment["JT_UI_TESTING_SEED_DATA"] == "1"
+    }
+
+    var shouldUseAdminJobTrackerUITestUser: Bool {
+        environment["JT_UI_TESTING_ADMIN"] == "1"
+    }
+}

--- a/Job Tracker/intent/watchOS/PhoneWatchSyncManager.swift
+++ b/Job Tracker/intent/watchOS/PhoneWatchSyncManager.swift
@@ -93,6 +93,11 @@ final class PhoneWatchSyncManager: NSObject {
         let today = Date()
         let cal = Calendar.current
 
+        return makeSnapshotItems(jobs: source, currentUserID: me, today: today)
+    }
+
+    func makeSnapshotItems(jobs source: [Job], currentUserID me: String, today: Date = Date()) -> [[String: Any]] {
+        let cal = Calendar.current
         let todaysMinePending = source.filter { job in
             let mine = (job.createdBy == me) || (job.assignedTo == me)
             guard mine else { return false }

--- a/Job TrackerTests/Integration/AppIntentEntryPointTests.swift
+++ b/Job TrackerTests/Integration/AppIntentEntryPointTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Job_Tracker
+
+final class AppIntentEntryPointTests: XCTestCase {
+    func testAppIntentEntryPointTitlesStayDiscoverable() throws {
+        if #available(iOS 16.0, *) {
+            XCTAssertTrue(String(describing: CreateJobIntent.title).contains("Create Job"))
+            XCTAssertTrue(String(describing: GetTodayJobsIntent.title).contains("Today's Jobs"))
+            XCTAssertTrue(String(describing: UpdateJobStatusIntent.title).contains("Update Job Status"))
+            XCTAssertTrue(String(describing: DirectionsToNextJobIntent.title).contains("Directions"))
+        }
+    }
+
+    func testJobIntentLocationFallbackReasonsAreUserReadable() throws {
+        if #available(iOS 16.0, *) {
+            let reason = JobIntentLocationResult.permissionDenied.fallbackReason
+            XCTAssertTrue(reason.contains("permission"))
+            XCTAssertTrue(reason.contains("next job"))
+        }
+    }
+}

--- a/Job TrackerTests/Integration/ServiceIntegrationSmokeTests.swift
+++ b/Job TrackerTests/Integration/ServiceIntegrationSmokeTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+import PDFKit
+@testable import Job_Tracker
+
+final class ServiceIntegrationSmokeTests: XCTestCase {
+    func testJobPhotoSlotsMapToFirestoreFields() {
+        XCTAssertEqual(JobPhotoSlot.house.firestoreField, "housePhotoURL")
+        XCTAssertEqual(JobPhotoSlot.nid.firestoreField, "nidPhotoURL")
+        XCTAssertEqual(JobPhotoSlot.can.firestoreField, "canPhotoURL")
+    }
+
+    func testWeeklyTimesheetPDFGeneratorWritesReadablePDF() throws {
+        let job = makeJob(id: "timesheet-job", address: "100 Safety Net Lane")
+        let generator = WeeklyTimesheetPDFGenerator(
+            startOfWeek: job.date,
+            endOfWeek: job.date.addingTimeInterval(6 * 24 * 60 * 60),
+            jobs: [job],
+            currentUserID: "user-1",
+            partnerUserID: nil,
+            supervisor: "Safety Supervisor",
+            name1: "Crew Tester",
+            name2: "",
+            gibsonHours: "8",
+            cableSouthHours: "0",
+            totalHours: "8",
+            gibsonHours2: "",
+            cableSouthHours2: "",
+            totalHours2: "",
+            dailyTotalHours: [Calendar.current.startOfDay(for: job.date): "8"]
+        )
+
+        let url = try XCTUnwrap(generator.generatePDF())
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+
+        let document = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertGreaterThan(document.pageCount, 0)
+    }
+
+    func testYellowSheetPDFGeneratorWritesReadablePDF() throws {
+        let user = AppUser(id: "user-1", firstName: "Crew", lastName: "Tester", email: "crew@example.com", position: "Technician")
+        let job = makeJob(id: "yellow-job", address: "200 Yellow Sheet Road")
+        let generator = YellowSheetPDFGenerator(weekStart: job.date, jobs: [job], user: user)
+
+        let url = try XCTUnwrap(generator.generatePDF())
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+
+        let document = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertGreaterThan(document.pageCount, 0)
+    }
+
+    @MainActor
+    func testArrivalAlertManagerStartsInactiveWhenDailyToggleIsOff() {
+        let defaults = UserDefaults(suiteName: "ArrivalAlertManagerTests-\(UUID().uuidString)")!
+        defaults.set(false, forKey: "arrivalAlertsEnabledToday")
+        let manager = ArrivalAlertManager(locationService: LocationService(), userDefaults: defaults)
+
+        if manager.status.message.localizedCaseInsensitiveContains("support") {
+            XCTAssertEqual(manager.status.kind, .error)
+        } else {
+            XCTAssertEqual(manager.status.kind, .inactive)
+            XCTAssertTrue(manager.status.message.localizedCaseInsensitiveContains("off"))
+        }
+    }
+
+    func testPhoneWatchSyncPayloadIncludesOnlyTodaysPendingUserJobs() {
+        let today = Date(timeIntervalSince1970: 1_800_000_000)
+        let yesterday = today.addingTimeInterval(-24 * 60 * 60)
+        let manager = PhoneWatchSyncManager.shared
+        let payload = manager.makeSnapshotItems(
+            jobs: [
+                makeJob(id: "mine", address: "100 Safety Net Lane", date: today, status: "Pending", createdBy: "user-1"),
+                makeJob(id: "done", address: "200 Done Road", date: today, status: "Done", createdBy: "user-1"),
+                makeJob(id: "old", address: "300 Old Road", date: yesterday, status: "Pending", createdBy: "user-1"),
+                makeJob(id: "other", address: "400 Other Road", date: today, status: "Pending", createdBy: "user-2")
+            ],
+            currentUserID: "user-1",
+            today: today
+        )
+
+        XCTAssertEqual(payload.count, 1)
+        XCTAssertEqual(payload.first?["id"] as? String, "mine")
+        XCTAssertEqual(payload.first?["address"] as? String, "100 Safety Net Lane")
+    }
+
+    private func makeJob(
+        id: String,
+        address: String,
+        date: Date = Date(),
+        status: String = "Pending",
+        createdBy: String = "user-1"
+    ) -> Job {
+        Job(
+            id: id,
+            address: address,
+            date: date,
+            status: status,
+            assignedTo: createdBy,
+            createdBy: createdBy,
+            notes: "Integration smoke test job",
+            jobNumber: id.uppercased(),
+            participants: [createdBy],
+            latitude: 36.0,
+            longitude: -88.0
+        )
+    }
+}

--- a/Job TrackerUITests/AdminNavigationUITests.swift
+++ b/Job TrackerUITests/AdminNavigationUITests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+final class AdminNavigationUITests: XCTestCase {
+    func testAdminNavigationIsHiddenForCrewUsers() {
+        let app = JobTrackerUITestSupport.launch(admin: false)
+
+        app.tabBars.buttons["More"].tap()
+        waitForElement(app.staticTexts["More"])
+        XCTAssertFalse(app.staticTexts["Admin"].exists)
+    }
+
+    func testAdminNavigationIsVisibleForAdminUsers() {
+        let app = JobTrackerUITestSupport.launch(admin: true)
+
+        app.tabBars.buttons["More"].tap()
+        waitForElement(app.staticTexts["More"])
+        waitForElement(app.staticTexts["Admin"])
+        app.staticTexts["Admin"].tap()
+        waitForElement(app.navigationBars["Admin"])
+    }
+}

--- a/Job TrackerUITests/AuthenticationUITests.swift
+++ b/Job TrackerUITests/AuthenticationUITests.swift
@@ -1,0 +1,14 @@
+import XCTest
+
+final class AuthenticationUITests: XCTestCase {
+    func testSignedOutUserSeesAuthenticationActionsAndValidation() {
+        let app = JobTrackerUITestSupport.launch(seedData: false)
+
+        waitForElement(app.buttons["Sign In"])
+        XCTAssertTrue(app.buttons["Create one"].exists)
+        XCTAssertTrue(app.buttons["Forgot password?"].exists)
+
+        app.buttons["Sign In"].tap()
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "email")).firstMatch.waitForExistence(timeout: 3))
+    }
+}

--- a/Job TrackerUITests/DashboardJobFlowUITests.swift
+++ b/Job TrackerUITests/DashboardJobFlowUITests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+final class DashboardJobFlowUITests: XCTestCase {
+    func testDashboardShowsSeededJobsAndCreateJobEntryPoint() {
+        let app = JobTrackerUITestSupport.launch()
+
+        waitForElement(app.staticTexts["Jobs"])
+        waitForElement(app.buttons["Create Job"])
+        waitForElement(app.staticTexts["100 Safety Net Lane"])
+
+        app.buttons["Create Job"].tap()
+        waitForElement(app.navigationBars["Create Job"])
+        XCTAssertTrue(app.buttons["Save"].exists)
+        app.buttons["Close"].tap()
+    }
+
+    func testJobDetailSupportsEditSaveAndDeleteControls() {
+        let app = JobTrackerUITestSupport.launch()
+
+        waitForElement(app.staticTexts["100 Safety Net Lane"])
+        app.staticTexts["100 Safety Net Lane"].tap()
+        waitForElement(app.navigationBars["Job Detail"])
+        XCTAssertTrue(app.buttons["Save"].exists)
+        XCTAssertTrue(app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Delete")).firstMatch.exists)
+    }
+}

--- a/Job TrackerUITests/JobTrackerUITestSupport.swift
+++ b/Job TrackerUITests/JobTrackerUITestSupport.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+final class JobTrackerUITestSupport {
+    static func launch(seedData: Bool = true, admin: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["JT_UI_TESTING"] = "1"
+        if seedData { app.launchEnvironment["JT_UI_TESTING_SEED_DATA"] = "1" }
+        if admin { app.launchEnvironment["JT_UI_TESTING_ADMIN"] = "1" }
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launch()
+        return app
+    }
+}
+
+extension XCTestCase {
+    func waitForElement(_ element: XCUIElement, timeout: TimeInterval = 8, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(element.waitForExistence(timeout: timeout), "Expected element to exist: \(element)", file: file, line: line)
+    }
+}

--- a/Job TrackerUITests/SearchTimesheetYellowSheetSettingsUITests.swift
+++ b/Job TrackerUITests/SearchTimesheetYellowSheetSettingsUITests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+final class SearchTimesheetYellowSheetSettingsUITests: XCTestCase {
+    func testSearchFindsSeededJob() {
+        let app = JobTrackerUITestSupport.launch()
+
+        app.tabBars.buttons["Search"].tap()
+        waitForElement(app.staticTexts["Job Search"])
+        let searchField = app.textFields["Address, job #, status, or teammate"]
+        waitForElement(searchField)
+        searchField.tap()
+        searchField.typeText("Safety Net")
+        waitForElement(app.staticTexts["100 Safety Net Lane"])
+    }
+
+    func testTimesheetsAndYellowSheetsAreReachable() {
+        let app = JobTrackerUITestSupport.launch()
+
+        app.tabBars.buttons["Timesheets"].tap()
+        waitForElement(app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "Timesheet")).firstMatch)
+
+        app.tabBars.buttons["Yellow Sheet"].tap()
+        waitForElement(app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "Yellow")).firstMatch)
+    }
+
+    func testSettingsAreReachableFromMore() {
+        let app = JobTrackerUITestSupport.launch()
+
+        app.tabBars.buttons["More"].tap()
+        waitForElement(app.staticTexts["More"])
+        app.staticTexts["Settings"].tap()
+        waitForElement(app.staticTexts["Settings"])
+        XCTAssertTrue(app.switches.matching(NSPredicate(format: "label CONTAINS[c] %@", "Smart Routing")).firstMatch.exists)
+    }
+}

--- a/firebase-emulator-tests/firestore-storage.rules.test.js
+++ b/firebase-emulator-tests/firestore-storage.rules.test.js
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { initializeTestEnvironment, assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+
+const firestoreRulesPath = 'firestore.rules';
+const storageRulesPath = 'storage.rules';
+const hasRules = existsSync(firestoreRulesPath) && existsSync(storageRulesPath);
+
+describe.skipIf(!hasRules)('Firebase emulator access rules', () => {
+  let testEnv;
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: 'job-tracker-safety-net',
+      firestore: {
+        rules: readFileSync(firestoreRulesPath, 'utf8')
+      },
+      storage: {
+        rules: readFileSync(storageRulesPath, 'utf8')
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv?.cleanup();
+  });
+
+  it('allows authenticated users to read their user profile and denies anonymous reads', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().collection('users').doc('crew-1').set({
+        firstName: 'Crew',
+        lastName: 'Tester',
+        email: 'crew@example.com'
+      });
+    });
+
+    const authed = testEnv.authenticatedContext('crew-1');
+    const anon = testEnv.unauthenticatedContext();
+
+    await assertSucceeds(authed.firestore().collection('users').doc('crew-1').get());
+    await assertFails(anon.firestore().collection('users').doc('crew-1').get());
+  });
+
+  it('allows job participants to read jobs and denies non-participants', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().collection('jobs').doc('job-1').set({
+        address: '100 Safety Net Lane',
+        participants: ['crew-1'],
+        createdBy: 'crew-1'
+      });
+    });
+
+    const participant = testEnv.authenticatedContext('crew-1');
+    const outsider = testEnv.authenticatedContext('crew-2');
+
+    await assertSucceeds(participant.firestore().collection('jobs').doc('job-1').get());
+    await assertFails(outsider.firestore().collection('jobs').doc('job-1').get());
+  });
+
+  it('allows owners to upload job photos and denies anonymous storage writes', async () => {
+    const authed = testEnv.authenticatedContext('crew-1');
+    const anon = testEnv.unauthenticatedContext();
+    const path = 'jobPhotos/job-1/photo.jpg';
+
+    await assertSucceeds(authed.storage().ref(path).put(new Uint8Array([1, 2, 3]), { contentType: 'image/jpeg' }));
+    await assertFails(anon.storage().ref(path).put(new Uint8Array([1, 2, 3]), { contentType: 'image/jpeg' }));
+  });
+});
+
+if (!hasRules) {
+  describe('Firebase emulator access rules', () => {
+    it('skips until firestore.rules and storage.rules are added', () => {
+      expect(hasRules).toBe(false);
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "test:firebase-rules": "vitest run firebase-emulator-tests"
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^4.0.1",
+    "firebase": "^11.8.1",
+    "vitest": "^3.1.4"
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve end-to-end confidence by adding deterministic UI tests that exercise authentication, dashboard/job flows, job create/edit/delete, search, timesheets, yellow sheets, settings, and admin-gated navigation.
- Provide fast integration smoke checks for key on-device services and generators (photo upload queue, PDF generators, arrival alerts, watch sync, and App Intent entry points) so regressions are caught before release.
- Prepare a Firebase emulator test scaffold for Firestore/Storage rules to validate security rules once rule files are added, and keep Xcode Cloud / local guardrails aligned with the safety-net plan.

### Description
- Added a seeded UI-test harness and a new `Job TrackerUITests` bundle with tests for authentication, dashboard/job flows, create/detail/delete controls, search, timesheets, yellow sheets, settings navigation, and admin visibility; launch uses `JT_UI_TESTING` env with optional seeded data and admin flag.
- Implemented lightweight app-side UI-test isolation and deterministic seed data paths (`TestingSupport.swift`, seed helpers in `JobsViewModel`/`AuthViewModel`, and guards to avoid configuring Firebase/notifications during UI-tests). 
- Added integration smoke tests under `Job TrackerTests/Integration` covering `JobPhotoSlot` mappings, `WeeklyTimesheetPDFGenerator`, `YellowSheetPDFGenerator`, `ArrivalAlertManager` startup state, `PhoneWatchSyncManager` payload filtering, and AppIntent entry-point metadata/fallback messaging.
- Wired up Firebase emulator test scaffolding (`firebase-emulator-tests/firestore-storage.rules.test.js`) with an npm script and `package.json` entry that intentionally skips until `firestore.rules` and `storage.rules` are added, and updated the shared scheme, `Job Tracker Safety Net.xctestplan`, project scheme, and a small Xcode Cloud smoke-test checklist and docs to include the new UI-test bundle and workflows.

### Testing
- Ran the safety-net configuration guard `ci_scripts/ci_pre_xcodebuild.sh` which completed its checks (it skipped a local `xcodebuild` resolution step in this Linux environment) and reported the safety-net configuration valid.
- Validated the updated test plan with `python3 -m json.tool 'Job Tracker Safety Net.xctestplan'` which succeeded and now includes the UI-test target.
- Performed a syntax check of the Firebase emulator test script with `node --check firebase-emulator-tests/firestore-storage.rules.test.js` which succeeded, and ran `bash -n ci_scripts/ci_pre_xcodebuild.sh` for shell parsing which also succeeded.
- Attempted `npm install --package-lock-only` to lock dev deps for the emulator tests but the environment blocked access to the public registry (`403 Forbidden` for `@firebase/rules-unit-testing`), so dependency installation is pending network/registry access in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b190f7a1c832d8b16e63c19b8b55b)