### PR TITLE
Fix Swift concurrency and deprecation warnings

### DIFF
--- a/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
+++ b/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
@@ -61,11 +61,11 @@ final class CarPlayJobDispatchService {
     private let maxJobs = 12
 
     init(
-        locationProvider: CarPlayLocationProvider = .shared,
+        locationProvider: CarPlayLocationProvider? = nil,
         firebaseService: FirebaseService = .shared,
         defaults: UserDefaults = .standard
     ) {
-        self.locationProvider = locationProvider
+        self.locationProvider = locationProvider ?? .shared
         self.firebaseService = firebaseService
         self.defaults = defaults
     }
@@ -130,7 +130,7 @@ final class CarPlayJobDispatchService {
 }
 
 @MainActor
-final class CarPlayLocationProvider: NSObject, CLLocationManagerDelegate {
+final class CarPlayLocationProvider: NSObject, @preconcurrency CLLocationManagerDelegate {
     static let shared = CarPlayLocationProvider()
 
     private let manager = CLLocationManager()

--- a/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
+++ b/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
@@ -15,7 +15,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
         didConnect interfaceController: CPInterfaceController
     ) {
         self.interfaceController = interfaceController
-        interfaceController.setRootTemplate(loadingTemplate(), animated: false)
+        interfaceController.setRootTemplate(loadingTemplate(), animated: false, completion: nil)
         Task { await reloadJobs(animated: true) }
     }
 
@@ -47,7 +47,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
             )
         }
 
-        interfaceController?.setRootTemplate(template, animated: animated)
+        interfaceController?.setRootTemplate(template, animated: animated, completion: nil)
     }
 
     private func loadingTemplate() -> CPListTemplate {
@@ -160,7 +160,7 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
             title: display.title,
             sections: [CPListSection(items: details)]
         )
-        interfaceController?.pushTemplate(template, animated: true)
+        interfaceController?.pushTemplate(template, animated: true, completion: nil)
     }
 
     private func informationalItem(title: String, detail: String?) -> CPListItem {

--- a/Job Tracker/Features/Shared/Mapping/LeafletWebMapView.swift
+++ b/Job Tracker/Features/Shared/Mapping/LeafletWebMapView.swift
@@ -12,7 +12,7 @@ struct LeafletWebMapView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
-        configuration.preferences.javaScriptEnabled = true
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
         configuration.userContentController.add(context.coordinator, name: Coordinator.messageHandlerName)
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
@@ -127,7 +127,7 @@ struct LeafletWebMapView: UIViewRepresentable {
             guard let json = encode(command) else { return }
             let js = "FiberBridge.handleCommand({type: 'centerMap', payload: \(json)});"
             webView.evaluateJavaScript(js) { [weak self] _, _ in
-                Task { await self?.viewModel.acknowledgeCenterCommand() }
+                Task { @MainActor in self?.viewModel.acknowledgeCenterCommand() }
             }
         }
 

--- a/Job Tracker/intent/watchOS/PhoneWatchSyncManager.swift
+++ b/Job Tracker/intent/watchOS/PhoneWatchSyncManager.swift
@@ -91,8 +91,6 @@ final class PhoneWatchSyncManager: NSObject {
         guard let me = currentUserId() else { return [] }
 
         let today = Date()
-        let cal = Calendar.current
-
         return makeSnapshotItems(jobs: source, currentUserID: me, today: today)
     }
 


### PR DESCRIPTION
### Motivation
- Address several Swift compiler errors and Xcode warnings related to async/await usage, thrown calls, deprecated CarPlay/WebKit APIs, and Swift 6 actor-isolation concerns.  
- Prevent runtime issues and data-race risks from referencing a main-actor-isolated static `shared` property from nonisolated contexts.  
- Clean up a small unused local to remove a compiler warning and simplify watch sync snapshot code.

### Description
- Updated CarPlay template presentation calls to the iOS 14+ completion-handler APIs by calling `setRootTemplate(_:animated:completion:)` and `pushTemplate(_:animated:completion:)` to avoid the async/throwing overloads and deprecation warnings in `JobDispatchCarPlaySceneDelegate.swift`.  
- Changed `CarPlayJobDispatchService` initializer to accept an optional `locationProvider` and fall back to `.shared` inside the initializer to avoid defaulting to a main-actor-isolated static from a nonisolated context in `CarPlayJobDispatchService.swift`.  
- Marked the Core Location delegate conformance as `@preconcurrency` (`CarPlayLocationProvider: NSObject, @preconcurrency CLLocationManagerDelegate`) to resolve Swift 6 actor-isolation crossing concerns in `CarPlayJobDispatchService.swift`.  
- Replaced deprecated WebKit preference usage with `configuration.defaultWebpagePreferences.allowsContentJavaScript = true` and removed an unnecessary `await` by executing the acknowledgement on the main actor (`Task { @MainActor in self?.viewModel.acknowledgeCenterCommand() }`) in `LeafletWebMapView.swift`.  
- Removed an unused `let cal = Calendar.current` local from the watch snapshot builder in `PhoneWatchSyncManager.swift` to silence an unused-variable warning.

### Testing
- Ran `git diff --check` which passed locally after the changes.  
- Attempted to run `xcodebuild -list -project "Job Tracker.xcodeproj"` but `xcodebuild` was not available in this environment so a full Xcode build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aeb3f4468832db99716943890430d)