### PR TITLE
Add CarPlay Job Dispatch: scene delegate, service, location provider, and docs

### DIFF
--- a/Documentation/Features/CarPlay.md
+++ b/Documentation/Features/CarPlay.md
@@ -1,0 +1,35 @@
+# CarPlay Job Dispatch
+
+The CarPlay experience is intentionally limited to safe, driving-focused job dispatch tasks. It is not a turn-by-turn navigation app; it surfaces the technician's current pending jobs and hands route guidance to Maps.
+
+## Responsibilities
+
+- Show only today's pending jobs for the signed-in technician.
+- Sort jobs by current distance when location is available, falling back to scheduled time and address when it is not.
+- Limit the CarPlay list to the closest twelve pending jobs so the in-car UI stays focused.
+- Provide a job detail screen with a primary **Start Directions** action.
+- Open Apple Maps driving directions using stored job coordinates, geocoding the address only when coordinates are missing.
+- Keep editing, photos, chat, timesheets, admin tools, and long-form search out of CarPlay.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `JobDispatchCarPlaySceneDelegate` | CarPlay scene delegate that owns the template stack, loading states, refresh actions, job details, and Maps handoff. |
+| `CarPlayJobDispatchService` | Loads today's jobs from `FirebaseService`, filters pending jobs, and prepares closest-first display models. |
+| `CarPlayLocationProvider` | Requests a short-lived location fix when the app already has location authorization. It does not request new permissions from CarPlay. |
+| `CarPlayJobDisplay` | Lightweight presentation wrapper for address title, status, job number, coordinates, and formatted distance. |
+
+## Entitlement Strategy
+
+Apple grants CarPlay through managed capabilities after reviewing the app category and use case. The project now includes the CarPlay scene and implementation code, but the app entitlements file should not add a CarPlay entitlement until Apple approves the managed capability and the provisioning profile is regenerated.
+
+Recommended request positioning:
+
+> Job Tracker is a private field-service dispatch app for technicians who drive between assigned job sites. The CarPlay experience shows today's pending jobs, sorts them by proximity, and lets the technician start driving directions without using the phone. It excludes editing, media capture, messaging, timesheets, admin workflows, and other non-driving tasks.
+
+## Testing Notes
+
+- Apple documents CarPlay simulator testing from Xcode by opening Simulator's CarPlay external display after configuring the project.
+- Real-device, TestFlight, and App Store distribution require Apple to approve the appropriate CarPlay managed capability and require a provisioning profile that contains the matching entitlement.
+- Because this is a driving-task/job-dispatch experience rather than a navigation app, do not add navigation-only dashboard, instrument-cluster, or map-window scenes.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -6,6 +6,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 
 - [Admin](Features/Admin.md)
 - [Authentication](Features/Authentication.md)
+- [CarPlay Job Dispatch](Features/CarPlay.md)
 - [Forced App Updates](Features/AppUpdate.md)
 - [Dashboard](Features/Dashboard.md)
 - [Help](Features/Help.md)

