### PR TITLE
Fix widget Info.plist build duplication

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -88,6 +88,16 @@
 		AA0000000000000000000002 /* Job Tracker Widgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Job Tracker Widgets.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		AA000000000000000000000C /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = AA0000000000000000000008 /* Job Tracker Widgets */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		CD1C8C782E5BBB140001CE7E /* Job Tracker Companion Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
@@ -111,6 +121,9 @@
 		};
 		AA0000000000000000000004 /* Job Tracker Widgets */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				AA000000000000000000000C /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */,
+			);
 			path = "Job Tracker Widgets";
 			sourceTree = "<group>";
 		};


### PR DESCRIPTION
### Motivation
- Xcode was producing a build conflict for `Job Tracker Widgets/Info.plist` because the file was both the target `INFOPLIST_FILE` and also included via the file-system synchronized group, causing `Multiple commands produce '.../Job Tracker Widgets.appex/Info.plist'`.

### Description
- Updated `Job Tracker.xcodeproj/project.pbxproj` to add a `PBXFileSystemSynchronizedBuildFileExceptionSet` that lists `Info.plist` under `membershipExceptions` for the `Job Tracker Widgets` target.
- Linked that exception set by adding an `exceptions` entry to the `Job Tracker Widgets` `PBXFileSystemSynchronizedRootGroup` so Xcode no longer treats the file as a synchronized membership item.
- This change keeps the target-level `INFOPLIST_FILE` setting for the widget unchanged so Xcode still uses the file as the extension Info.plist but no longer copies/duplicates it as a resource.

### Testing
- Ran `plutil -- "Job Tracker.xcodeproj/project.pbxproj"` and it reported the project file as `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c9432c57c832d9150852c0f1887ef)