### PR TITLE
Prepare CarPlay entitlement request

### DIFF
--- a/Documentation/CarPlayEntitlementRequest.md
+++ b/Documentation/CarPlayEntitlementRequest.md
@@ -1,0 +1,49 @@
+# CarPlay Entitlement Request Packet
+
+Use this packet when submitting Job Tracker for Apple CarPlay entitlement review.
+
+## Recommended Request Category
+
+Request the **Driving Task** CarPlay category. Job Tracker is not a turn-by-turn navigation provider, media app, messaging app, parking app, EV charging app, or quick-ordering app. The CarPlay surface is limited to a short, read-only dispatch workflow that helps a technician choose the next assigned job and hand directions to Maps.
+
+Do **not** add a CarPlay entitlement key to `Job Tracker/Job Tracker.entitlements` before Apple approves the managed capability and the provisioning profile has been regenerated. Apple requires the entitlement in the App ID, provisioning profile, and app entitlements file to match after approval.
+
+## Copy/Paste Use-Case Summary
+
+> Job Tracker is a private field-service dispatch app for technicians who drive between assigned job sites. The CarPlay experience supports a driving task: it shows only today's jobs created by the signed-in technician, keeps the list capped and sorted by the technician's routing preference, and provides a single primary action to start driving directions through Maps. The CarPlay UI is read-only and excludes job editing, photo capture, messaging, chat, timesheets, admin tools, broad search, and any long-form workflow that should remain on iPhone.
+
+## In-App Evidence to Mention
+
+- The app registers one CarPlay scene named `JobDispatchCarPlay` that uses `CPTemplateApplicationScene` and `JobDispatchCarPlaySceneDelegate`.
+- CarPlay data comes from `CarPlayJobDispatchService`, which loads today's dashboard jobs for the signed-in user only and limits the display to twelve jobs.
+- The CarPlay detail view contains only driving-relevant reference fields and the `Start Directions` action.
+- The CarPlay implementation does not create a navigation map, turn-by-turn route engine, dashboard scene, instrument-cluster scene, media playback UI, chat UI, or editing UI.
+
+## Reviewer Demo Script
+
+1. Sign in on iPhone with a technician account that has jobs scheduled for the current day.
+2. Connect the app to the CarPlay Simulator from Xcode.
+3. Open Job Tracker on CarPlay.
+4. Confirm the first screen shows **Today's Jobs** with only the technician's own jobs.
+5. Select a job and confirm the detail screen is read-only.
+6. Tap **Start Directions** and confirm the app hands off driving directions to the selected Maps provider.
+7. Return to the iPhone app to demonstrate that editing, photos, chat, timesheets, admin tools, and search are not available in CarPlay.
+
+## Pre-Submission Checklist
+
+- [ ] Apple Developer Program account is active and the bundle ID matches `com.quinton.Job-Tracker-CS25`.
+- [ ] Request text uses the Driving Task positioning above and does not claim Job Tracker is a navigation app.
+- [ ] `Job Tracker/Job Tracker.entitlements` does not contain any CarPlay entitlement until Apple approves the managed capability.
+- [ ] Once Apple approves access, enable the approved CarPlay capability for the App ID, regenerate provisioning profiles, and then add only the approved entitlement key to the app entitlements file.
+- [ ] Run the CarPlay Simulator demo script and capture screenshots/video for the request if Apple asks for supporting material.
+- [ ] Verify the production build does not ship hard-coded service credentials in the app Info.plist.
+
+## Post-Approval Implementation Step
+
+After Apple grants the managed capability, add the exact approved entitlement key to `Job Tracker/Job Tracker.entitlements` as a Boolean `true`, update signing to use the regenerated provisioning profile, and build on a Mac with Xcode. If Apple grants a specific Driving Task entitlement that is not visible in Xcode's standard CarPlay capability list, use the exact key provided by Apple in the approval response/provisioning profile.
+
+## References
+
+- Apple Developer: [CarPlay](https://developer.apple.com/carplay/) describes Driving Task apps as a CarPlay-supported use case.
+- Apple Developer Documentation: [Requesting CarPlay Entitlements](https://developer.apple.com/documentation/carplay/requesting-carplay-entitlements) explains that CarPlay access is granted through managed capabilities and requires matching App ID, provisioning profile, and entitlements configuration after approval.
+- Apple Human Interface Guidelines: [CarPlay](https://developer.apple.com/design/human-interface-guidelines/carplay/) emphasizes simplified, driving-optimized interfaces with minimal interaction.

--- a/Documentation/Features/CarPlay.md
+++ b/Documentation/Features/CarPlay.md
@@ -7,7 +7,7 @@ The CarPlay experience is intentionally limited to safe, driving-focused job dis
 - Show only today's dashboard jobs created by the signed-in technician, matching the phone dashboard's ownership scope rather than exposing another user's jobs.
 - Sort jobs by current distance when location is available, honoring the dashboard routing preference for closest-first or furthest-first; fall back to scheduled time and address when distance is unavailable.
 - Limit the CarPlay list to twelve jobs after applying the routing preference so the in-car UI stays focused.
-- Provide a read-only job detail screen with a primary **Start Directions** action and the same core job reference fields the dashboard cards expose. Editing and adding info stay on the phone for CarPlay safety.
+- Provide a read-only job detail screen with a primary **Start Directions** action and only compact driving-relevant reference fields. Editing and adding info stay on the phone for CarPlay safety.
 - Open driving directions with the dashboard's selected map provider: Google Maps when selected and available, otherwise Apple Maps, using stored job coordinates and geocoding the address only when needed.
 - Keep editing, photos, chat, timesheets, admin tools, and long-form search out of CarPlay.
 
@@ -22,7 +22,9 @@ The CarPlay experience is intentionally limited to safe, driving-focused job dis
 
 ## Entitlement Strategy
 
-Apple grants CarPlay through managed capabilities after reviewing the app category and use case. The project now includes the CarPlay scene and implementation code, but the app entitlements file should not add a CarPlay entitlement until Apple approves the managed capability and the provisioning profile is regenerated.
+Apple grants CarPlay through managed capabilities after reviewing the app category and use case. The project includes the CarPlay scene and implementation code, but the app entitlements file must not add a CarPlay entitlement until Apple approves the managed capability and the provisioning profile is regenerated.
+
+Request the **Driving Task** category because Job Tracker provides a limited dispatch workflow for choosing a job destination and starting directions; it is not a turn-by-turn navigation app. Use the complete request packet in [CarPlayEntitlementRequest.md](../CarPlayEntitlementRequest.md) when submitting the request.
 
 Recommended request positioning:
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -7,6 +7,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 - [Admin](Features/Admin.md)
 - [Authentication](Features/Authentication.md)
 - [CarPlay Job Dispatch](Features/CarPlay.md)
+- [CarPlay Entitlement Request Packet](CarPlayEntitlementRequest.md)
 - [Forced App Updates](Features/AppUpdate.md)
 - [Dashboard](Features/Dashboard.md)
 - [Help](Features/Help.md)

--- a/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
+++ b/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
@@ -137,23 +137,11 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
         if let portalID = display.job.portalID?.trimmingCharacters(in: .whitespacesAndNewlines), !portalID.isEmpty {
             details.append(informationalItem(title: "Portal ID", detail: portalID))
         }
-        if let assignments = display.job.assignments?.trimmingCharacters(in: .whitespacesAndNewlines), !assignments.isEmpty {
+        if let assignments = compactDrivingDetail(display.job.assignments) {
             details.append(informationalItem(title: "Assignment", detail: assignments))
         }
-        if let materials = display.job.materialsUsed?.trimmingCharacters(in: .whitespacesAndNewlines), !materials.isEmpty {
-            details.append(informationalItem(title: "Materials", detail: materials))
-        }
-        if let nidFootage = display.job.nidFootage?.trimmingCharacters(in: .whitespacesAndNewlines), !nidFootage.isEmpty {
-            details.append(informationalItem(title: "NID Footage", detail: nidFootage))
-        }
-        if let canFootage = display.job.canFootage?.trimmingCharacters(in: .whitespacesAndNewlines), !canFootage.isEmpty {
-            details.append(informationalItem(title: "Can Footage", detail: canFootage))
-        }
-        if let placement = display.job.jobPlacement?.trimmingCharacters(in: .whitespacesAndNewlines), !placement.isEmpty {
+        if let placement = compactDrivingDetail(display.job.jobPlacement) {
             details.append(informationalItem(title: "Placement", detail: placement))
-        }
-        if let notes = display.job.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
-            details.append(informationalItem(title: "Notes", detail: notes))
         }
 
         let template = CPListTemplate(
@@ -161,6 +149,19 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
             sections: [CPListSection(items: details)]
         )
         interfaceController?.pushTemplate(template, animated: true, completion: nil)
+    }
+
+    private func compactDrivingDetail(_ value: String?, maxCharacters: Int = 80) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+
+        if trimmed.count <= maxCharacters {
+            return trimmed
+        }
+
+        let cutoff = trimmed.index(trimmed.startIndex, offsetBy: maxCharacters)
+        return String(trimmed[..<cutoff]).trimmingCharacters(in: .whitespacesAndNewlines) + "…"
     }
 
     private func informationalItem(title: String, detail: String?) -> CPListItem {

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -43,9 +43,9 @@
 			</array>
 		</dict>
 	</dict>
-<key>OPENAI_API_KEY</key>
-<string>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</string>
-<key>GEMINI_API_KEY</key>
-<string></string>
+	<key>OPENAI_API_KEY</key>
+	<string></string>
+	<key>GEMINI_API_KEY</key>
+	<string></string>
 </dict>
 </plist>

--- a/ci_scripts/carplay_entitlement_preflight.sh
+++ b/ci_scripts/carplay_entitlement_preflight.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INFO_PLIST="$ROOT_DIR/Job-Tracker-Info.plist"
+ENTITLEMENTS="$ROOT_DIR/Job Tracker/Job Tracker.entitlements"
+CARPLAY_DOC="$ROOT_DIR/Documentation/CarPlayEntitlementRequest.md"
+DELEGATE="$ROOT_DIR/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift"
+SERVICE="$ROOT_DIR/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift"
+
+fail() {
+  echo "❌ $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "✅ $1"
+}
+
+[[ -f "$INFO_PLIST" ]] || fail "Missing app Info.plist"
+[[ -f "$ENTITLEMENTS" ]] || fail "Missing app entitlements file"
+[[ -f "$CARPLAY_DOC" ]] || fail "Missing CarPlay entitlement request packet"
+[[ -f "$DELEGATE" ]] || fail "Missing CarPlay scene delegate"
+[[ -f "$SERVICE" ]] || fail "Missing CarPlay dispatch service"
+
+/usr/bin/python3 - <<PY
+import plistlib
+from pathlib import Path
+for path in [Path(r"$INFO_PLIST"), Path(r"$ENTITLEMENTS")]:
+    with path.open("rb") as fh:
+        plistlib.load(fh)
+PY
+pass "Info.plist and entitlements plist files parse successfully"
+
+rg -q "CPTemplateApplicationSceneSessionRoleApplication" "$INFO_PLIST" \
+  || fail "Info.plist does not register the CarPlay scene session role"
+rg -q "JobDispatchCarPlaySceneDelegate" "$INFO_PLIST" \
+  || fail "Info.plist does not point to JobDispatchCarPlaySceneDelegate"
+pass "CarPlay scene is registered in Info.plist"
+
+if rg -q "com\.apple\.developer\.carplay" "$ENTITLEMENTS"; then
+  fail "CarPlay entitlement is present before managed-capability approval"
+fi
+pass "No CarPlay entitlement is embedded before Apple approval"
+
+if /usr/bin/python3 - <<PY
+import plistlib
+from pathlib import Path
+info = plistlib.loads(Path(r"$INFO_PLIST").read_bytes())
+for key in ["OPENAI_API_KEY", "GEMINI_API_KEY"]:
+    value = info.get(key, "")
+    if isinstance(value, str) and value.strip():
+        raise SystemExit(1)
+PY
+then
+  pass "Info.plist does not contain hard-coded AI service credentials"
+else
+  fail "Info.plist contains a hard-coded AI service credential"
+fi
+
+rg -q "private let maxJobs = 12" "$SERVICE" \
+  || fail "CarPlay job list is not capped to twelve jobs"
+rg -q "createdBy == currentUserID" "$SERVICE" \
+  || fail "CarPlay service does not filter jobs to the signed-in user"
+pass "CarPlay dispatch service keeps the in-car list scoped and capped"
+
+if rg -q "ChatView|Timesheet|Admin|ImagePicker|Photo|PDFEditor|Search" "$DELEGATE"; then
+  fail "CarPlay delegate references a non-driving workflow"
+fi
+pass "CarPlay delegate stays focused on driving-task templates"
+
+pass "CarPlay entitlement request preflight passed"


### PR DESCRIPTION
### Motivation
- Prepare the app and documentation for submitting a CarPlay entitlement request with clear reviewer guidance and a focused driving-task UX.
- Reduce in-car distraction risk by keeping only compact, driving-relevant job details in the CarPlay UI.
- Remove embedded service credentials from shipped metadata to avoid exposing API keys during review. 
- Make entitlement preflight checks repeatable and automatable to catch issues before submission. 

### Description
- Add a CarPlay entitlement request packet at `Documentation/CarPlayEntitlementRequest.md` containing recommended request language, demo steps, checklist, post-approval guidance, and references. 
- Tighten the CarPlay detail UI in `Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift` by trimming long fields via a new `compactDrivingDetail` helper and omitting non-driving fields from the CarPlay detail list. 
- Clear hard-coded AI service credential values in `Job-Tracker-Info.plist` for `OPENAI_API_KEY` and `GEMINI_API_KEY`. 
- Add a preflight script `ci_scripts/carplay_entitlement_preflight.sh` that validates plist parsing, scene registration, absence of a pre-approved CarPlay entitlement, credential hygiene, job scoping/capping, and non-driving workflow references. 
- Update documentation by linking the new entitlement packet from `Documentation/Features/CarPlay.md` and adding it to `Documentation/README.md`. 

### Testing
- Ran the preflight script `./ci_scripts/carplay_entitlement_preflight.sh` and it completed successfully. 
- Validated plist parsing with `python3 -m plistlib 'Job-Tracker-Info.plist'` and `python3 -m plistlib 'Job Tracker/Job Tracker.entitlements'`, both succeeded. 
- Ran unit/emulator rules tests via `npm run test:firebase-rules` (Vitest) and the Firebase rules test suite passed. 
- Ran `git diff --check` and repository checks passed; `xcodebuild` was not available in this environment so native Xcode project validation must be run on a Mac with Xcode before final submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1de30a98832d89429bb94b7f9bfe)