--- a/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
+++ b/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
@@ -1,0 +1,170 @@
+import CoreLocation
+import Foundation
+
+struct CarPlayJobDisplay: Identifiable, Hashable {
+    let job: Job
+    let distance: CLLocationDistance?
+
+    var id: String { job.id }
+
+    var title: String {
+        let short = job.shortAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        return short.isEmpty ? "Job" : short
+    }
+
+    var detail: String {
+        var parts: [String] = []
+        if let distance {
+            parts.append(Self.formatDistance(distance))
+        }
+        parts.append(job.displayStatus)
+        if let jobNumber = job.jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !jobNumber.isEmpty {
+            parts.append("Job #\(jobNumber)")
+        }
+        return parts.joined(separator: " • ")
+    }
+
+    var fullAddress: String {
+        job.address.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var coordinate: CLLocationCoordinate2D? {
+        guard let latitude = job.latitude, let longitude = job.longitude else { return nil }
+        return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    static func formatDistance(_ meters: CLLocationDistance) -> String {
+        guard meters.isFinite else { return "" }
+        let miles = meters / 1_609.344
+        if miles >= 10 {
+            return "\(Int(miles.rounded())) mi"
+        }
+        if miles >= 0.1 {
+            return String(format: "%.1f mi", miles)
+        }
+        let feet = meters * 3.28084
+        return "\(Int(feet.rounded())) ft"
+    }
+}
+
+@MainActor
+final class CarPlayJobDispatchService {
+    enum SnapshotState {
+        case jobs([CarPlayJobDisplay], locationAvailable: Bool)
+        case signedOut
+        case error(String)
+    }
+
+    private let locationProvider: CarPlayLocationProvider
+    private let firebaseService: FirebaseService
+    private let maxJobs = 12
+
+    init(
+        locationProvider: CarPlayLocationProvider = .shared,
+        firebaseService: FirebaseService = .shared
+    ) {
+        self.locationProvider = locationProvider
+        self.firebaseService = firebaseService
+    }
+
+    func loadTodayPendingJobs() async -> SnapshotState {
+        guard firebaseService.currentUserID() != nil else {
+            return .signedOut
+        }
+
+        do {
+            let here = await locationProvider.currentLocation()
+            let jobs = try await firebaseService.fetchJobsAsync(for: Date())
+            let pending = jobs.filter { $0.isPending }
+            let displays = sortedDisplays(for: pending, currentLocation: here)
+            return .jobs(Array(displays.prefix(maxJobs)), locationAvailable: here != nil)
+        } catch {
+            return .error(error.localizedDescription)
+        }
+    }
+
+    private func sortedDisplays(for jobs: [Job], currentLocation: CLLocation?) -> [CarPlayJobDisplay] {
+        let displays = jobs.map { job -> CarPlayJobDisplay in
+            let distance = currentLocation.flatMap { here in job.clLocation?.distance(from: here) }
+            return CarPlayJobDisplay(job: job, distance: distance)
+        }
+
+        return displays.sorted { lhs, rhs in
+            switch (lhs.distance, rhs.distance) {
+            case let (left?, right?):
+                if left != right { return left < right }
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            case (nil, nil):
+                break
+            }
+
+            if lhs.job.date != rhs.job.date {
+                return lhs.job.date < rhs.job.date
+            }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+    }
+}
+
+@MainActor
+final class CarPlayLocationProvider: NSObject, CLLocationManagerDelegate {
+    static let shared = CarPlayLocationProvider()
+
+    private let manager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation?, Never>?
+    private var timeoutWorkItem: DispatchWorkItem?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.distanceFilter = 50
+        manager.activityType = .automotiveNavigation
+    }
+
+    func currentLocation() async -> CLLocation? {
+        if let recent = manager.location, abs(recent.timestamp.timeIntervalSinceNow) < 300 {
+            return recent
+        }
+
+        switch manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return await withCheckedContinuation { continuation in
+                finish(with: nil)
+                self.continuation = continuation
+                manager.requestLocation()
+
+                let timeout = DispatchWorkItem { [weak self] in
+                    Task { @MainActor in
+                        self?.finish(with: self?.manager.location)
+                    }
+                }
+                timeoutWorkItem = timeout
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: timeout)
+            }
+        case .notDetermined, .restricted, .denied:
+            return manager.location
+        @unknown default:
+            return manager.location
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        finish(with: locations.last ?? manager.location)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        finish(with: manager.location)
+    }
+
+    private func finish(with location: CLLocation?) {
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: location)
+    }
+}

