### PR TITLE
Add CarPlay Job Dispatch feature, service, scene delegate, docs, and plist configuration

### DIFF
--- a/Documentation/Features/CarPlay.md
+++ b/Documentation/Features/CarPlay.md
@@ -1,0 +1,35 @@
+# CarPlay Job Dispatch
+
+The CarPlay experience is intentionally limited to safe, driving-focused job dispatch tasks. It is not a turn-by-turn navigation app; it surfaces the technician's current pending jobs and hands route guidance to Maps.
+
+## Responsibilities
+
+- Show only today's pending jobs created by the signed-in technician, matching the dashboard's personal job-list behavior.
+- Respect the existing Smart Routing settings: closest-first or farthest-first when enabled and location is available, otherwise scheduled time/address order.
+- Limit the CarPlay list to twelve pending jobs so the in-car UI stays focused.
+- Provide a job detail screen with a primary **Start Directions** action.
+- Open the user's selected maps provider (Google Maps when configured, with Apple Maps fallback) using stored job coordinates, geocoding the address only when coordinates are missing.
+- Keep editing, photos, chat, timesheets, admin tools, and long-form search out of CarPlay.
+
+## Key Types
+
+| Type | Role |
+| --- | --- |
+| `JobDispatchCarPlaySceneDelegate` | CarPlay scene delegate that owns the template stack, loading states, refresh actions, job details, and Maps handoff. |
+| `CarPlayJobDispatchService` | Loads today's jobs from `FirebaseService`, filters pending jobs to `createdBy == currentUserID`, and applies the same Smart Routing order preference used by the dashboard. |
+| `CarPlayLocationProvider` | Requests a short-lived location fix when the app already has location authorization. It does not request new permissions from CarPlay. |
+| `CarPlayJobDisplay` | Lightweight presentation wrapper for address title, status, job number, coordinates, and formatted distance. |
+
+## Entitlement Strategy
+
+Apple grants CarPlay through managed capabilities after reviewing the app category and use case. The project now includes the CarPlay scene and implementation code, but the app entitlements file should not add a CarPlay entitlement until Apple approves the managed capability and the provisioning profile is regenerated.
+
+Recommended request positioning:
+
+> Job Tracker is a private field-service dispatch app for technicians who drive between assigned job sites. The CarPlay experience shows today's pending jobs created by the signed-in technician, honors the existing closest/farthest Smart Routing setting, and lets the technician start driving directions without using the phone. It excludes editing, media capture, messaging, timesheets, admin workflows, and other non-driving tasks.
+
+## Testing Notes
+
+- Apple documents CarPlay simulator testing from Xcode by opening Simulator's CarPlay external display after configuring the project.
+- Real-device, TestFlight, and App Store distribution require Apple to approve the appropriate CarPlay managed capability and require a provisioning profile that contains the matching entitlement.
+- Because this is a driving-task/job-dispatch experience rather than a navigation app, do not add navigation-only dashboard, instrument-cluster, or map-window scenes.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -6,6 +6,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 
 - [Admin](Features/Admin.md)
 - [Authentication](Features/Authentication.md)
+- [CarPlay Job Dispatch](Features/CarPlay.md)
 - [Forced App Updates](Features/AppUpdate.md)
 - [Dashboard](Features/Dashboard.md)
 - [Help](Features/Help.md)

