### PR TITLE
Add photo upload failure handling, sync details sheet, and resilient upload queue

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
@@ -4,6 +4,8 @@ struct DashboardSyncBanner: View {
     let done: Int
     let total: Int
     let inFlight: Int
+    let failed: Int
+    let waitingForNetwork: Bool
     let phase: CGFloat
 
     private var progress: CGFloat {
@@ -12,6 +14,8 @@ struct DashboardSyncBanner: View {
     }
 
     private var title: String {
+        if failed > 0 { return "Upload needs attention" }
+        if waitingForNetwork { return "Waiting for connection" }
         if total == 0 { return "All changes are up to date" }
         if done >= total { return "All changes uploaded" }
         if inFlight > 0 { return "Uploading… (\(inFlight) in progress)" }
@@ -41,7 +45,7 @@ struct DashboardSyncBanner: View {
             }
 
             HStack(spacing: JTSpacing.sm) {
-                Image(systemName: "arrow.up.arrow.down.circle.fill")
+                Image(systemName: failed > 0 ? "exclamationmark.triangle.fill" : "arrow.up.arrow.down.circle.fill")
                     .imageScale(.medium)
                     .foregroundStyle(Color.white.opacity(0.95))
                 Text(title)
@@ -62,7 +66,7 @@ struct DashboardSyncBanner: View {
         .frame(height: 44)
         .padding(.horizontal, JTSpacing.lg)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(title)
+        .accessibilityLabel("\(title). Tap for details.")
     }
 }
 
@@ -101,13 +105,13 @@ struct WaterWave: Shape {
 }
 
 #Preview("Sync Banner – Uploading") {
-    DashboardSyncBanner(done: 2, total: 5, inFlight: 1, phase: 0.3)
+    DashboardSyncBanner(done: 2, total: 5, inFlight: 1, failed: 0, waitingForNetwork: false, phase: 0.3)
         .padding(.vertical)
         .background(JTGradients.background.ignoresSafeArea())
 }
 
 #Preview("Sync Banner – Complete") {
-    DashboardSyncBanner(done: 5, total: 5, inFlight: 0, phase: 0.9)
+    DashboardSyncBanner(done: 5, total: 5, inFlight: 0, failed: 0, waitingForNetwork: false, phase: 0.9)
         .padding(.vertical)
         .background(JTGradients.background.ignoresSafeArea())
         .frame(maxWidth: 600)

--- a/Job Tracker/Features/Dashboard/Components/DashboardSyncDetailsSheet.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSyncDetailsSheet.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct DashboardSyncDetailsSheet: View {
+    @ObservedObject var jobsViewModel: JobsViewModel
+    @ObservedObject private var photoUploadQueue = JobPhotoUploadQueue.shared
+
+    private var pendingJobCount: Int { jobsViewModel.pendingWriteIDs.count }
+    private var pendingJobLabel: String {
+        let suffix = pendingJobCount == 1 ? "" : "s"
+        return "\(pendingJobCount) job change\(suffix) waiting to sync"
+    }
+    private var activePhotoStatuses: [JobPhotoUploadStatus] { photoUploadQueue.uploadStatuses }
+    private var failedPhotoStatuses: [JobPhotoUploadStatus] {
+        activePhotoStatuses.filter { $0.state == .failed }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if pendingJobCount > 0 {
+                    Section("Job changes") {
+                        Label(pendingJobLabel, systemImage: "doc.badge.clock")
+                            .foregroundStyle(.primary)
+                    }
+                }
+
+                Section("Photo uploads") {
+                    if activePhotoStatuses.isEmpty {
+                        Label("No photo uploads waiting", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(activePhotoStatuses) { status in
+                            DashboardPhotoUploadStatusRow(status: status)
+                        }
+                    }
+                }
+
+                if !failedPhotoStatuses.isEmpty {
+                    Section("Recovery") {
+                        Button {
+                            photoUploadQueue.retryFailedUploads()
+                        } label: {
+                            Label("Retry all failed uploads", systemImage: "arrow.clockwise")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Sync Details")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private struct DashboardPhotoUploadStatusRow: View {
+    let status: JobPhotoUploadStatus
+    @ObservedObject private var photoUploadQueue = JobPhotoUploadQueue.shared
+
+    private var iconName: String {
+        switch status.state {
+        case .pending:
+            return "clock"
+        case .uploading:
+            return "arrow.up.circle.fill"
+        case .waitingForNetwork:
+            return "wifi.slash"
+        case .retrying:
+            return "arrow.clockwise.circle"
+        case .failed:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var iconColor: Color {
+        switch status.state {
+        case .failed:
+            return .orange
+        case .uploading:
+            return .accentColor
+        case .waitingForNetwork:
+            return .secondary
+        default:
+            return .secondary
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JTSpacing.xs) {
+            HStack(alignment: .top, spacing: JTSpacing.sm) {
+                Image(systemName: iconName)
+                    .foregroundStyle(iconColor)
+                    .frame(width: 22)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(status.title)
+                        .font(.subheadline.weight(.semibold))
+                    Text(status.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if status.attempts > 0 {
+                        Text("Attempts: \(status.attempts)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+
+            if status.state == .failed {
+                HStack {
+                    Button("Retry") { photoUploadQueue.retryUpload(id: status.id) }
+                        .buttonStyle(.borderedProminent)
+                    Button("Discard") { photoUploadQueue.discardUpload(id: status.id) }
+                        .buttonStyle(.bordered)
+                }
+                .font(.caption.weight(.semibold))
+                .padding(.leading, 30)
+            }
+        }
+        .padding(.vertical, JTSpacing.xs)
+    }
+}

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -134,8 +134,11 @@ struct DashboardView: View {
                             done: viewModel.syncDone,
                             total: viewModel.syncTotal,
                             inFlight: viewModel.syncInFlight,
+                            failed: viewModel.syncFailed,
+                            waitingForNetwork: viewModel.syncWaitingForNetwork,
                             phase: viewModel.wavePhase
                         )
+                        .onTapGesture { viewModel.presentSyncDetails() }
                         .transition(.move(edge: .top).combined(with: .opacity))
                     }
 
@@ -185,6 +188,8 @@ struct DashboardView: View {
                     DashboardDailyShareSheet(items: viewModel.shareItems, subject: viewModel.shareSubject)
                 case .createJob:
                     CreateJobView()
+                case .syncDetails:
+                    DashboardSyncDetailsSheet(jobsViewModel: jobsViewModel)
                 }
             }
             .sheet(isPresented: showSystemShareBinding) {
@@ -231,7 +236,15 @@ struct DashboardView: View {
                 let total = (info["total"] as? Int) ?? 0
                 let done = (info["uploaded"] as? Int) ?? (info["done"] as? Int) ?? 0
                 let inFlight = (info["inFlight"] as? Int) ?? 0
-                viewModel.handlePhotoUploadSyncStateChange(total: total, done: done, inFlight: inFlight)
+                let failed = (info["failed"] as? Int) ?? 0
+                let waitingForNetwork = (info["waitingForNetwork"] as? Bool) ?? false
+                viewModel.handlePhotoUploadSyncStateChange(
+                    total: total,
+                    done: done,
+                    inFlight: inFlight,
+                    failed: failed,
+                    waitingForNetwork: waitingForNetwork
+                )
             }
             .onChange(of: viewModel.showSyncBanner) { visible in
                 if visible {

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -24,6 +24,7 @@ final class DashboardViewModel: ObservableObject {
         case datePicker
         case share
         case createJob
+        case syncDetails
 
         var id: Int { hashValue }
     }
@@ -50,6 +51,8 @@ final class DashboardViewModel: ObservableObject {
     @Published var syncTotal: Int = 0
     @Published var syncDone: Int = 0
     @Published var syncInFlight: Int = 0
+    @Published var syncFailed: Int = 0
+    @Published var syncWaitingForNetwork = false
     @Published var wavePhase: CGFloat = 0
 
     private var jobSyncTotal: Int = 0
@@ -58,6 +61,8 @@ final class DashboardViewModel: ObservableObject {
     private var photoSyncTotal: Int = 0
     private var photoSyncDone: Int = 0
     private var photoSyncInFlight: Int = 0
+    private var photoSyncFailed: Int = 0
+    private var photoSyncWaitingForNetwork = false
     @Published var nearestJobID: String?
     @Published var selectedJob: Job?
 
@@ -441,10 +446,12 @@ final class DashboardViewModel: ObservableObject {
         updateCombinedSyncState()
     }
 
-    func handlePhotoUploadSyncStateChange(total: Int, done: Int, inFlight: Int) {
+    func handlePhotoUploadSyncStateChange(total: Int, done: Int, inFlight: Int, failed: Int = 0, waitingForNetwork: Bool = false) {
         photoSyncTotal = max(total, 0)
         photoSyncDone = max(min(done, total), 0)
         photoSyncInFlight = max(inFlight, 0)
+        photoSyncFailed = max(failed, 0)
+        photoSyncWaitingForNetwork = waitingForNetwork
         updateCombinedSyncState()
     }
 
@@ -452,19 +459,45 @@ final class DashboardViewModel: ObservableObject {
         syncTotal = jobSyncTotal + photoSyncTotal
         syncDone = jobSyncDone + photoSyncDone
         syncInFlight = jobSyncInFlight + photoSyncInFlight
+        syncFailed = photoSyncFailed
+        syncWaitingForNetwork = photoSyncWaitingForNetwork
 
         withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
-            showSyncBanner = (syncTotal > 0) && (syncDone < syncTotal)
+            showSyncBanner = syncTotal > 0 && (syncDone < syncTotal || syncFailed > 0)
         }
-        if syncTotal > 0 && syncDone >= syncTotal {
+        if syncTotal > 0 && syncDone >= syncTotal && syncFailed == 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
                 guard let self else { return }
                 guard self.syncTotal > 0, self.syncDone >= self.syncTotal else { return }
                 withAnimation(.easeInOut(duration: 0.25)) {
                     self.showSyncBanner = false
                 }
+                self.resetCompletedSyncTotalsIfNeeded()
             }
         }
+    }
+
+    private func resetCompletedSyncTotalsIfNeeded() {
+        if jobSyncTotal > 0 && jobSyncDone >= jobSyncTotal {
+            jobSyncTotal = 0
+            jobSyncDone = 0
+            jobSyncInFlight = 0
+        }
+        if photoSyncTotal > 0 && photoSyncDone >= photoSyncTotal && photoSyncFailed == 0 {
+            photoSyncTotal = 0
+            photoSyncDone = 0
+            photoSyncInFlight = 0
+            photoSyncWaitingForNetwork = false
+        }
+        syncTotal = jobSyncTotal + photoSyncTotal
+        syncDone = jobSyncDone + photoSyncDone
+        syncInFlight = jobSyncInFlight + photoSyncInFlight
+        syncFailed = photoSyncFailed
+        syncWaitingForNetwork = photoSyncWaitingForNetwork
+    }
+
+    func presentSyncDetails() {
+        activeSheet = .syncDetails
     }
 
     func startWaveAnimation() {

--- a/Job Tracker/Features/Jobs/JobsViewModel.swift
+++ b/Job Tracker/Features/Jobs/JobsViewModel.swift
@@ -341,6 +341,16 @@ class JobsViewModel: ObservableObject {
         let docRef = db.collection("jobs").document()
         var newJob = job
         newJob.id = docRef.documentID
+        var initialParticipants = Set(newJob.participants ?? [])
+        if let creator = newJob.createdBy, !creator.isEmpty {
+            initialParticipants.insert(creator)
+        }
+        if let assignee = newJob.assignedTo, !assignee.isEmpty {
+            initialParticipants.insert(assignee)
+        }
+        if !initialParticipants.isEmpty {
+            newJob.participants = Array(initialParticipants).sorted()
+        }
 
         // Optimistically mark as pending so UI can show “Syncing…”
         DispatchQueue.main.async {
@@ -355,7 +365,12 @@ class JobsViewModel: ObservableObject {
                 DispatchQueue.main.async { completion(true) }
             case .failure(let error):
                 print("Error creating job via service: \(error)")
-                DispatchQueue.main.async { completion(false) }
+                DispatchQueue.main.async {
+                    self.pendingWriteIDs.remove(docRef.documentID)
+                    self.hasPendingWrites = !self.pendingWriteIDs.isEmpty
+                    self.postSyncStateChange()
+                    completion(false)
+                }
             }
             // Listener established by fetch methods will reconcile & clear pending when server ACKs
         }

--- a/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
+++ b/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Combine
 import FirebaseFirestore
+import FirebaseStorage
+import Network
 import UIKit
 
 /// Dedicated photo slots on a job document.
@@ -29,6 +31,84 @@ private struct PendingJobPhotoUpload: Identifiable, Codable, Equatable {
     let createdAt: Date
     var attempts: Int
     var lastErrorDescription: String?
+    var uploadedURL: String?
+    var isFailed: Bool
+
+    init(
+        id: String,
+        jobID: String,
+        slot: JobPhotoSlot,
+        fileName: String,
+        createdAt: Date,
+        attempts: Int,
+        lastErrorDescription: String?,
+        uploadedURL: String?,
+        isFailed: Bool
+    ) {
+        self.id = id
+        self.jobID = jobID
+        self.slot = slot
+        self.fileName = fileName
+        self.createdAt = createdAt
+        self.attempts = attempts
+        self.lastErrorDescription = lastErrorDescription
+        self.uploadedURL = uploadedURL
+        self.isFailed = isFailed
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        jobID = try container.decode(String.self, forKey: .jobID)
+        slot = try container.decode(JobPhotoSlot.self, forKey: .slot)
+        fileName = try container.decode(String.self, forKey: .fileName)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        attempts = try container.decodeIfPresent(Int.self, forKey: .attempts) ?? 0
+        lastErrorDescription = try container.decodeIfPresent(String.self, forKey: .lastErrorDescription)
+        uploadedURL = try container.decodeIfPresent(String.self, forKey: .uploadedURL)
+        isFailed = try container.decodeIfPresent(Bool.self, forKey: .isFailed) ?? false
+    }
+}
+
+struct JobPhotoUploadStatus: Identifiable, Equatable {
+    enum State: Equatable {
+        case pending
+        case uploading
+        case waitingForNetwork
+        case retrying
+        case failed
+    }
+
+    let id: String
+    let jobID: String
+    let slot: JobPhotoSlot
+    let createdAt: Date
+    let attempts: Int
+    let lastErrorDescription: String?
+    let state: State
+
+    var title: String {
+        switch slot {
+        case .house: return "House photo"
+        case .nid: return "NID photo"
+        case .can: return "Can photo"
+        }
+    }
+
+    var subtitle: String {
+        switch state {
+        case .pending:
+            return "Waiting to upload"
+        case .uploading:
+            return "Uploading now"
+        case .waitingForNetwork:
+            return "Waiting for connection"
+        case .retrying:
+            return "Will retry automatically"
+        case .failed:
+            return lastErrorDescription ?? "Upload failed"
+        }
+    }
 }
 
 /// Persists selected job photos locally, uploads them outside of the detail save flow,
@@ -45,6 +125,9 @@ final class JobPhotoUploadQueue: ObservableObject {
     @Published private(set) var pendingCount: Int = 0
     @Published private(set) var inFlightCount: Int = 0
     @Published private(set) var completedCount: Int = 0
+    @Published private(set) var failedCount: Int = 0
+    @Published private(set) var waitingForNetwork: Bool = false
+    @Published private(set) var uploadStatuses: [JobPhotoUploadStatus] = []
 
     private let fileManager: FileManager
     private let queueDirectory: URL
@@ -55,6 +138,10 @@ final class JobPhotoUploadQueue: ObservableObject {
     private var activeUploadID: String?
     private var retryTask: Task<Void, Never>?
     private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
+    private let pathMonitor = NWPathMonitor()
+    private let pathMonitorQueue = DispatchQueue(label: "com.jobtracker.photoUploadQueue.network")
+    private var isNetworkAvailable = true
+    private let maximumAttempts = 5
     private var cycleTotalCount: Int = 0
     private var cycleDoneCount: Int = 0
 
@@ -68,13 +155,15 @@ final class JobPhotoUploadQueue: ObservableObject {
         try? fileManager.createDirectory(at: queueDirectory, withIntermediateDirectories: true)
         loadManifest()
         cycleTotalCount = items.count
-        pendingCount = items.count
+        refreshPublishedCounts()
+        startNetworkMonitoring()
         publishSyncState()
         processQueue()
     }
 
     deinit {
         retryTask?.cancel()
+        pathMonitor.cancel()
 
         let taskID = backgroundTaskID
         if taskID != .invalid {
@@ -104,7 +193,9 @@ final class JobPhotoUploadQueue: ObservableObject {
                         fileName: fileName,
                         createdAt: Date(),
                         attempts: 0,
-                        lastErrorDescription: nil
+                        lastErrorDescription: nil,
+                        uploadedURL: nil,
+                        isFailed: false
                     )
                 )
             } catch {
@@ -118,7 +209,7 @@ final class JobPhotoUploadQueue: ObservableObject {
         items.append(contentsOf: addedItems)
         ensureBackgroundTaskIfNeeded()
         cycleTotalCount += addedItems.count
-        pendingCount = items.count
+        refreshPublishedCounts()
         saveManifest()
         publishSyncState()
         scheduleRetry(after: 1.0)
@@ -127,7 +218,47 @@ final class JobPhotoUploadQueue: ObservableObject {
     func retryPendingUploads() {
         retryTask?.cancel()
         retryTask = nil
+        refreshPublishedCounts()
+        publishSyncState()
         processQueue()
+    }
+
+    func retryFailedUploads() {
+        for index in items.indices where items[index].isFailed {
+            items[index].attempts = 0
+            items[index].isFailed = false
+            items[index].lastErrorDescription = nil
+        }
+        refreshPublishedCounts()
+        saveManifest()
+        publishSyncState()
+        processQueue()
+    }
+
+    func retryUpload(id: String) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index].attempts = 0
+        items[index].isFailed = false
+        items[index].lastErrorDescription = nil
+        refreshPublishedCounts()
+        saveManifest()
+        publishSyncState()
+        processQueue()
+    }
+
+    func discardUpload(id: String) {
+        guard activeUploadID != id, let index = items.firstIndex(where: { $0.id == id }) else { return }
+        let removed = items.remove(at: index)
+        try? fileManager.removeItem(at: queueDirectory.appendingPathComponent(removed.fileName))
+        if items.isEmpty {
+            cycleTotalCount = 0
+            cycleDoneCount = 0
+            completedCount = 0
+        }
+        refreshPublishedCounts()
+        saveManifest()
+        publishSyncState()
+        endBackgroundTaskIfIdle()
     }
 
     func publishCurrentSyncState() {
@@ -136,7 +267,14 @@ final class JobPhotoUploadQueue: ObservableObject {
 
     private func processQueue() {
         guard activeUploadID == nil else { return }
-        guard let next = items.first else {
+        guard isNetworkAvailable else {
+            waitingForNetwork = items.contains { !$0.isFailed }
+            inFlightCount = 0
+            refreshPublishedCounts()
+            publishSyncState()
+            return
+        }
+        guard let next = items.first(where: { !$0.isFailed }) else {
             resetCycleIfFinished()
             return
         }
@@ -145,6 +283,11 @@ final class JobPhotoUploadQueue: ObservableObject {
         activeUploadID = next.id
         inFlightCount = 1
         publishSyncState()
+
+        if let uploadedURL = next.uploadedURL {
+            patchJob(next, photoURL: uploadedURL)
+            return
+        }
 
         let fileURL = queueDirectory.appendingPathComponent(next.fileName)
         guard let data = try? Data(contentsOf: fileURL) else {
@@ -157,7 +300,13 @@ final class JobPhotoUploadQueue: ObservableObject {
                 guard let self else { return }
                 switch result {
                 case .success(let urlString):
-                    self.patchJob(next, photoURL: urlString)
+                    if let index = self.items.firstIndex(where: { $0.id == next.id }) {
+                        self.items[index].uploadedURL = urlString
+                        self.saveManifest()
+                    }
+                    var uploadedItem = next
+                    uploadedItem.uploadedURL = urlString
+                    self.patchJob(uploadedItem, photoURL: urlString)
                 case .failure(let error):
                     self.handleFailure(for: next, error: error)
                 }
@@ -181,29 +330,57 @@ final class JobPhotoUploadQueue: ObservableObject {
     private func handleFailure(for item: PendingJobPhotoUpload, error: Error) {
         guard activeUploadID == item.id else { return }
 
-        if isFirestoreNotFound(error) {
-            finish(item, removingLocalFile: true)
-            return
-        }
-
         activeUploadID = nil
         inFlightCount = 0
+
+        var attempts = item.attempts + 1
+        var shouldFailPermanently = isNonRetryable(error)
+        if isFirestoreNotFound(error) {
+            // A photo can finish uploading before an offline-created job document is visible on the
+            // server. Keep the local file/manifest and retry the Firestore patch instead of deleting it.
+            shouldFailPermanently = attempts >= maximumAttempts
+        }
 
         if let index = items.firstIndex(where: { $0.id == item.id }) {
             items[index].attempts += 1
             items[index].lastErrorDescription = error.localizedDescription
+            items[index].isFailed = shouldFailPermanently || items[index].attempts >= maximumAttempts
+            attempts = items[index].attempts
         }
 
-        pendingCount = items.count
+        refreshPublishedCounts()
         saveManifest()
         publishSyncState()
-        ensureBackgroundTaskIfNeeded()
-        scheduleRetry(after: retryDelay(forAttempts: (items.first { $0.id == item.id }?.attempts ?? item.attempts + 1)))
+
+        if items.contains(where: { !$0.isFailed }) {
+            ensureBackgroundTaskIfNeeded()
+            scheduleRetry(after: retryDelay(forAttempts: attempts))
+        } else {
+            endBackgroundTaskIfIdle()
+        }
     }
 
     private func isFirestoreNotFound(_ error: Error) -> Bool {
         let nsError = error as NSError
         return nsError.domain == FirestoreErrorDomain && nsError.code == FirestoreErrorCode.notFound.rawValue
+    }
+
+    private func isNonRetryable(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == FirestoreErrorDomain {
+            return nsError.code == FirestoreErrorCode.permissionDenied.rawValue
+                || nsError.code == FirestoreErrorCode.unauthenticated.rawValue
+        }
+        if nsError.domain == StorageErrorDomain,
+           let code = StorageErrorCode(rawValue: nsError.code) {
+            switch code {
+            case .unauthenticated, .unauthorized, .invalidArgument, .objectNotFound, .quotaExceeded:
+                return true
+            default:
+                return false
+            }
+        }
+        return false
     }
 
     private func finish(_ item: PendingJobPhotoUpload, removingLocalFile: Bool) {
@@ -226,7 +403,7 @@ final class JobPhotoUploadQueue: ObservableObject {
 
         cycleDoneCount += 1
         completedCount = cycleDoneCount
-        pendingCount = items.count
+        refreshPublishedCounts()
         saveManifest()
         publishSyncState()
         processQueue()
@@ -250,19 +427,19 @@ final class JobPhotoUploadQueue: ObservableObject {
     }
 
     private func resetCycleIfFinished() {
-        guard activeUploadID == nil, items.isEmpty else { return }
+        guard activeUploadID == nil, !items.contains(where: { !$0.isFailed }) else { return }
         if cycleTotalCount > 0, cycleDoneCount >= cycleTotalCount {
             publishSyncState()
         }
         cycleTotalCount = 0
         cycleDoneCount = 0
         completedCount = 0
-        pendingCount = 0
+        refreshPublishedCounts()
         endBackgroundTaskIfIdle()
     }
 
     private func ensureBackgroundTaskIfNeeded() {
-        guard backgroundTaskID == .invalid, !items.isEmpty else { return }
+        guard backgroundTaskID == .invalid, items.contains(where: { !$0.isFailed }) else { return }
 
         backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "JobPhotoUploadQueue") { [weak self] in
             Task { @MainActor [weak self] in
@@ -276,14 +453,14 @@ final class JobPhotoUploadQueue: ObservableObject {
         retryTask = nil
         activeUploadID = nil
         inFlightCount = 0
-        pendingCount = items.count
+        refreshPublishedCounts()
         saveManifest()
         publishSyncState()
         endBackgroundTaskIfNeeded()
     }
 
     private func endBackgroundTaskIfIdle() {
-        guard activeUploadID == nil, items.isEmpty else { return }
+        guard activeUploadID == nil, !items.contains(where: { !$0.isFailed }) else { return }
         endBackgroundTaskIfNeeded()
     }
 
@@ -318,8 +495,56 @@ final class JobPhotoUploadQueue: ObservableObject {
         }
     }
 
+    private func startNetworkMonitoring() {
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                guard let self else { return }
+                let wasAvailable = self.isNetworkAvailable
+                self.isNetworkAvailable = path.status == .satisfied
+                self.waitingForNetwork = !self.isNetworkAvailable && self.items.contains { !$0.isFailed }
+                self.refreshPublishedCounts()
+                self.publishSyncState()
+                if !wasAvailable && self.isNetworkAvailable {
+                    self.retryPendingUploads()
+                }
+            }
+        }
+        pathMonitor.start(queue: pathMonitorQueue)
+    }
+
+    private func refreshPublishedCounts() {
+        failedCount = items.filter(\.isFailed).count
+        pendingCount = items.filter { !$0.isFailed }.count
+        waitingForNetwork = !isNetworkAvailable && pendingCount > 0
+        uploadStatuses = items.map { item in
+            let state: JobPhotoUploadStatus.State
+            if item.isFailed {
+                state = .failed
+            } else if activeUploadID == item.id {
+                state = .uploading
+            } else if waitingForNetwork {
+                state = .waitingForNetwork
+            } else if item.attempts > 0 {
+                state = .retrying
+            } else {
+                state = .pending
+            }
+            return JobPhotoUploadStatus(
+                id: item.id,
+                jobID: item.jobID,
+                slot: item.slot,
+                createdAt: item.createdAt,
+                attempts: item.attempts,
+                lastErrorDescription: item.lastErrorDescription,
+                state: state
+            )
+        }
+    }
+
     private func publishSyncState() {
-        let total = max(cycleTotalCount, items.count + cycleDoneCount)
+        refreshPublishedCounts()
+        let activeCount = items.filter { !$0.isFailed }.count
+        let total = max(cycleTotalCount, activeCount + failedCount + cycleDoneCount)
         let done = min(cycleDoneCount, total)
         NotificationCenter.default.post(
             name: .jobPhotoUploadsSyncStateDidChange,
@@ -329,7 +554,9 @@ final class JobPhotoUploadQueue: ObservableObject {
                 "done": done,
                 "uploaded": done,
                 "inFlight": inFlightCount,
-                "pending": items.count
+                "pending": pendingCount,
+                "failed": failedCount,
+                "waitingForNetwork": waitingForNetwork
             ]
         )
     }

--- a/Job TrackerTests/DashboardSyncStateTests.swift
+++ b/Job TrackerTests/DashboardSyncStateTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Job_Tracker
+
+@MainActor
+final class DashboardSyncStateTests: XCTestCase {
+    func testCompletedSyncCycleResetsBeforeNextCycle() async throws {
+        let viewModel = DashboardViewModel()
+
+        viewModel.handleSyncStateChange(total: 1, done: 1, inFlight: 0)
+        XCTAssertEqual(viewModel.syncTotal, 1)
+        XCTAssertEqual(viewModel.syncDone, 1)
+
+        try await Task.sleep(nanoseconds: 1_200_000_000)
+
+        XCTAssertFalse(viewModel.showSyncBanner)
+        XCTAssertEqual(viewModel.syncTotal, 0)
+        XCTAssertEqual(viewModel.syncDone, 0)
+
+        viewModel.handleSyncStateChange(total: 1, done: 0, inFlight: 1)
+
+        XCTAssertEqual(viewModel.syncTotal, 1)
+        XCTAssertEqual(viewModel.syncDone, 0)
+        XCTAssertEqual(viewModel.syncInFlight, 1)
+        XCTAssertTrue(viewModel.showSyncBanner)
+    }
+
+    func testFailedPhotoUploadKeepsDetailsVisibleWithoutActiveUpload() {
+        let viewModel = DashboardViewModel()
+
+        viewModel.handlePhotoUploadSyncStateChange(total: 1, done: 0, inFlight: 0, failed: 1)
+
+        XCTAssertEqual(viewModel.syncTotal, 1)
+        XCTAssertEqual(viewModel.syncDone, 0)
+        XCTAssertEqual(viewModel.syncFailed, 1)
+        XCTAssertTrue(viewModel.showSyncBanner)
+    }
+}


### PR DESCRIPTION
### Motivation
- Surface photo upload failures and network-waiting state in the dashboard sync UI so users can take recovery actions.
- Provide a details sheet to inspect and retry/discard individual photo uploads.
- Make the photo upload queue more robust across network changes, background execution, and non-retryable errors.

### Description
- Updated `DashboardSyncBanner` to accept `failed` and `waitingForNetwork` flags, change the icon/title when failures or network waits exist, and improve the accessibility label; banner now opens details on tap.
- Added `DashboardSyncDetailsSheet` to show pending job changes and photo upload statuses with per-item retry and discard actions and a bulk retry button for failed uploads.
- Extended `DashboardView` to pass photo upload state into the banner, present the new details sheet, and include additional info from the `jobPhotoUploadsSyncStateDidChange` notification.
- Enhanced `DashboardViewModel` with `syncFailed` and `syncWaitingForNetwork` state, updated combined sync state logic to keep the banner visible for failures, added `presentSyncDetails()` and logic to reset completed totals.
- Improved `JobsViewModel.createJob` to include creator/assignee in `participants` and to clear pending write bookkeeping on create failure.
- Reworked `JobPhotoUploadQueue` with persistent manifest fields, `JobPhotoUploadStatus` states, network monitoring using `NWPathMonitor`, retry/discard APIs, non-retryable error handling for Firestore/Storage errors, refined background task handling, and richer notifications (including `failed` and `waitingForNetwork`).

### Testing
- Added `DashboardSyncStateTests` unit tests which exercise banner visibility and failed-photo behavior and these tests passed.
- Project builds and unit test suite run successfully in CI (including the new sync state tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f078c6d94832da772659f789e1239)