### PR TITLE
Document iOS 26 and iPadOS 26 platform opportunities

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -29,6 +29,6 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 - The [Design System guide](../Job%20Tracker/DesignSystem/DesignSystem.md) documents shared colors, typography, glass cards, and button styles.
 - Tests under `Job TrackerTests/` demonstrate integration points for Firestore, search matching, and PDF exports. Reviewing the tests is a fast way to see expected behaviours for each feature's view model.
 
-- The [iOS 17–26 Opportunity Review](iOS26OpportunityReview.md) captures post-iOS-16 platform features that could benefit the app.
+- The [iOS 26 and iPadOS 26 Opportunity Review](iOS26OpportunityReview.md) captures iOS 26 and iPadOS 26 platform opportunities that could benefit the app.
 
 When you add a new feature module, place a matching Markdown file under `Documentation/Features/` and link it above. This keeps the engineering and product teams aligned on workflows, data contracts, and UI responsibilities.

--- a/Documentation/iOS26OpportunityReview.md
+++ b/Documentation/iOS26OpportunityReview.md
@@ -1,175 +1,341 @@
-# iOS 17–26 Opportunity Review
+# iOS 26 and iPadOS 26 Opportunity Review
 
-_Last reviewed: June 11, 2026_
+_Last reviewed: June 12, 2026_
 
-This review looks at Job Tracker's current iOS codebase and identifies Apple platform features introduced after iOS 16 that are most likely to benefit the app now that the original iOS 16 baseline is no longer the main constraint.
+This review maps the current Job Tracker codebase to Apple platform capabilities that are now practical because every iPhone/iPad target in the Xcode project is set to iOS/iPadOS 26.0 and the watch companion is set to watchOS 26.0. It focuses on features that can improve field-work speed, supervisor visibility, iPad productivity, privacy, and system-level discoverability.
 
-## Current project baseline
+## Review basis
 
-- The Xcode project still sets the iPhone deployment target to iOS 16.0 for the app and test targets, even though the README describes the product as an iOS 17+ / watchOS 10+ app.
-- The primary app is already a modern SwiftUI app with Firebase-backed jobs, timesheets, yellow sheets, partner chat, MapKit/Core Location routing, CarPlay dispatch, watchOS companion views, iMessage sharing, PDF export, and App Intents shortcuts.
-- Existing post-iOS-16-ready surfaces include App Intents, ShareLink/PDF export, MapKit search/completer flows, watch synchronization, and a Gemini-backed Splice Assist workflow.
+### Current app footprint
 
-## Best opportunities
+- **Supported platforms**: The main app, widgets, unit tests, and UI tests are configured with `IPHONEOS_DEPLOYMENT_TARGET = 26.0`; the app targets both iPhone and iPad; the watch app targets watchOS 26.0.
+- **Core workflow**: Firebase-backed jobs, dashboard routing, search, weekly timesheets, yellow sheets, partner pairing, chat, admin maintenance, forced updates, CarPlay dispatch, watch companion, iMessage sharing, PDF export, widgets, Live Activities, and App Intents.
+- **UI architecture**: A SwiftUI shell uses a `TabView` with `.sidebarAdaptable`, which is a strong base for iPhone tab navigation and iPad sidebars.
+- **System experiences already started**: The code already publishes a shared job snapshot to widgets, reloads WidgetKit timelines, and creates/updates an ActivityKit Live Activity for the active or next job.
+- **AI workflow already started**: Splice Assist currently sends image-backed prompts to Gemini, which creates an obvious migration/augmentation path for Apple Intelligence and Foundation Models.
 