--- a/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
+++ b/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
@@ -1,0 +1,189 @@
+import CarPlay
+import CoreLocation
+import Foundation
+import MapKit
+import UIKit
+
+@objc(JobDispatchCarPlaySceneDelegate)
+@MainActor
+final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
+    private var interfaceController: CPInterfaceController?
+    private let service = CarPlayJobDispatchService()
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didConnect interfaceController: CPInterfaceController
+    ) {
+        self.interfaceController = interfaceController
+        interfaceController.setRootTemplate(loadingTemplate(), animated: false)
+        Task { await reloadJobs(animated: true) }
+    }
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didDisconnectInterfaceController interfaceController: CPInterfaceController
+    ) {
+        if self.interfaceController === interfaceController {
+            self.interfaceController = nil
+        }
+    }
+
+    private func reloadJobs(animated: Bool) async {
+        let state = await service.loadTodayPendingJobs()
+        let template: CPListTemplate
+
+        switch state {
+        case let .jobs(displays, locationAvailable):
+            template = jobsTemplate(displays: displays, locationAvailable: locationAvailable)
+        case .signedOut:
+            template = messageTemplate(
+                title: "Job Tracker",
+                message: "Sign in on your iPhone to see today's assigned jobs in CarPlay."
+            )
+        case let .error(message):
+            template = messageTemplate(
+                title: "Can't Load Jobs",
+                message: message.isEmpty ? "Check your connection and try again." : message
+            )
+        }
+
+        interfaceController?.setRootTemplate(template, animated: animated)
+    }
+
+    private func loadingTemplate() -> CPListTemplate {
+        messageTemplate(title: "Today's Jobs", message: "Loading assigned jobs…")
+    }
+
+    private func jobsTemplate(displays: [CarPlayJobDisplay], locationAvailable: Bool) -> CPListTemplate {
+        let title = "Today's Jobs"
+        var sections: [CPListSection] = []
+
+        if displays.isEmpty {
+            sections.append(
+                CPListSection(items: [
+                    informationalItem(
+                        title: "No pending jobs today",
+                        detail: "You're clear for now."
+                    )
+                ])
+            )
+        } else {
+            let jobItems = displays.map { display in
+                let item = CPListItem(text: display.title, detailText: display.detail)
+                item.accessoryType = .disclosureIndicator
+                item.handler = { [weak self] _, completion in
+                    Task { @MainActor in
+                        self?.showDetail(for: display)
+                        completion()
+                    }
+                }
+                return item
+            }
+            sections.append(CPListSection(items: jobItems))
+        }
+
+        let refreshItem = CPListItem(
+            text: "Refresh Jobs",
+            detailText: locationAvailable ? "Update today's assignments" : "Update jobs; location unavailable"
+        )
+        refreshItem.handler = { [weak self] _, completion in
+            Task { @MainActor in
+                await self?.reloadJobs(animated: true)
+                completion()
+            }
+        }
+        sections.append(CPListSection(items: [refreshItem]))
+
+        return CPListTemplate(title: title, sections: sections)
+    }
+
+    private func messageTemplate(title: String, message: String) -> CPListTemplate {
+        let retry = CPListItem(text: "Refresh", detailText: "Try loading jobs again")
+        retry.handler = { [weak self] _, completion in
+            Task { @MainActor in
+                await self?.reloadJobs(animated: true)
+                completion()
+            }
+        }
+
+        return CPListTemplate(
+            title: title,
+            sections: [
+                CPListSection(items: [informationalItem(title: message, detail: nil)]),
+                CPListSection(items: [retry])
+            ]
+        )
+    }
+
+    private func showDetail(for display: CarPlayJobDisplay) {
+        let directionsItem = CPListItem(text: "Start Directions", detailText: display.fullAddress)
+        directionsItem.handler = { [weak self] _, completion in
+            Task { @MainActor in
+                await self?.openDirections(to: display)
+                completion()
+            }
+        }
+
+        let statusItem = informationalItem(title: "Status", detail: display.job.displayStatus)
+        let addressItem = informationalItem(title: "Address", detail: display.fullAddress)
+        var details = [directionsItem, statusItem, addressItem]
+
+        if let jobNumber = display.job.jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !jobNumber.isEmpty {
+            details.append(informationalItem(title: "Job Number", detail: jobNumber))
+        }
+        if let locationNumber = display.job.locationNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !locationNumber.isEmpty {
+            details.append(informationalItem(title: "Location Number", detail: locationNumber))
+        }
+        if let assignments = display.job.assignments?.trimmingCharacters(in: .whitespacesAndNewlines), !assignments.isEmpty {
+            details.append(informationalItem(title: "Assignment", detail: assignments))
+        }
+
+        let template = CPListTemplate(
+            title: display.title,
+            sections: [CPListSection(items: details)]
+        )
+        interfaceController?.pushTemplate(template, animated: true)
+    }
+
+    private func informationalItem(title: String, detail: String?) -> CPListItem {
+        let item = CPListItem(text: title, detailText: detail)
+        item.isEnabled = false
+        return item
+    }
+
+    private func openDirections(to display: CarPlayJobDisplay) async {
+        if let coordinate = display.coordinate {
+            openMaps(coordinate: coordinate, name: display.title)
+            return
+        }
+
+        let geocodedCoordinate = await geocode(display.fullAddress)
+        if let geocodedCoordinate {
+            openMaps(coordinate: geocodedCoordinate, name: display.title)
+            return
+        }
+
+        if let encoded = display.fullAddress.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+           let url = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)&dirflg=d") {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func geocode(_ address: String) async -> CLLocationCoordinate2D? {
+        await withCheckedContinuation { continuation in
+            CLGeocoder().geocodeAddressString(address) { placemarks, _ in
+                continuation.resume(returning: placemarks?.first?.location?.coordinate)
+            }
+        }
+    }
+
+    private func openMaps(coordinate: CLLocationCoordinate2D, name: String) {
+        let source = MKMapItem.forCurrentLocation()
+        let destination = MKMapItem(placemark: MKPlacemark(coordinate: coordinate))
+        destination.name = name
+        MKMapItem.openMaps(
+            with: [source, destination],
+            launchOptions: [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
+        )
+    }
+}

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -17,6 +17,32 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>JobDispatchCarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).JobDispatchCarPlaySceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 <key>OPENAI_API_KEY</key>
 <string>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</string>
 <key>GEMINI_API_KEY</key>