--- a/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
+++ b/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
@@ -1,0 +1,197 @@
+import CoreLocation
+import Foundation
+
+struct CarPlayJobDisplay: Identifiable, Hashable {
+    let job: Job
+    let distance: CLLocationDistance?
+
+    var id: String { job.id }
+
+    var title: String {
+        let short = job.shortAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        return short.isEmpty ? "Job" : short
+    }
+
+    var detail: String {
+        var parts: [String] = []
+        if let distance {
+            parts.append(Self.formatDistance(distance))
+        }
+        parts.append(job.displayStatus)
+        if let jobNumber = job.jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !jobNumber.isEmpty {
+            parts.append("Job #\(jobNumber)")
+        }
+        return parts.joined(separator: " • ")
+    }
+
+    var fullAddress: String {
+        job.address.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var coordinate: CLLocationCoordinate2D? {
+        guard let latitude = job.latitude, let longitude = job.longitude else { return nil }
+        return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    static func formatDistance(_ meters: CLLocationDistance) -> String {
+        guard meters.isFinite else { return "" }
+        let miles = meters / 1_609.344
+        if miles >= 10 {
+            return "\(Int(miles.rounded())) mi"
+        }
+        if miles >= 0.1 {
+            return String(format: "%.1f mi", miles)
+        }
+        let feet = meters * 3.28084
+        return "\(Int(feet.rounded())) ft"
+    }
+}
+
+@MainActor
+final class CarPlayJobDispatchService {
+    enum SnapshotState {
+        case jobs([CarPlayJobDisplay], locationAvailable: Bool, smartRoutingEnabled: Bool, orderedByDistance: Bool, sortedClosestFirst: Bool)
+        case signedOut
+        case error(String)
+    }
+
+    private let locationProvider: CarPlayLocationProvider
+    private let firebaseService: FirebaseService
+    private let userDefaults: UserDefaults
+    private let maxJobs = 12
+
+    init(
+        locationProvider: CarPlayLocationProvider = .shared,
+        firebaseService: FirebaseService = .shared,
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.locationProvider = locationProvider
+        self.firebaseService = firebaseService
+        self.userDefaults = userDefaults
+    }
+
+    func loadTodayPendingJobs() async -> SnapshotState {
+        guard let currentUserID = firebaseService.currentUserID() else {
+            return .signedOut
+        }
+
+        do {
+            let shouldOrderByDistance = userDefaults.bool(forKey: "smartRoutingEnabled")
+            let sortedClosestFirst = userDefaults.string(forKey: "routingOptimizeBy") != "farthest"
+            let here = shouldOrderByDistance ? await locationProvider.currentLocation() : nil
+            let jobs = try await firebaseService.fetchJobsAsync(for: Date())
+            let pendingCreatedByUser = jobs.filter { job in
+                job.isPending && job.createdBy == currentUserID
+            }
+            let displays = sortedDisplays(
+                for: pendingCreatedByUser,
+                currentLocation: here,
+                orderByDistance: shouldOrderByDistance,
+                sortedClosestFirst: sortedClosestFirst
+            )
+            return .jobs(
+                Array(displays.prefix(maxJobs)),
+                locationAvailable: here != nil,
+                smartRoutingEnabled: shouldOrderByDistance,
+                orderedByDistance: shouldOrderByDistance && here != nil,
+                sortedClosestFirst: sortedClosestFirst
+            )
+        } catch {
+            return .error(error.localizedDescription)
+        }
+    }
+
+    private func sortedDisplays(
+        for jobs: [Job],
+        currentLocation: CLLocation?,
+        orderByDistance: Bool,
+        sortedClosestFirst: Bool
+    ) -> [CarPlayJobDisplay] {
+        let displays = jobs.map { job -> CarPlayJobDisplay in
+            let distance = currentLocation.flatMap { here in job.clLocation?.distance(from: here) }
+            return CarPlayJobDisplay(job: job, distance: distance)
+        }
+
+        return displays.sorted { lhs, rhs in
+            if orderByDistance, currentLocation != nil {
+                switch (lhs.distance, rhs.distance) {
+                case let (left?, right?):
+                    if left != right {
+                        return sortedClosestFirst ? left < right : left > right
+                    }
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                case (nil, nil):
+                    break
+                }
+            }
+
+            if lhs.job.date != rhs.job.date {
+                return lhs.job.date < rhs.job.date
+            }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+    }
+}
+
+@MainActor
+final class CarPlayLocationProvider: NSObject, CLLocationManagerDelegate {
+    static let shared = CarPlayLocationProvider()
+
+    private let manager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation?, Never>?
+    private var timeoutWorkItem: DispatchWorkItem?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.distanceFilter = 50
+        manager.activityType = .automotiveNavigation
+    }
+
+    func currentLocation() async -> CLLocation? {
+        if let recent = manager.location, abs(recent.timestamp.timeIntervalSinceNow) < 300 {
+            return recent
+        }
+
+        switch manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return await withCheckedContinuation { continuation in
+                finish(with: nil)
+                self.continuation = continuation
+                manager.requestLocation()
+
+                let timeout = DispatchWorkItem { [weak self] in
+                    Task { @MainActor in
+                        self?.finish(with: self?.manager.location)
+                    }
+                }
+                timeoutWorkItem = timeout
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: timeout)
+            }
+        case .notDetermined, .restricted, .denied:
+            return manager.location
+        @unknown default:
+            return manager.location
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        finish(with: locations.last ?? manager.location)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        finish(with: manager.location)
+    }
+
+    private func finish(with location: CLLocation?) {
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: location)
+    }
+}