-| Priority | Platform feature | Introduced after iOS 16 | Best fit in this project | Why it matters |
-| --- | --- | --- | --- | --- |
-| 1 | Live Activities + Dynamic Island | iOS 16.1, richer system adoption in later iOS releases | Dashboard, route-to-next-job, active job status, arrival alerts | Keeps the technician's active job, ETA, assignment, and status visible without opening the app. |
-| 2 | Widgets + interactive widgets + controls | Interactive widgets in iOS 17; Control Center / Lock Screen controls in later releases | Today's jobs, quick status updates, partner pairing, timesheet clock/status shortcuts | Turns frequent actions into one-tap entry points from Home Screen, Lock Screen, StandBy, Action button, or Control Center. |
-| 3 | App Intents schemas, entities, Spotlight indexing, and App Intents testing | Expanded substantially after iOS 16 and in the newest SDKs | Existing `CreateJobIntent`, `UpdateJobStatusIntent`, current-job intents, global job search | Lets Siri and Spotlight understand Job Tracker data naturally instead of relying only on fixed shortcut phrases. |
-| 4 | Foundation Models / Apple Intelligence integration | iOS 26+ SDK family | Splice Assist, job-sheet parsing, timesheet summarization, supervisor import cleanup | Could move parts of the current Gemini workflow on-device/private and reduce latency/cost for text extraction, summarization, and guided troubleshooting. |
-| 5 | MapKit for SwiftUI modernization | iOS 17+ | `MapsView`, route overlays, job search detail maps, fiber asset display | Replacing older UIKit/web-map wrappers where practical would simplify overlays, annotations, Look Around previews, selection, and route visualization. |
-| 6 | TipKit | iOS 17+ | Help center, onboarding tutorial, first-use prompts on dashboard/search/timesheets | Contextual tips can replace some custom tutorial plumbing while remaining system-consistent and suppressible. |
-| 7 | PhotosPicker + Transferable + Vision OCR | PhotosPicker in iOS 16, better fit once modernizing iOS 17+ code; Vision OCR continues to improve | Job photos, NID/CAN photos, yellow-sheet import, Splice Assist image intake | Safer photo-library privacy, better multi-select/import UX, and local text extraction before upload. |
-| 8 | Observation + SwiftData for local-only state | iOS 17+ | View models with heavy `@Published` usage, offline drafts, cached map assets, local timesheet drafts | Observation can reduce redraw overhead; SwiftData can store local drafts/caches while Firebase remains the source of truth. |
-| 9 | Liquid Glass / latest design system updates | iOS 26+ design language | App shell, dashboard cards, settings, navigation bars, icons | The app already has a custom glass design system, so it is well positioned for a visual refresh that feels native on iOS 26 while retaining brand colors. |
-| 10 | Passkeys / Sign in with Apple improvements | Mature post-iOS-16 adoption | Authentication | Reduces password-reset support, improves security, and aligns with platform expectations for field workers. |
+### Apple documentation consulted
+
+- [Liquid Glass overview](https://developer.apple.com/documentation/technologyoverviews/liquid-glass)
+- [Adopting Liquid Glass](https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass)
+- [SwiftUI Glass API](https://developer.apple.com/documentation/swiftui/glass)
+- [Foundation Models](https://developer.apple.com/documentation/FoundationModels)
+- [Apple Intelligence and Siri AI](https://developer.apple.com/documentation/appintents/apple-intelligence-and-siri-ai)
+- [Visual intelligence App Intents schema](https://developer.apple.com/documentation/appintents/app-schema-domain-visual-intelligence)
+- [Widgets, Live Activities, and Controls](https://developer.apple.com/documentation/appintents/widgets-and-live-activities)
+- [MapKit for SwiftUI](https://developer.apple.com/documentation/mapkit/mapkit-for-swiftui)
+- [Core Location live updates](https://developer.apple.com/documentation/corelocation/adopting-live-updates-in-core-location)
+- [PencilKit](https://developer.apple.com/documentation/pencilkit)
+
+## Executive priority list
+
+| Priority | Opportunity | Best project fit | Why it should be considered |
+| --- | --- | --- | --- |
+| 1 | Finish the iOS 26 system-experience layer | Widgets, Live Activity, App Intents, Control Center controls, Action button | The app already has shared snapshots, WidgetKit, ActivityKit, and App Intents; this is the fastest route to daily technician value. |
+| 2 | Adopt Liquid Glass intentionally | Design system, app shell, dashboard cards, tab/sidebar chrome, widget visual language | The app already has custom glass cards and gradients, so a focused refresh can feel native without rewriting every screen. |
+| 3 | Add App Entities, Spotlight indexing, Siri/Apple Intelligence schemas, and visual intelligence | Jobs, addresses, active assignments, supervisor notes, timesheets, yellow sheets | Current intents are action-oriented. iOS 26 can understand app content better if jobs and documents become indexed app entities. |
+| 4 | Add Foundation Models as a private/on-device AI tier | Splice Assist, job-note cleanup, timesheet summary, yellow-sheet QA, supervisor import validation | Splice Assist already proves the product need; Foundation Models can reduce latency and external API exposure for supported tasks. |
+| 5 | Modernize iPad workflows | Sidebar, multiwindow documents, resizable detail panes, keyboard shortcuts, drag and drop | The app now targets iPadOS 26 and has large document/form workflows that are better on iPad than in phone-first sheets. |
+| 6 | Upgrade mapping and location | MapKit for SwiftUI, route overlays, Look Around, Core Location live updates, arrival monitoring | Routing and dispatch are core to the product, and the current code mixes native location, Leaflet web maps, and MapKit search. |
+| 7 | Improve photo/PDF capture and annotation | PhotosPicker/Transferable, Vision OCR, PencilKit, PDFKit | Yellow sheets, timesheets, Splice Assist, and job photos all benefit from safer import, OCR, and Apple Pencil markup. |
+| 8 | Refactor state and local persistence | Observation, SwiftData local drafts/cache, async Firestore boundaries | The codebase has many `ObservableObject` view models; iOS 26-only support makes modern state and local draft storage easier to adopt gradually. |
+| 9 | Expand watchOS 26 companion value | Smart Stack relevance, watch actions, current job status, location-aware glance | The watch target exists and syncs daily job data; adding actions would reduce phone use on job sites. |
+| 10 | Strengthen privacy/security platform adoption | Passkeys, Sign in with Apple, App Privacy improvements, on-device AI fallback | Authentication is Firebase email/password today; passkeys and private AI align better with field-worker usage and sensitive job data. |
 
 ## Detailed recommendations
 
-### 1. Raise the deployment target intentionally
+### 1. Finish the system-experience layer
 
-The project should first decide whether the new supported minimum is iOS 17, iOS 18, or iOS 26. The best pragmatic move is usually:
+**Current state**
 
-1. Raise the minimum to **iOS 17** first, because it unlocks Observation, SwiftData, TipKit, MapKit for SwiftUI, and interactive widgets while leaving a broad install base.
-2. Add **iOS 18/26 availability-gated enhancements** for controls, Apple Intelligence, and Liquid Glass rather than requiring every user to be on the newest OS immediately.
-3. Update README/Xcode project alignment so documentation and build settings agree.
+- `JobSystemExperienceService` persists daily job snapshots to an app group, reloads WidgetKit timelines, and requests/updates a Live Activity for the active or next job.
+- The widget extension includes Today Jobs and Current Job widgets plus an ActivityKit configuration for the Live Activity.
+- The app already has App Intents for creating jobs, updating job status, getting today’s jobs, directions, nearest-job assignment/footage, and summaries.
 
-### 2. Add a Job Live Activity
+**Next features to add**
 
-Create a `JobTrackerLiveActivity` target using ActivityKit. Suggested states:
+1. **Control Center controls / Action button actions**
+   - Add controls for “Open next route,” “Mark current job done,” “Set nearest job assignment,” “Add footage,” and “Start arrival monitoring.”
+   - Reuse the existing App Intent resolver where possible.
+   - Require confirmation for destructive/status-changing actions.
 
-- active job address and assignment;
-- current status: pending, in progress, completed, issue reported;
-- ETA/distance if location permission is granted;
-- quick deep links for directions, call/message partner, and open the job detail;
-- arrival alert status.
+2. **Interactive widget actions**
+   - Add intent-backed buttons directly inside the Current Job widget: open route, mark done, message partner, copy address.
+   - Keep the widget read-only when the shared snapshot is stale or the user is signed out.
 
-This fits the existing dashboard and route/arrival-alert services. It would make the app much more useful while technicians are driving or working with gloves where opening the full app is inconvenient.
+3. **Richer Live Activity states**
+   - Include ETA, travel distance, arrival-monitoring status, partner assignment, and next required action.
+   - End the Live Activity automatically when the active job becomes done or when the day changes.
+   - Use deep links for job detail, dashboard, Maps directions, and partner chat.
 
-### 3. Add widgets and system controls
+4. **Testing**
+   - Expand `AppIntentEntryPointTests` to verify the new intents, stale snapshot behavior, and permission-denied location fallbacks.
 
-Recommended widgets/controls:
+**Risk**: Any action available outside the app needs conservative permission checks because WidgetKit/App Intents can execute while the full app UI is not visible.
 
-- **Today Jobs widget**: count of today's jobs, next address, current assignment, supervisor notes.
-- **Current Job widget**: active job card with status and directions deep link.
-- **Timesheet widget**: current week totals and submit/export status.
-- **Control Center / Action button control**: “Mark current job complete,” “Open next route,” “Add footage,” or “Start arrival monitoring.”
+### 2. Adopt Liquid Glass through the design system, not one-off screens
 
-The app already has App Intents for creating jobs, updating status, getting today’s jobs, directions, current assignment, and footage, so this work should extend existing intent code rather than starting from scratch.
+**Current state**
 
-### 4. Upgrade App Intents from shortcut phrases to entities and schemas
+- The app already defines a brand-specific design system (`JTColors`, `JTComponents`, theme presets, elevations, gradients, glass-card utilities).
+- The SwiftUI tab shell uses modern tab APIs and `.sidebarAdaptable`, giving iPadOS a natural place to pick up system navigation behavior.
 
-The current App Intents are useful but phrase-driven. A next-generation integration should add:
+**Next features to add**
 
-- `JobEntity` with stable IDs, address, scheduled date, status, assignment, and crew fields;
-- `JobEntityQuery` so Siri, Spotlight, widgets, and Shortcuts can resolve specific jobs;
-- indexed job entities for Spotlight results like “show the job on Main Street”;
-- parameter summaries and dialogs that make shortcuts easier to configure;
-- App Intents tests to validate Siri/Shortcuts behavior without full UI tests;
-- view annotations where supported so users can say things like “update this job” from a visible job detail screen.
+1. **Create a single `JTGlassSurface` abstraction**
+   - Wrap iOS 26 `glassEffect` in the design system.
+   - Apply it consistently to dashboard cards, more-menu cards, action buttons, and status HUDs.
+   - Keep a plain material fallback only if a future target adds lower OS support again.
 
-This is one of the highest leverage upgrades because the project already has many intent entry points.
+2. **Audit custom nav/background treatments**
+   - Build with the iOS 26 SDK and compare screens that use standard `NavigationStack`, `TabView`, `List`, `Toolbar`, and custom gradient backgrounds.
+   - Remove custom chrome where standard controls already receive Liquid Glass automatically.
 
-### 5. Build an Apple Intelligence path for Splice Assist
+3. **Refresh app icons and widget surfaces**
+   - Prepare icons using the current Apple icon guidance and align widget backgrounds with the new material style.
 
-Splice Assist currently sends cropped map images and prompts to Gemini. With the latest Apple Intelligence/Foundation Models direction, create a provider abstraction:
+**Risk**: Overusing custom glass can hurt readability. Prioritize hierarchy: navigation chrome first, primary action cards second, dense forms last.
 
-- keep Gemini as the cloud fallback for complex image reasoning;
-- add an Apple Foundation Models provider for eligible devices/OS versions;
-- use Vision OCR/barcode/text extraction locally before making any cloud call;
-- support “summarize this yellow sheet,” “extract assignment from photo,” and “draft supervisor notes” workflows;
-- add evaluation fixtures for common splice-map prompts so prompt and model changes can be tested.
+### 3. Make jobs real App Entities and index them for Spotlight/Siri
 
-This approach improves privacy and offline resilience while preserving existing functionality when Apple Intelligence is unavailable.
+**Current state**
 
-### 6. Modernize mapping incrementally
+- App Intents currently accept simple parameters such as address/job number/status rather than strongly typed app entities.
+- `JobIntentResolver` can find today’s nearest pending job using Core Location and Firebase.
 
-The app currently uses MapKit in several places and a Leaflet-backed web map for fiber assets. Do not rewrite the entire map surface at once. Instead:
+**Next features to add**
 
-- start with job detail/search maps using MapKit for SwiftUI markers, selection, polylines, and route previews;
-- add Look Around previews for job addresses where available;
-- keep Leaflet for dense fiber editing until native MapKit overlays can match the required editing workflow;
-- expose the same map data model to both renderers so the app can migrate screen by screen.
+1. **Define `JobEntity` and `JobEntityQuery`**
+   - Include job ID, address, short address, job number, status, assignment, scheduled date, participant names, and optional coordinate.
+   - Provide queries for today’s jobs, pending jobs, nearest job, recent crew jobs, and job-number lookup.
 
-### 7. Replace custom tutorial moments with TipKit where appropriate
+2. **Adopt assistant schemas where applicable**
+   - Map “open job,” “update job status,” “get current assignment,” “set assignment,” “get directions,” and “summarize current job” into schema-backed intents.
+   - Add onscreen context so a user can say “mark this one done” while viewing a job detail.
 
-The Help feature already has an interactive tutorial. TipKit is useful for smaller contextual prompts:
+3. **Index jobs and documents in Spotlight**
+   - Index current/recent jobs, yellow sheets, timesheets, and supervisor documents that the signed-in user is allowed to access.
+   - De-index on sign-out or role changes.
 
-- first time opening dashboard quick actions;
-- first time sharing a job;
-- first time adding CAN/NID footage;
-- first time cropping an image in Splice Assist;
-- first time exporting/submitting a timesheet.
+4. **Add visual intelligence search**
+   - Use the visual intelligence semantic content search schema so a technician can point the camera at a work order, house number, or NID/CAN label and search matching jobs.
+   - Return `JobEntity` results and route to job detail.
 
-Keep the full tutorial for onboarding, but use TipKit for lightweight reminders where a modal tutorial is too heavy.
+**Risk**: Spotlight and Siri integrations must respect Firebase security, user roles, partner scoping, and sign-out cleanup.
 
-### 8. Improve image intake and document extraction
+### 4. Add Foundation Models as an on-device/private AI tier
 
-Recommended improvements:
+**Current state**
 
-- replace `UIImagePickerController` wrappers with SwiftUI `PhotosPicker` where photo-library import is needed;
-- use `Transferable` models for job photo payloads and iMessage/share flows;
-- run Vision OCR locally on yellow sheets, NID labels, CAN labels, and splice-map crops;
-- pre-fill forms from OCR results while allowing technician confirmation before saving.
+- Splice Assist encodes an image and sends it with task-specific prompts to Gemini.
+- The current architecture already separates prompt generation in the view model from network execution in `GeminiService`.
 
-This should reduce typing in the field and improve data quality.
+**Next features to add**
 
-### 9. Add local-first drafts and caches
+1. **Introduce an `AIService` protocol**
+   - Keep Gemini as one implementation.
+   - Add a Foundation Models implementation for supported devices and tasks.
+   - Route requests by capability: on-device first for summarization/extraction, cloud model for unsupported multimodal or complex cases.
 
-Firebase should remain the server source of truth, but iOS 17+ local persistence can improve field reliability:
+2. **Start with low-risk structured outputs**
+   - Job-note cleanup.
+   - Timesheet week summary.
+   - Yellow-sheet missing-field checklist.
+   - Supervisor import validation.
+   - Fiber color/assignment extraction when confidence is high.
 
-- local job edit drafts before upload;
-- offline photo-upload queue metadata;
-- cached fiber map assets;
-- partially completed timesheets/yellow sheets;
-- last-known dashboard snapshot for no-service areas.
+3. **Use guided generation types**
+   - Define typed outputs such as `JobSummary`, `TimesheetIssue`, `YellowSheetMissingField`, and `SpliceAnalysisResult`.
+   - Store confidence and source text/image context for review.
 
-SwiftData is a candidate for these local-only records, but it should be introduced behind repository protocols so tests and Firebase sync remain clean.
+4. **Add evaluations**
+   - Build a small test corpus of real anonymized job notes, yellow-sheet samples, and splice images.
+   - Compare Gemini and Foundation Models responses before enabling automatic suggestions.
 
-### 10. Refresh design for iOS 26 without losing brand identity
+**Risk**: Field operations should not rely on unchecked AI. Keep all AI output reviewable, auditable, and easy to reject.
 
-The app already has design-system files and “glass” component language. A safe iOS 26 visual pass would:
+### 5. Make iPadOS 26 a first-class productivity surface
 
-- audit custom blur/material/elevation tokens against current system materials;
-- adopt new navigation/tab/sidebar behaviors where available;
-- refresh app icons through Apple's current icon tooling;
-- keep the current brand palette but reduce custom effects that conflict with system Liquid Glass.
+**Current state**
+
+- The app targets iPad and allows all iPad orientations.
+- The tab container already uses `.sidebarAdaptable`.
+- Timesheets, yellow sheets, maps, admin, and PDF review are naturally iPad-friendly workflows.
+
+**Next features to add**
+
+1. **Use split/detail layouts for dense workflows**
+   - Jobs/search: list of jobs on the left, selected job detail/map on the right.
+   - Timesheets: week/day list on the left, editable detail and PDF preview on the right.
+   - Yellow sheets: checklist sections on the left, PDF/annotation preview on the right.
+   - Admin: roster table on the left, selected-user flags/history on the right.
+
+2. **Add keyboard shortcuts**
+   - New job, search, next pending job, mark done, export PDF, open current route, switch tabs.
+
+3. **Add drag and drop**
+   - Drag job addresses into Maps/Messages.
+   - Drop images/PDFs into Splice Assist or Yellow Sheet attachments.
+
+4. **Evaluate multiwindow scenes**
+   - Let supervisors keep dashboard, maps, and admin open in separate windows on iPad.
+
+**Risk**: Avoid duplicating business logic. Build adaptive views over the same view models/services rather than separate iPad-only feature stacks.
+
+### 6. Modernize maps, routing, and arrival monitoring
+
+**Current state**
+
+- The shared mapping feature includes `MapsView`, `RouteService`, `LocationService`, `GeofenceService`, `ArrivalAlertManager`, and a `LeafletWebMapView` for fiber assets.
+- App Intents can find and route to the nearest job.
+
+**Next features to add**
+
+1. **Move job maps toward MapKit for SwiftUI**
+   - Use native annotations for jobs, crew, and selected assets.
+   - Use `MapPolyline` for routes and fiber spans where the geometry is available.
+   - Add Look Around previews for job addresses when available.
+
+2. **Use Core Location live updates for active route mode**
+   - Replace one-off location callbacks in active workflows with async location streams.
+   - Surface diagnostics when location updates are unavailable or throttled.
+
+3. **Tie arrival monitoring to Live Activities and controls**
+   - Starting arrival monitoring should update the Live Activity and expose a Stop/Resume action.
+   - Arrival should offer “mark in progress,” “open job,” or “notify partner.”
+
+4. **Keep Leaflet only where it is clearly better**
+   - If fiber asset data depends on web mapping/GeoJSON behaviors, keep Leaflet for that surface.
+   - Use native MapKit for routing, selected job detail, and user-location workflows.
+
+**Risk**: Location and background behavior can affect battery. Add explicit user controls and clear status copy.
+
+### 7. Upgrade photo import, OCR, PDF, and Apple Pencil workflows
+
+**Current state**
+
+- Job photos and Splice Assist use image pickers/Camera APIs.
+- Timesheets and yellow sheets generate PDFs, preview PDFs, and support editable PDF views.
+
+**Next features to add**
+
+1. **Use PhotosPicker + Transferable for photo import**
+   - Replace older picker wrappers where the source is the photo library.
+   - Keep camera capture for direct job-site photos.
+
+2. **Add Vision OCR pre-processing**
+   - Extract addresses, job numbers, CAN/NID labels, material codes, and supervisor notes from images before upload.
+   - Use extracted text as context for App Intents, Spotlight, and AI.
+
+3. **Improve iPad Apple Pencil support**
+   - Add PencilKit signatures and annotations for yellow sheets and timesheet sign-off.
+   - Keep PDFKit output as the final export artifact.
+
+4. **Add document quality checks**
+   - Warn if a signature is missing, required yellow-sheet fields are blank, or photos are too blurry/dark.
+
+**Risk**: OCR can create incorrect fields. Default to suggestions, not automatic overwrites.
+
+### 8. Gradually adopt Observation and SwiftData where they help
+
+**Current state**
+
+- Most view models use `ObservableObject`/`@Published` and Firebase listeners.
+- Firebase should remain the server source of truth.
+
+**Next features to add**
+
+1. **Observation for new/refactored local UI state**
+   - Start with self-contained screens: Help/Tutorials, Settings/Profile, Splice Assist, PDF editors.
+   - Avoid rewriting stable Firebase-heavy view models only for style.
+
+2. **SwiftData for local drafts and caches**
+   - Offline job creation drafts.
+   - Timesheet/yellow-sheet drafts.
+   - Recently viewed jobs.
+   - Cached fiber map metadata.
+   - AI result drafts awaiting technician approval.
+
+3. **Sync conflict policy**
+   - Store draft origin, last edited timestamp, Firebase document version, and conflict state.
+
+**Risk**: A local database plus Firestore can create conflicting sources of truth. Restrict SwiftData to drafts/cache until a full sync strategy exists.
+
+### 9. Expand watchOS 26 companion workflows
+
+**Current state**
+
+- The watch app uses WatchConnectivity and has dashboard/detail views for jobs.
+
+**Next features to add**
+
+1. **Current job glance**
+   - Show next pending job, assignment, distance, and status.
+
+2. **Watch App Intents/actions**
+   - Mark current job done.
+   - Open directions on phone.
+   - Notify partner.
+   - Add quick footage/status note.
+
+3. **Smart Stack relevance**
+   - Surface the current job near scheduled time or when arrival monitoring is active.
+
+**Risk**: Keep watch actions short and confirmation-friendly; detailed editing belongs on iPhone/iPad.
+
+### 10. Strengthen authentication and privacy
+
+**Current state**
+
+- The app uses Firebase Auth and role flags for admin/supervisor flows.
+- Sensitive field data includes locations, job assignments, photos, notes, timesheets, yellow sheets, and partner messages.
+
+**Next features to add**
+
+1. **Passkeys and Sign in with Apple**
+   - Add platform-native sign-in options alongside existing Firebase flows.
+   - Reduce password-reset friction for field crews.
+
+2. **Privacy-aware AI routing**
+   - Use on-device/Foundation Models for summaries and extraction where possible.
+   - Require explicit user action before sending job-site photos or notes to third-party AI.
+
+3. **Data lifecycle controls**
+   - On sign-out, clear app group snapshots, Spotlight indexes, cached SwiftData drafts that are not needed, and widget-visible data.
+
+**Risk**: System experiences can display stale/sensitive data after sign-out if app group stores and indexes are not cleared.
 
 ## Suggested implementation roadmap
 
-### Phase 1: Low-risk modernization
+### Phase 1 — Fast wins, low architectural risk
 
-- Align deployment target and README.
-- Add `JobEntity`/`JobEntityQuery` and App Intents tests.
-- Add a Today Jobs widget using existing data and intents.
-- Replace photo-library-only `UIImagePickerController` paths with `PhotosPicker`.
+1. Add intent-backed Control Center controls and Action button actions for next route and current job status.
+2. Extend the Current Job widget with safe interactive actions.
+3. Add Live Activity ETA/distance/arrival-monitoring state.
+4. Wrap iOS 26 Liquid Glass in `JTGlassSurface` and update the dashboard/app shell first.
+5. Clear app group/widget data on sign-out.
 
-### Phase 2: Field productivity
+### Phase 2 — Content intelligence and iPad workflows
 
-- Add Live Activity for current job.
-- Add Control Center/Action button controls for current-job actions.
-- Add OCR-assisted form/photo extraction.
-- Add TipKit prompts around high-friction flows.
+1. Add `JobEntity`, entity queries, and Spotlight indexing.
+2. Add onscreen App Intent context to job detail and current dashboard cards.
+3. Build iPad split layouts for search/jobs, timesheets, yellow sheets, and admin.
+4. Add PhotosPicker/Transferable and OCR for job photos/yellow sheets/Splice Assist.
+5. Add PencilKit signatures and annotation improvements.
 
-### Phase 3: Intelligent and native-feeling workflows
+### Phase 3 — AI and advanced mapping
 
-- Add Apple Intelligence/Foundation Models provider abstraction for Splice Assist and document summarization.
-- Add SwiftData local drafts/caches.
-- Migrate selected map screens to MapKit for SwiftUI.
-- Refresh the design system for iOS 26 materials and iconography.
+1. Add an `AIService` protocol with Gemini and Foundation Models implementations.
+2. Add guided-generation outputs and evaluations for Splice Assist and document QA.
+3. Move route/job maps to MapKit for SwiftUI where native maps fit.
+4. Add visual intelligence semantic content search for work orders, house numbers, CAN/NID labels, and job documents.
+5. Add SwiftData local drafts for offline timesheets/yellow sheets/jobs.
 
-## Features to defer
+## Decisions needed before implementation
 
-- A full rewrite from Firebase models to SwiftData. SwiftData is better here for local caches/drafts, not as a replacement for Firestore collaboration.
-- A full Leaflet-to-MapKit rewrite before validating native editing parity for fiber assets.
-- Requiring iOS 26 as the minimum immediately. Prefer iOS 17 minimum plus availability gates unless the actual user base is already nearly all on iOS 26+.
-- Image Playground/Genmoji integrations. They are interesting platform features, but they do not solve a core Job Tracker workflow as directly as Live Activities, widgets, intents, OCR, maps, or on-device assistance.
-
-## Apple references reviewed
-
-- Apple Developer: [What’s new in iOS](https://developer.apple.com/ios/whats-new/)
-- Apple Developer: [What’s new in Apple Intelligence](https://developer.apple.com/apple-intelligence/whats-new/)
-- Apple Developer Documentation: [App Intents](https://developer.apple.com/documentation/appintents/app-intents)
-- Apple Developer Documentation: [Widgets, Live Activities, and controls](https://developer.apple.com/documentation/appintents/widgets-and-live-activities)
-- Apple Developer Documentation: [MapKit for SwiftUI](https://developer.apple.com/documentation/mapkit/mapkit-for-swiftui)
+- Which system actions are safe to execute without opening the app?
+- Should status-changing widget/control actions require confirmation every time?
+- Which job data is allowed in Spotlight and widgets for each role?
+- Should Gemini remain the default AI backend, or should Foundation Models be the default when available?
+- Which iPad screens should support multiwindow first?
+- How long should local drafts, OCR text, and AI outputs be retained?


### PR DESCRIPTION
### Motivation
- Bring the project documentation up to date with the current deployment baseline (iOS/iPadOS 26 and watchOS 26) and record the platform features that unlock new product opportunities. 
- Provide a prioritized, actionable roadmap for system experiences (widgets, Live Activities, App Intents), Liquid Glass design adoption, App Entities/Spotlight/Siri, Foundation Models, iPad productivity, mapping, photo/PDF/OCR, local drafts, and privacy choices. 

### Description
- Rewrote and expanded `Documentation/iOS26OpportunityReview.md` to a comprehensive “iOS 26 and iPadOS 26 Opportunity Review” including review basis, priorities, detailed recommendations, phased roadmap, and decision prompts. 
- Updated `Documentation/README.md` to point to the refreshed review using the new title. 
- No runtime/source code changes were made; this PR is documentation-only and the changes were committed to the repo. 

### Testing
- Ran `git diff --check` which returned clean with no whitespace or merge errors (`git diff --check` succeeded). 
- Verified the documentation files were staged and committed successfully (`git commit` completed). 
- No unit, UI, or integration test suites were executed because the change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c95641038832d9ca8bca3ba5a4742)