### PR DESCRIPTION
### Motivation

- Provide a focused CarPlay experience for technicians to view and start directions to today's pending jobs without exposing non-driving workflows. 
- Surface a small, proximity-sorted list of assignments and hand off routing to Apple Maps rather than implementing in-app navigation. 
- Keep entitlement changes out of the repo and document the managed-capability workflow so CarPlay is only enabled after Apple's approval.

### Description

- Added a CarPlay feature documentation file `Documentation/Features/CarPlay.md` and linked it from `Documentation/README.md` describing responsibilities, types, entitlements, and testing notes.  
- Implemented `JobDispatchCarPlaySceneDelegate` which drives the CarPlay UI using `CPListTemplate`, shows job details, provides a `Start Directions` action, and hands off to Maps via coordinates or geocoding.  
- Added `CarPlayJobDispatchService`, `CarPlayJobDisplay`, and `CarPlayLocationProvider` in `Job Tracker/Features/CarPlay/` to fetch today's pending jobs from `FirebaseService`, produce up-to-12 proximity-sorted display models, and obtain a short-lived location fix without requesting new permissions.  
- Updated `Job-Tracker-Info.plist` to register the `CPTemplateApplicationScene` configuration and wire the scene delegate class, while documenting that the CarPlay entitlement must not be added until Apple approval.

### Testing

- Ran the project's unit test target `Job TrackerTests` and the suite completed successfully.  
- Performed an automated build verification via `xcodebuild` for the app scheme which succeeded without compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2abaf85654832da18e687ce032a907)