### PR TITLE
Skip Xcode Cloud safety-net for Archive/Build actions

### DIFF
--- a/Documentation/TestingSafetyNet.md
+++ b/Documentation/TestingSafetyNet.md
@@ -37,5 +37,5 @@ When Firestore or Storage rules files are added, keep `firebase-emulator-tests/f
 - Keep the scheme's Test action pointed at `Job Tracker Safety Net.xctestplan`.
 - Keep code coverage enabled in both the shared scheme and the test plan.
 - Add every new XCTest or UI-test target to `Job Tracker Safety Net.xctestplan` unless it is intentionally isolated in a separate documented workflow.
-- Run `ci_scripts/ci_pre_xcodebuild.sh` after changing the Xcode project, shared scheme, or test plan. The script fails when the scheme no longer references the plan, coverage is disabled, or an XCTest target is missing from the plan.
+- Run `ci_scripts/ci_pre_xcodebuild.sh` after changing the Xcode project, shared scheme, or test plan. The script fails when the scheme no longer references the plan, coverage is disabled, or an XCTest target is missing from the plan. In Xcode Cloud, the script exits before Archive/Build actions and runs only for Test actions.
 - Follow `.xcode-cloud/smoke-test-checklist.md` for the lightweight Xcode Cloud/manual build smoke checks that cover the iOS app, watch app, and iMessage extension surface.

--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -7,7 +7,7 @@ The repository now treats Xcode Cloud as the safety net for the full app project
 - The shared `Job Tracker` scheme runs `Job Tracker Safety Net.xctestplan`.
 - The safety-net test plan includes the `Job TrackerTests` XCTest bundle, the seeded `Job TrackerUITests` UI-test bundle, and collects code coverage.
 - The checked-in project keeps the main app target wired to the embedded watch app for normal local builds and archive workflows. The watch app must support both `watchos` and `watchsimulator`, and framework references must resolve from `SDKROOT` so supported simulator builds remain portable across current Xcode Cloud images.
-- `ci_scripts/ci_pre_xcodebuild.sh` runs before Xcode Cloud's build/test action and fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date. During Xcode Cloud Test actions (`build-for-testing`, `test`, or `test-without-building`), the script removes the host app's watch embed/dependency edges in the temporary checkout so unit-test builds do not fail destination resolution when the workflow supplies generic or unpaired iOS simulators.
+- `ci_scripts/ci_pre_xcodebuild.sh` is test-only in Xcode Cloud: it exits immediately for Archive/Build actions, then runs only for Test actions (`build-for-testing`, `test`, or `test-without-building`). For Test actions, it fails fast if the shared scheme, test plan, XCTest target coverage, or watch simulator compatibility drifts out of date, and removes the host app's watch embed/dependency edges in the temporary checkout so unit-test builds do not fail destination resolution when the workflow supplies generic or unpaired iOS simulators.
 
 ## Run tests locally
 
@@ -49,7 +49,7 @@ Create or update the workflow in Xcode with these settings:
 6. Enable code coverage for the workflow.
 7. Run the workflow for pull requests and before release/archive workflows.
 
-A separate Build action is not required before the Test action because Xcode builds the app and test host as part of the test action. The companion watch app remains part of normal local/archive project wiring, but the pre-xcodebuild guard temporarily omits it for Xcode Cloud Test actions because the safety-net unit tests do not exercise the packaged watch app. Archive and Build actions keep the embedded watch app intact.
+A separate Build action is not required before the Test action because Xcode builds the app and test host as part of the test action. The companion watch app remains part of normal local/archive project wiring, but the pre-xcodebuild guard temporarily omits it for Xcode Cloud Test actions because the safety-net unit tests do not exercise the packaged watch app. Archive and Build actions skip the custom safety-net script and keep the embedded watch app intact.
 
 ## Future-proofing rules
 

--- a/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
+++ b/Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme
@@ -30,7 +30,7 @@
       codeCoverageEnabled = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Job Tracker Safety Net.xctestplan"
+            reference = "container:../Job Tracker Safety Net.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -10,6 +10,21 @@ cd "$REPOSITORY_ROOT"
 PROJECT_PATH="Job Tracker.xcodeproj"
 SCHEME_PATH="$PROJECT_PATH/xcshareddata/xcschemes/Job Tracker.xcscheme"
 TEST_PLAN_PATH="Job Tracker Safety Net.xctestplan"
+
+# Xcode Cloud runs ci_pre_xcodebuild.sh before every workflow action, including
+# Archive. Keep these safety-net checks out of Archive/Build actions so release
+# packaging is not blocked by a test-only guardrail.
+if [ "${CI_XCODE_CLOUD:-}" = "TRUE" ]; then
+  case "${CI_XCODEBUILD_ACTION:-}" in
+    build-for-testing|test|test-without-building)
+      ;;
+    *)
+      printf '[xcode-cloud-safety-net] Skipping test-only safety-net script for Xcode Cloud action %s.\n' "${CI_XCODEBUILD_ACTION:-unknown}"
+      exit 0
+      ;;
+  esac
+fi
+
 log() {
   printf '[xcode-cloud-safety-net] %s\n' "$1"
 }


### PR DESCRIPTION
### Motivation
- The pre-build safety-net `ci_pre_xcodebuild.sh` was running for every Xcode Cloud action and could block Archive/Build workflows by enforcing test-only guardrails.
- The TestPlan reference in the shared scheme did not resolve from inside the `.xcodeproj` bundle which caused the guard to fail in CI checkouts.
- Documentation did not state that the script is intended only for Test actions in Xcode Cloud, which led to confusion when archives failed.

### Description
- Update `ci_scripts/ci_pre_xcodebuild.sh` to exit early when `CI_XCODE_CLOUD=TRUE` and `CI_XCODEBUILD_ACTION` is not `build-for-testing`, `test`, or `test-without-building`, so Archive/Build actions skip the test-only checks.
- Preserve the existing test-only behavior for Test actions so the script still performs the temporary removal of the watch embed/dependency edges for Xcode Cloud test runs.
- Fix the shared scheme `Job Tracker.xcscheme` to reference the test plan as `container:../Job Tracker Safety Net.xctestplan` so the plan resolves correctly from inside the `.xcodeproj` bundle.
- Update `Documentation/XcodeCloudTesting.md` and `Documentation/TestingSafetyNet.md` to clarify that the safety-net script is skipped for Archive/Build actions and runs only for Test actions in Xcode Cloud.

### Testing
- Ran `sh ci_scripts/ci_pre_xcodebuild.sh` locally and it completed successfully.
- Simulated an Archive action with `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=archive sh ci_scripts/ci_pre_xcodebuild.sh` and the script exited immediately as intended.
- Simulated a Test action in a temporary checkout with `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=test sh ci_scripts/ci_pre_xcodebuild.sh` and the script ran the test-only behavior and succeeded.
- Ran `git diff --check` to verify diffs/whitespace and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f20c75c34832db7d9c2ea24ce4b0a)