### PR TITLE
Add support email link to Profile account section

### DIFF
--- a/Job Tracker/Features/Settings/ProfileView.swift
+++ b/Job Tracker/Features/Settings/ProfileView.swift
@@ -323,6 +323,20 @@ private extension ProfileView {
                 JTPrimaryButton("Sign Out", systemImage: "rectangle.portrait.and.arrow.right") {
                     authViewModel.signOut()
                 }
+
+                VStack(alignment: .leading, spacing: JTSpacing.xs) {
+                    Text("Need support?")
+                        .font(JTTypography.captionEmphasized)
+                        .foregroundStyle(JTColors.textPrimary)
+
+                    Link("qathom8991@gmail.com", destination: URL(string: "mailto:qathom8991@gmail.com")!)
+                        .font(JTTypography.caption)
+                        .foregroundStyle(JTColors.accent)
+                        .textSelection(.enabled)
+                        .accessibilityLabel("Email support at qathom8991@gmail.com")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, JTSpacing.xs)
             }
             .padding(JTSpacing.lg)
         }


### PR DESCRIPTION
### Motivation
- Provide a visible support contact on the Profile screen so users can quickly email for help directly from the account section.

### Description
- Added a "Need support?" block beneath the Sign Out button in `Job Tracker/Features/Settings/ProfileView.swift` that shows `qathom8991@gmail.com` as a `Link` with a `mailto:` destination, selectable text styling, and an accessibility label.

### Testing
- Attempted to run `xcodebuild -list -project 'Job Tracker.xcodeproj'` to validate the project, but `xcodebuild` is not available in this environment so no automated Xcode build/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2a002524832dbc3f24b9b2ed7372)