### PR TITLE
Align CarPlay jobs with dashboard behavior

### DIFF
--- a/Documentation/Features/CarPlay.md
+++ b/Documentation/Features/CarPlay.md
@@ -1,14 +1,14 @@
 # CarPlay Job Dispatch
 
-The CarPlay experience is intentionally limited to safe, driving-focused job dispatch tasks. It is not a turn-by-turn navigation app; it surfaces the technician's current pending jobs and hands route guidance to Maps.
+The CarPlay experience is intentionally limited to safe, driving-focused job dispatch tasks. It is not a turn-by-turn navigation app; it surfaces the technician's current dashboard jobs and hands route guidance to Maps.
 
 ## Responsibilities
 
-- Show only today's pending jobs for the signed-in technician.
-- Sort jobs by current distance when location is available, falling back to scheduled time and address when it is not.
-- Limit the CarPlay list to the closest twelve pending jobs so the in-car UI stays focused.
-- Provide a job detail screen with a primary **Start Directions** action.
-- Open Apple Maps driving directions using stored job coordinates, geocoding the address only when coordinates are missing.
+- Show only today's dashboard jobs created by the signed-in technician, matching the phone dashboard's ownership scope rather than exposing another user's jobs.
+- Sort jobs by current distance when location is available, honoring the dashboard routing preference for closest-first or furthest-first; fall back to scheduled time and address when distance is unavailable.
+- Limit the CarPlay list to twelve jobs after applying the routing preference so the in-car UI stays focused.
+- Provide a read-only job detail screen with a primary **Start Directions** action and the same core job reference fields the dashboard cards expose. Editing and adding info stay on the phone for CarPlay safety.
+- Open driving directions with the dashboard's selected map provider: Google Maps when selected and available, otherwise Apple Maps, using stored job coordinates and geocoding the address only when needed.
 - Keep editing, photos, chat, timesheets, admin tools, and long-form search out of CarPlay.
 
 ## Key Types
@@ -16,7 +16,7 @@ The CarPlay experience is intentionally limited to safe, driving-focused job dis
 | Type | Role |
 | --- | --- |
 | `JobDispatchCarPlaySceneDelegate` | CarPlay scene delegate that owns the template stack, loading states, refresh actions, job details, and Maps handoff. |
-| `CarPlayJobDispatchService` | Loads today's jobs from `FirebaseService`, filters pending jobs, and prepares closest-first display models. |
+| `CarPlayJobDispatchService` | Loads today's jobs from `FirebaseService`, filters to jobs created by the current user, and prepares routing-preference-aware display models. |
 | `CarPlayLocationProvider` | Requests a short-lived location fix when the app already has location authorization. It does not request new permissions from CarPlay. |
 | `CarPlayJobDisplay` | Lightweight presentation wrapper for address title, status, job number, coordinates, and formatted distance. |
 
@@ -26,7 +26,7 @@ Apple grants CarPlay through managed capabilities after reviewing the app catego
 
 Recommended request positioning:
 
-> Job Tracker is a private field-service dispatch app for technicians who drive between assigned job sites. The CarPlay experience shows today's pending jobs, sorts them by proximity, and lets the technician start driving directions without using the phone. It excludes editing, media capture, messaging, timesheets, admin workflows, and other non-driving tasks.
+> Job Tracker is a private field-service dispatch app for technicians who drive between assigned job sites. The CarPlay experience shows today's dashboard jobs created by the signed-in technician, sorts them by the user's routing preference, and lets the technician start driving directions without using the phone. It excludes editing, media capture, messaging, timesheets, admin workflows, and other non-driving tasks.
 
 ## Testing Notes
 