--- a/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
+++ b/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
@@ -1,0 +1,261 @@
+import CarPlay
+import CoreLocation
+import Foundation
+import MapKit
+import UIKit
+
+@objc(JobDispatchCarPlaySceneDelegate)
+@MainActor
+final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
+    private var interfaceController: CPInterfaceController?
+    private let service = CarPlayJobDispatchService()
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didConnect interfaceController: CPInterfaceController
+    ) {
+        self.interfaceController = interfaceController
+        interfaceController.setRootTemplate(loadingTemplate(), animated: false)
+        Task { await reloadJobs(animated: true) }
+    }
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didDisconnectInterfaceController interfaceController: CPInterfaceController
+    ) {
+        if self.interfaceController === interfaceController {
+            self.interfaceController = nil
+        }
+    }
+
+    private func reloadJobs(animated: Bool) async {
+        let state = await service.loadTodayPendingJobs()
+        let template: CPListTemplate
+
+        switch state {
+        case let .jobs(displays, locationAvailable, smartRoutingEnabled, orderedByDistance, sortedClosestFirst):
+            template = jobsTemplate(
+                displays: displays,
+                locationAvailable: locationAvailable,
+                smartRoutingEnabled: smartRoutingEnabled,
+                orderedByDistance: orderedByDistance,
+                sortedClosestFirst: sortedClosestFirst
+            )
+        case .signedOut:
+            template = messageTemplate(
+                title: "Job Tracker",
+                message: "Sign in on your iPhone to see today's assigned jobs in CarPlay."
+            )
+        case let .error(message):
+            template = messageTemplate(
+                title: "Can't Load Jobs",
+                message: message.isEmpty ? "Check your connection and try again." : message
+            )
+        }
+
+        interfaceController?.setRootTemplate(template, animated: animated)
+    }
+
+    private func loadingTemplate() -> CPListTemplate {
+        messageTemplate(title: "Today's Jobs", message: "Loading assigned jobs…")
+    }
+
+    private func jobsTemplate(
+        displays: [CarPlayJobDisplay],
+        locationAvailable: Bool,
+        smartRoutingEnabled: Bool,
+        orderedByDistance: Bool,
+        sortedClosestFirst: Bool
+    ) -> CPListTemplate {
+        let title = "Today's Jobs"
+        var sections: [CPListSection] = []
+
+        if displays.isEmpty {
+            sections.append(
+                CPListSection(items: [
+                    informationalItem(
+                        title: "No pending jobs today",
+                        detail: "You're clear for now."
+                    )
+                ])
+            )
+        } else {
+            let jobItems = displays.map { display in
+                let item = CPListItem(text: display.title, detailText: display.detail)
+                item.accessoryType = .disclosureIndicator
+                item.handler = { [weak self] _, completion in
+                    Task { @MainActor in
+                        self?.showDetail(for: display)
+                        completion()
+                    }
+                }
+                return item
+            }
+            sections.append(CPListSection(items: jobItems))
+            sections.append(
+                CPListSection(items: [
+                    informationalItem(
+                        title: orderedByDistance
+                            ? (sortedClosestFirst ? "Sorted closest-first" : "Sorted farthest-first")
+                            : "Sorted by scheduled time",
+                        detail: orderingDetailText(
+                            orderedByDistance: orderedByDistance,
+                            smartRoutingEnabled: smartRoutingEnabled
+                        )
+                    )
+                ])
+            )
+        }
+
+        let refreshItem = CPListItem(
+            text: "Refresh Jobs",
+            detailText: locationAvailable || !smartRoutingEnabled
+                ? "Update today's assignments"
+                : "Update jobs; location unavailable"
+        )
+        refreshItem.handler = { [weak self] _, completion in
+            Task { @MainActor in
+                await self?.reloadJobs(animated: true)
+                completion()
+            }
+        }
+        sections.append(CPListSection(items: [refreshItem]))
+
+        return CPListTemplate(title: title, sections: sections)
+    }
+
+    private func orderingDetailText(orderedByDistance: Bool, smartRoutingEnabled: Bool) -> String {
+        if orderedByDistance {
+            return "Matches your Smart Routing setting."
+        }
+        if smartRoutingEnabled {
+            return "Location unavailable, so distance sorting is paused."
+        }
+        return "Enable Smart Routing on iPhone to sort by distance."
+    }
+
+    private func messageTemplate(title: String, message: String) -> CPListTemplate {
+        let retry = CPListItem(text: "Refresh", detailText: "Try loading jobs again")
+        retry.handler = { [weak self] _, completion in
+            Task { @MainActor in
+                await self?.reloadJobs(animated: true)
+                completion()
+            }
+        }
+
+        return CPListTemplate(
+            title: title,
+            sections: [
+                CPListSection(items: [informationalItem(title: message, detail: nil)]),
+                CPListSection(items: [retry])
+            ]
+        )
+    }
+
+    private func showDetail(for display: CarPlayJobDisplay) {
+        let directionsItem = CPListItem(text: "Start Directions", detailText: display.fullAddress)
+        directionsItem.handler = { [weak self] _, completion in
+            Task { @MainActor in
+                await self?.openDirections(to: display)
+                completion()
+            }
+        }
+
+        let statusItem = informationalItem(title: "Status", detail: display.job.displayStatus)
+        let addressItem = informationalItem(title: "Address", detail: display.fullAddress)
+        var details = [directionsItem, statusItem, addressItem]
+
+        if let jobNumber = display.job.jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !jobNumber.isEmpty {
+            details.append(informationalItem(title: "Job Number", detail: jobNumber))
+        }
+        if let locationNumber = display.job.locationNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !locationNumber.isEmpty {
+            details.append(informationalItem(title: "Location Number", detail: locationNumber))
+        }
+        if let assignments = display.job.assignments?.trimmingCharacters(in: .whitespacesAndNewlines), !assignments.isEmpty {
+            details.append(informationalItem(title: "Assignment", detail: assignments))
+        }
+        if let materials = display.job.materialsUsed?.trimmingCharacters(in: .whitespacesAndNewlines), !materials.isEmpty {
+            details.append(informationalItem(title: "Materials", detail: materials))
+        }
+        if let notes = display.job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
+            details.append(informationalItem(title: "Notes", detail: notes))
+        }
+
+        let template = CPListTemplate(
+            title: display.title,
+            sections: [CPListSection(items: details)]
+        )
+        interfaceController?.pushTemplate(template, animated: true)
+    }
+
+    private func informationalItem(title: String, detail: String?) -> CPListItem {
+        let item = CPListItem(text: title, detailText: detail)
+        item.isEnabled = false
+        return item
+    }
+
+    private func openDirections(to display: CarPlayJobDisplay) async {
+        let coordinate = display.coordinate ?? await geocode(display.fullAddress)
+        if UserDefaults.standard.string(forKey: "addressSuggestionProvider") == "google" {
+            openGoogleMaps(to: display, coordinate: coordinate)
+            return
+        }
+
+        if let coordinate {
+            openAppleMaps(coordinate: coordinate, name: display.title)
+            return
+        }
+
+        openAppleMaps(address: display.fullAddress)
+    }
+
+    private func geocode(_ address: String) async -> CLLocationCoordinate2D? {
+        await withCheckedContinuation { continuation in
+            CLGeocoder().geocodeAddressString(address) { placemarks, _ in
+                continuation.resume(returning: placemarks?.first?.location?.coordinate)
+            }
+        }
+    }
+
+    private func openGoogleMaps(to display: CarPlayJobDisplay, coordinate: CLLocationCoordinate2D?) {
+        let destination: String
+        if let coordinate {
+            destination = "\(coordinate.latitude),\(coordinate.longitude)"
+        } else {
+            destination = display.fullAddress
+        }
+
+        guard let encoded = destination.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let googleURL = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") else {
+            openAppleMaps(address: display.fullAddress)
+            return
+        }
+
+        UIApplication.shared.open(googleURL, options: [:]) { [weak self] success in
+            guard !success else { return }
+            Task { @MainActor in
+                if let coordinate {
+                    self?.openAppleMaps(coordinate: coordinate, name: display.title)
+                } else {
+                    self?.openAppleMaps(address: display.fullAddress)
+                }
+            }
+        }
+    }
+
+    private func openAppleMaps(coordinate: CLLocationCoordinate2D, name: String) {
+        let source = MKMapItem.forCurrentLocation()
+        let destination = MKMapItem(placemark: MKPlacemark(coordinate: coordinate))
+        destination.name = name
+        MKMapItem.openMaps(
+            with: [source, destination],
+            launchOptions: [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
+        )
+    }
+
+    private func openAppleMaps(address: String) {
+        guard let encoded = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)&dirflg=d") else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -17,6 +17,32 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>JobDispatchCarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).JobDispatchCarPlaySceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 <key>OPENAI_API_KEY</key>
 <string>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</string>
 <key>GEMINI_API_KEY</key>


### PR DESCRIPTION
### Motivation

- Provide an in-car, driving-focused view of today's pending jobs for technicians without enabling full app features in CarPlay.
- Honor existing Smart Routing preferences and limit the CarPlay UI surface to concise job dispatch and start-directions actions.

### Description

- Adds a feature guide `Documentation/Features/CarPlay.md` and links it from `Documentation/README.md` describing responsibilities, key types, entitlements, and testing notes. 
- Implements `CarPlayJobDispatchService` and `CarPlayJobDisplay` to load today's pending jobs from `FirebaseService`, filter by `createdBy == currentUserID`, apply Smart Routing order from `UserDefaults` (`smartRoutingEnabled` and `routingOptimizeBy`), and cap the list to 12 items.
- Adds `CarPlayLocationProvider` to request a short-lived location fix (3s timeout) when the app already has location authorization and exposes `currentLocation()` for distance sorting.
- Implements `JobDispatchCarPlaySceneDelegate` to build CarPlay `CPListTemplate` views for job lists, details, refresh handling, and a primary `Start Directions` action that opens Google Maps (when configured) or falls back to Apple Maps with coordinate geocoding as needed.
- Updates `Job-Tracker-Info.plist` to register a `CPTemplateApplicationScene` configuration and the `JobDispatchCarPlaySceneDelegate` scene delegate class without adding entitlement changes; documentation includes entitlement guidance.

### Testing

- Ran the existing automated unit/integration test suite under `Job TrackerTests`; the suite completed and passed against these changes.
- No new automated tests were added for CarPlay UI templates or the location/geocoding handoff; CarPlay behavior is documented for validation with Xcode's CarPlay simulator and real-device testing after provisioning changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2abaf85654832da18e687ce032a907)