--- a/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
+++ b/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
@@ -57,33 +57,53 @@ final class CarPlayJobDispatchService {
 
     private let locationProvider: CarPlayLocationProvider
     private let firebaseService: FirebaseService
+    private let defaults: UserDefaults
     private let maxJobs = 12
 
     init(
         locationProvider: CarPlayLocationProvider = .shared,
-        firebaseService: FirebaseService = .shared
+        firebaseService: FirebaseService = .shared,
+        defaults: UserDefaults = .standard
     ) {
         self.locationProvider = locationProvider
         self.firebaseService = firebaseService
+        self.defaults = defaults
     }
 
-    func loadTodayPendingJobs() async -> SnapshotState {
-        guard firebaseService.currentUserID() != nil else {
+    func loadTodayDashboardJobs() async -> SnapshotState {
+        guard let currentUserID = firebaseService.currentUserID() else {
             return .signedOut
         }
 
         do {
             let here = await locationProvider.currentLocation()
             let jobs = try await firebaseService.fetchJobsAsync(for: Date())
-            let pending = jobs.filter { $0.isPending }
-            let displays = sortedDisplays(for: pending, currentLocation: here)
+            let ownJobs = jobs.filter { $0.createdBy == currentUserID }
+            let displays = sortedDisplays(
+                for: ownJobs,
+                currentLocation: here,
+                sortClosest: shouldSortClosest
+            )
             return .jobs(Array(displays.prefix(maxJobs)), locationAvailable: here != nil)
         } catch {
             return .error(error.localizedDescription)
         }
     }
 
-    private func sortedDisplays(for jobs: [Job], currentLocation: CLLocation?) -> [CarPlayJobDisplay] {
+    private var shouldSortClosest: Bool {
+        switch defaults.string(forKey: "routingOptimizeBy") {
+        case "farthest", "furthest":
+            return false
+        default:
+            return true
+        }
+    }
+
+    private func sortedDisplays(
+        for jobs: [Job],
+        currentLocation: CLLocation?,
+        sortClosest: Bool
+    ) -> [CarPlayJobDisplay] {
         let displays = jobs.map { job -> CarPlayJobDisplay in
             let distance = currentLocation.flatMap { here in job.clLocation?.distance(from: here) }
             return CarPlayJobDisplay(job: job, distance: distance)
@@ -92,7 +112,7 @@ final class CarPlayJobDispatchService {
         return displays.sorted { lhs, rhs in
             switch (lhs.distance, rhs.distance) {
             case let (left?, right?):
-                if left != right { return left < right }
+                if left != right { return sortClosest ? left < right : left > right }
             case (_?, nil):
                 return true
             case (nil, _?):

--- a/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
+++ b/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
@@ -29,7 +29,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
     }
 
     private func reloadJobs(animated: Bool) async {
-        let state = await service.loadTodayPendingJobs()
+        let state = await service.loadTodayDashboardJobs()
         let template: CPListTemplate
 
         switch state {
@@ -38,7 +38,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
         case .signedOut:
             template = messageTemplate(
                 title: "Job Tracker",
-                message: "Sign in on your iPhone to see today's assigned jobs in CarPlay."
+                message: "Sign in on your iPhone to see today's dashboard jobs in CarPlay."
             )
         case let .error(message):
             template = messageTemplate(
@@ -51,7 +51,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
     }
 
     private func loadingTemplate() -> CPListTemplate {
-        messageTemplate(title: "Today's Jobs", message: "Loading assigned jobs…")
+        messageTemplate(title: "Today's Jobs", message: "Loading your dashboard jobs…")
     }
 
     private func jobsTemplate(displays: [CarPlayJobDisplay], locationAvailable: Bool) -> CPListTemplate {
@@ -62,8 +62,8 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
             sections.append(
                 CPListSection(items: [
                     informationalItem(
-                        title: "No pending jobs today",
-                        detail: "You're clear for now."
+                        title: "No jobs on your dashboard today",
+                        detail: "Jobs you created for today will appear here."
                     )
                 ])
             )
@@ -84,7 +84,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
 
         let refreshItem = CPListItem(
             text: "Refresh Jobs",
-            detailText: locationAvailable ? "Update today's assignments" : "Update jobs; location unavailable"
+            detailText: locationAvailable ? "Update today's dashboard jobs" : "Update jobs; location unavailable"
         )
         refreshItem.handler = { [weak self] _, completion in
             Task { @MainActor in
@@ -134,8 +134,26 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
         if let locationNumber = display.job.locationNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !locationNumber.isEmpty {
             details.append(informationalItem(title: "Location Number", detail: locationNumber))
         }
+        if let portalID = display.job.portalID?.trimmingCharacters(in: .whitespacesAndNewlines), !portalID.isEmpty {
+            details.append(informationalItem(title: "Portal ID", detail: portalID))
+        }
         if let assignments = display.job.assignments?.trimmingCharacters(in: .whitespacesAndNewlines), !assignments.isEmpty {
             details.append(informationalItem(title: "Assignment", detail: assignments))
+        }
+        if let materials = display.job.materialsUsed?.trimmingCharacters(in: .whitespacesAndNewlines), !materials.isEmpty {
+            details.append(informationalItem(title: "Materials", detail: materials))
+        }
+        if let nidFootage = display.job.nidFootage?.trimmingCharacters(in: .whitespacesAndNewlines), !nidFootage.isEmpty {
+            details.append(informationalItem(title: "NID Footage", detail: nidFootage))
+        }
+        if let canFootage = display.job.canFootage?.trimmingCharacters(in: .whitespacesAndNewlines), !canFootage.isEmpty {
+            details.append(informationalItem(title: "Can Footage", detail: canFootage))
+        }
+        if let placement = display.job.jobPlacement?.trimmingCharacters(in: .whitespacesAndNewlines), !placement.isEmpty {
+            details.append(informationalItem(title: "Placement", detail: placement))
+        }
+        if let notes = display.job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
+            details.append(informationalItem(title: "Notes", detail: notes))
         }
 
         let template = CPListTemplate(
@@ -152,20 +170,42 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
     }
 
     private func openDirections(to display: CarPlayJobDisplay) async {
+        if UserDefaults.standard.string(forKey: "addressSuggestionProvider") == "google",
+           await openGoogleMaps(to: display) {
+            return
+        }
+
         if let coordinate = display.coordinate {
-            openMaps(coordinate: coordinate, name: display.title)
+            openAppleMaps(coordinate: coordinate, name: display.title)
             return
         }
 
         let geocodedCoordinate = await geocode(display.fullAddress)
         if let geocodedCoordinate {
-            openMaps(coordinate: geocodedCoordinate, name: display.title)
+            openAppleMaps(coordinate: geocodedCoordinate, name: display.title)
             return
         }
 
-        if let encoded = display.fullAddress.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-           let url = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)&dirflg=d") {
-            UIApplication.shared.open(url)
+        openAppleMapsAddress(display.fullAddress)
+    }
+
+    private func openGoogleMaps(to display: CarPlayJobDisplay) async -> Bool {
+        let destination: String
+        if let coordinate = display.coordinate {
+            destination = "\(coordinate.latitude),\(coordinate.longitude)"
+        } else {
+            destination = display.fullAddress
+        }
+
+        guard let encoded = destination.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "comgooglemaps://?daddr=\(encoded)&directionsmode=driving") else {
+            return false
+        }
+
+        return await withCheckedContinuation { continuation in
+            UIApplication.shared.open(url, options: [:]) { success in
+                continuation.resume(returning: success)
+            }
         }
     }
 
@@ -177,7 +217,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
         }
     }
 
-    private func openMaps(coordinate: CLLocationCoordinate2D, name: String) {
+    private func openAppleMaps(coordinate: CLLocationCoordinate2D, name: String) {
         let source = MKMapItem.forCurrentLocation()
         let destination = MKMapItem(placemark: MKPlacemark(coordinate: coordinate))
         destination.name = name
@@ -185,5 +225,11 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
             with: [source, destination],
             launchOptions: [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
         )
+    }
+
+    private func openAppleMapsAddress(_ address: String) {
+        guard let encoded = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)&dirflg=d") else { return }
+        UIApplication.shared.open(url)
     }
 }


### PR DESCRIPTION
### Motivation
- CarPlay should present the same user-scoped set of jobs that the phone dashboard shows (only jobs the signed-in technician created) rather than exposing other users' assignments.  
- The in-car list must respect the app's routing preference (closest-first vs farthest-first) and remain a safe, read-only dispatch surface that hands off directions to Maps.  
- Update documentation and behavior so CarPlay map handoff matches the dashboard's selected map provider and the CarPlay UI shows the same reference fields as the dashboard.

### Description
- Changed `CarPlayJobDispatchService` to fetch today's jobs via `fetchJobsAsync(for:)`, filter to jobs where `createdBy == currentUserID`, and expose a new `loadTodayDashboardJobs()` entry point in place of the former pending-job loader.  
- Added `UserDefaults` dependency inside `CarPlayJobDispatchService` and implemented `shouldSortClosest` so sorting honors the dashboard `routingOptimizeBy` preference and supports closest/farthest ordering during `sortedDisplays(...)`.  
- Updated `JobDispatchCarPlaySceneDelegate` to call `loadTodayDashboardJobs()`, refreshed copy/empty-state text to reference “dashboard jobs”, and expanded the detail screen to surface the same read-only reference fields the dashboard exposes (portal ID, materials, NID/Can footage, placement, notes, etc.).  
- Implemented Google Maps handoff with a fallback to Apple Maps (added `openGoogleMaps(...)`, `openAppleMaps(...)`, and `openAppleMapsAddress(...)`) and updated `openDirections(...)` logic to respect the `addressSuggestionProvider` setting.  
- Updated `Documentation/Features/CarPlay.md` to match the corrected ownership scope, routing preference behavior, read-only safety constraints, and map-provider handoff behavior.

### Testing
- Ran a repository sanity check with `git diff --check` and verified there were no whitespace or diff-check issues.  
- Performed targeted code searches with `rg` to verify changed symbols and copy (`loadTodayDashboardJobs`, `routingOptimizeBy`, and updated empty-state strings) are present in the codebase and docs.  
- Attempted to run `xcodebuild -list -project 'Job Tracker.xcodeproj'` to exercise an Xcode build listing, but `xcodebuild` is not available in this execution environment so an in-Xcode build/test verification was not performed.  
- Confirmed Swift tooling is present via `swift --version` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ae50302f0832daad6ad12320a7819)