### PR TITLE
Begin iOS 26 system experience implementation

### DIFF
--- a/Job Tracker Widgets/JobTrackerWidgets.swift
+++ b/Job Tracker Widgets/JobTrackerWidgets.swift
@@ -20,6 +20,23 @@ struct JobSystemSnapshot: Codable, Hashable {
         }
     }
 
+    struct ArrivalMonitoring: Codable, Hashable {
+        enum State: String, Codable, Hashable {
+            case inactive
+            case active
+            case warning
+            case error
+        }
+
+        var state: State
+        var message: String
+
+        static let inactive = ArrivalMonitoring(
+            state: .inactive,
+            message: "Arrival monitoring is off."
+        )
+    }
+
     var generatedAt: Date
     var selectedDate: Date
     var totalCount: Int
@@ -27,6 +44,7 @@ struct JobSystemSnapshot: Codable, Hashable {
     var completedCount: Int
     var nextJob: Item?
     var activeJob: Item?
+    var arrivalMonitoring: ArrivalMonitoring
     var jobs: [Item]
 
     static let empty = JobSystemSnapshot(
@@ -37,6 +55,7 @@ struct JobSystemSnapshot: Codable, Hashable {
         completedCount: 0,
         nextJob: nil,
         activeJob: nil,
+        arrivalMonitoring: .inactive,
         jobs: []
     )
 }
@@ -46,6 +65,8 @@ struct JobLiveActivityAttributes: ActivityAttributes {
         var status: String
         var etaText: String?
         var distanceText: String?
+        var arrivalMonitoringState: String?
+        var arrivalMonitoringMessage: String?
         var lastUpdated: Date
     }
 
@@ -64,6 +85,9 @@ private enum SharedStore {
         let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
         guard let data = defaults.data(forKey: snapshotKey),
               let snapshot = try? JSONDecoder.jobTrackerSystemExperiences.decode(JobSystemSnapshot.self, from: data) else {
+            return .empty
+        }
+        if Date().timeIntervalSince(snapshot.generatedAt) > 6 * 60 * 60 {
             return .empty
         }
         return snapshot
@@ -194,9 +218,15 @@ struct CurrentJobWidgetView: View {
                             .lineLimit(1)
                     }
                     Spacer(minLength: 0)
-                    Text("Open Job Tracker")
-                        .font(.caption2.bold())
-                        .foregroundStyle(.tint)
+                    if entry.snapshot.arrivalMonitoring.state == .active {
+                        Label("Monitoring arrivals", systemImage: "location.badge.checkmark")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.green)
+                    } else {
+                        Text("Open Job Tracker")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.tint)
+                    }
                 }
                 .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
             } else {
@@ -263,12 +293,17 @@ struct LiveActivityLockScreenView: View {
                 Text(context.attributes.shortAddress)
                     .font(.headline)
                     .lineLimit(1)
-                Text([context.attributes.assignment, context.state.distanceText, context.state.etaText]
-                    .compactMap { $0 }
-                    .joined(separator: " • "))
+                Text(routeStatusText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                if let monitoringMessage = context.state.arrivalMonitoringMessage,
+                   context.state.arrivalMonitoringState == "active" {
+                    Label(monitoringMessage, systemImage: "location.badge.checkmark")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                        .lineLimit(1)
+                }
             }
             Spacer()
             Text(context.state.status)
@@ -279,6 +314,13 @@ struct LiveActivityLockScreenView: View {
         }
         .padding()
         .widgetURL(URL(string: "jobtracker://job?id=\(context.attributes.jobID)"))
+    }
+
+    private var routeStatusText: String {
+        let text = [context.attributes.assignment, context.state.distanceText, context.state.etaText]
+            .compactMap { $0 }
+            .joined(separator: " • ")
+        return text.isEmpty ? context.state.status : text
     }
 }
 

--- a/Job Tracker/DesignSystem/JTComponents.swift
+++ b/Job Tracker/DesignSystem/JTComponents.swift
@@ -78,6 +78,41 @@ private struct JTNavigationBarModifier: ViewModifier {
     }
 }
 
+
+/// A reusable iOS 26 Liquid Glass surface for cards, HUDs, and action clusters.
+/// Keep custom glass centralized here so screens inherit system behavior consistently.
+@MainActor
+struct JTGlassSurface<Content: View>: View {
+    private let cornerRadius: CGFloat
+    private let strokeColor: Color
+    private let strokeWidth: CGFloat
+    private let shadow: JTShadow?
+    private let content: () -> Content
+
+    init(cornerRadius: CGFloat = JTShapes.cardCornerRadius,
+         strokeColor: Color? = nil,
+         strokeWidth: CGFloat = 1,
+         shadow: JTShadow? = JTElevations.card,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.cornerRadius = cornerRadius
+        self.strokeColor = strokeColor ?? JTColors.glassStroke
+        self.strokeWidth = strokeWidth
+        self.shadow = shadow
+        self.content = content
+    }
+
+    var body: some View {
+        let surface = content()
+            .jtGlassBackground(cornerRadius: cornerRadius, strokeColor: strokeColor, strokeWidth: strokeWidth)
+
+        if let shadow {
+            surface.jtShadow(shadow)
+        } else {
+            surface
+        }
+    }
+}
+
 /// Glass-morphism surface used for dashboard cards and detail panels.
 @MainActor
 struct GlassCard<Content: View>: View {
@@ -100,9 +135,13 @@ struct GlassCard<Content: View>: View {
     }
 
     var body: some View {
-        content()
-            .jtGlassBackground(cornerRadius: cornerRadius, strokeColor: strokeColor, strokeWidth: strokeWidth)
-            .jtShadow(shadow)
+        JTGlassSurface(
+            cornerRadius: cornerRadius,
+            strokeColor: strokeColor,
+            strokeWidth: strokeWidth,
+            shadow: shadow,
+            content: content
+        )
     }
 }
 

--- a/Job Tracker/Features/Authentication/AuthViewModel.swift
+++ b/Job Tracker/Features/Authentication/AuthViewModel.swift
@@ -133,6 +133,7 @@ class AuthViewModel: ObservableObject {
                 switch result {
                 case .success:
                     self?.stopCurrentUserListener()
+                    JobSystemExperienceService.shared.clearSensitiveSystemExperienceData()
                     self?.applyUser(nil)
                     completion(.success(()))
                 case .failure(let error):
@@ -144,6 +145,7 @@ class AuthViewModel: ObservableObject {
 
     func signOut() {
         if ProcessInfo.processInfo.isJobTrackerUITesting {
+            JobSystemExperienceService.shared.clearSensitiveSystemExperienceData()
             applyUser(nil)
             return
         }
@@ -151,6 +153,7 @@ class AuthViewModel: ObservableObject {
         do {
             stopCurrentUserListener()
             try FirebaseService.shared.signOutUser()
+            JobSystemExperienceService.shared.clearSensitiveSystemExperienceData()
             applyUser(nil)
         } catch {
             print("Sign-out error: \(error)")

--- a/Job Tracker/Features/Shared/Services/ArrivalAlertManager.swift
+++ b/Job Tracker/Features/Shared/Services/ArrivalAlertManager.swift
@@ -20,7 +20,9 @@ final class ArrivalAlertManager: ObservableObject {
         let message: String
     }
 
-    @Published private(set) var status: Status
+    @Published private(set) var status: Status {
+        didSet { publishSystemExperienceStatus() }
+    }
     @Published private(set) var authorizationStatus: UNAuthorizationStatus
 
     private let locationService: LocationService
@@ -302,6 +304,10 @@ final class ArrivalAlertManager: ObservableObject {
             monitoredJobIDs.remove(jobID)
             scheduleNotification(for: job)
             updateStatusForActiveMonitors()
+            JobSystemExperienceService.shared.publishArrivalMonitoring(
+                state: .active,
+                message: "Arrived at \(job.shortAddress). Update or open the job when ready."
+            )
         case .monitoringFailed(let identifier, let error):
             if let identifier, let jobID = jobID(fromRegionIdentifier: identifier) {
                 monitoredJobIDs.remove(jobID)
@@ -335,6 +341,25 @@ final class ArrivalAlertManager: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    private func publishSystemExperienceStatus() {
+        let state: JobSystemSnapshot.ArrivalMonitoring.State
+        switch status.kind {
+        case .inactive:
+            state = .inactive
+        case .active:
+            state = .active
+        case .warning:
+            state = .warning
+        case .error:
+            state = .error
+        }
+
+        JobSystemExperienceService.shared.publishArrivalMonitoring(
+            state: state,
+            message: status.message
+        )
+    }
 
     private var isNotificationAuthorized: Bool {
         switch authorizationStatus {

--- a/Job Tracker/Features/SystemExperiences/JobLiveActivityAttributes.swift
+++ b/Job Tracker/Features/SystemExperiences/JobLiveActivityAttributes.swift
@@ -6,6 +6,8 @@ struct JobLiveActivityAttributes: ActivityAttributes {
         var status: String
         var etaText: String?
         var distanceText: String?
+        var arrivalMonitoringState: String?
+        var arrivalMonitoringMessage: String?
         var lastUpdated: Date
     }
 

--- a/Job Tracker/Features/SystemExperiences/JobSystemExperienceService.swift
+++ b/Job Tracker/Features/SystemExperiences/JobSystemExperienceService.swift
@@ -16,7 +16,7 @@ final class JobSystemExperienceService {
     func publish(snapshot: JobSystemSnapshot) {
         persist(snapshot)
         WidgetCenter.shared.reloadAllTimelines()
-        Task { await updateLiveActivity(using: snapshot.activeJob ?? snapshot.nextJob) }
+        Task { await updateLiveActivity(using: snapshot.activeJob ?? snapshot.nextJob, monitoring: snapshot.arrivalMonitoring) }
     }
 
     func publish(jobs: [Job], selectedDate: Date, distanceStrings: [String: String] = [:]) {
@@ -26,6 +26,7 @@ final class JobSystemExperienceService {
         let items = dayJobs.map { JobSystemSnapshot.Item(job: $0, distanceText: distanceStrings[$0.id]) }
         let pending = items.filter(\.isPending)
         let completed = max(0, items.count - pending.count)
+        let existingMonitoring = loadSnapshot()?.arrivalMonitoring ?? .inactive
         let snapshot = JobSystemSnapshot(
             generatedAt: Date(),
             selectedDate: selectedDate,
@@ -34,6 +35,7 @@ final class JobSystemExperienceService {
             completedCount: completed,
             nextJob: pending.first ?? items.first,
             activeJob: pending.first,
+            arrivalMonitoring: existingMonitoring,
             jobs: Array(items.prefix(8))
         )
         publish(snapshot: snapshot)
@@ -42,8 +44,37 @@ final class JobSystemExperienceService {
     func publishStatusChange(job: Job, status: String, distanceText: String? = nil) {
         var item = JobSystemSnapshot.Item(job: job, distanceText: distanceText)
         item.status = CrewPosition.statusDisplayName(from: status)
-        Task { await updateLiveActivity(using: item) }
+        Task { await updateLiveActivity(using: item, monitoring: loadSnapshot()?.arrivalMonitoring ?? .inactive) }
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func publishArrivalMonitoring(state: JobSystemSnapshot.ArrivalMonitoring.State, message: String) {
+        let monitoring = JobSystemSnapshot.ArrivalMonitoring(state: state, message: message)
+        var snapshot = loadSnapshot() ?? .empty
+        snapshot.arrivalMonitoring = monitoring
+        snapshot.generatedAt = Date()
+        persist(snapshot)
+        WidgetCenter.shared.reloadAllTimelines()
+        Task { await updateLiveActivity(using: snapshot.activeJob ?? snapshot.nextJob, monitoring: monitoring) }
+    }
+
+    func clearSensitiveSystemExperienceData() {
+        let defaults = UserDefaults(suiteName: Self.appGroupIdentifier) ?? .standard
+        defaults.removeObject(forKey: Self.snapshotKey)
+        defaults.synchronize()
+        WidgetCenter.shared.reloadAllTimelines()
+        Task {
+            for activity in Activity<JobLiveActivityAttributes>.activities {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+            activeActivityID = nil
+        }
+    }
+
+    private func loadSnapshot() -> JobSystemSnapshot? {
+        let defaults = UserDefaults(suiteName: Self.appGroupIdentifier) ?? .standard
+        guard let data = defaults.data(forKey: Self.snapshotKey) else { return nil }
+        return try? JSONDecoder.jobTrackerSystemExperiences.decode(JobSystemSnapshot.self, from: data)
     }
 
     private func persist(_ snapshot: JobSystemSnapshot) {
@@ -52,7 +83,10 @@ final class JobSystemExperienceService {
         defaults.set(data, forKey: Self.snapshotKey)
     }
 
-    private func updateLiveActivity(using item: JobSystemSnapshot.Item?) async {
+    private func updateLiveActivity(
+        using item: JobSystemSnapshot.Item?,
+        monitoring: JobSystemSnapshot.ArrivalMonitoring = .inactive
+    ) async {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
         let existing = Activity<JobLiveActivityAttributes>.activities.first
         guard let item else {
@@ -67,6 +101,8 @@ final class JobSystemExperienceService {
             status: item.status,
             etaText: nil,
             distanceText: item.distanceText,
+            arrivalMonitoringState: monitoring.state.rawValue,
+            arrivalMonitoringMessage: monitoring.message,
             lastUpdated: Date()
         )
 
@@ -96,6 +132,14 @@ final class JobSystemExperienceService {
             print("[SystemExperiences] Live Activity request failed: \(error.localizedDescription)")
             #endif
         }
+    }
+}
+
+private extension JSONDecoder {
+    static var jobTrackerSystemExperiences: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
     }
 }
 

--- a/Job Tracker/Features/SystemExperiences/JobSystemSnapshot.swift
+++ b/Job Tracker/Features/SystemExperiences/JobSystemSnapshot.swift
@@ -17,6 +17,23 @@ struct JobSystemSnapshot: Codable, Hashable {
         }
     }
 
+    struct ArrivalMonitoring: Codable, Hashable {
+        enum State: String, Codable, Hashable {
+            case inactive
+            case active
+            case warning
+            case error
+        }
+
+        var state: State
+        var message: String
+
+        static let inactive = ArrivalMonitoring(
+            state: .inactive,
+            message: "Arrival monitoring is off."
+        )
+    }
+
     var generatedAt: Date
     var selectedDate: Date
     var totalCount: Int
@@ -24,6 +41,7 @@ struct JobSystemSnapshot: Codable, Hashable {
     var completedCount: Int
     var nextJob: Item?
     var activeJob: Item?
+    var arrivalMonitoring: ArrivalMonitoring
     var jobs: [Item]
 
     static let empty = JobSystemSnapshot(
@@ -34,6 +52,7 @@ struct JobSystemSnapshot: Codable, Hashable {
         completedCount: 0,
         nextJob: nil,
         activeJob: nil,
+        arrivalMonitoring: .inactive,
         jobs: []
     )
 }


### PR DESCRIPTION
### Motivation
- Surface iOS 26 system experiences (widgets, Live Activities, App Intents) with arrival-monitoring state so technicians get timely arrival prompts and supervisors see accurate status. 
- Consolidate Liquid Glass styling into a reusable surface to keep iOS 26 `glassEffect` usage consistent across the app. 
- Ensure sensitive system-experience data (app-group snapshots / Live Activities) is cleared on sign-out/account deletion to avoid stale exposure.

### Description
- Added a reusable `JTGlassSurface` and routed existing `GlassCard` rendering through it to centralize Liquid Glass behavior (`Job Tracker/DesignSystem/JTComponents.swift`).
- Extended the shared snapshot with `ArrivalMonitoring` state and updated `JobLiveActivityAttributes.ContentState` to include `arrivalMonitoringState` and `arrivalMonitoringMessage` so widgets and Live Activities can reflect arrival monitoring (`Job Tracker/Features/SystemExperiences/JobSystemSnapshot.swift`, `Job Tracker/Features/SystemExperiences/JobLiveActivityAttributes.swift`).
- Enhanced `JobSystemExperienceService` to persist/load arrival-monitoring, publish arrival-monitoring updates via `publishArrivalMonitoring`, include monitoring state when updating Live Activities, and provide `clearSensitiveSystemExperienceData` to clear app-group snapshots and end Live Activities (`Job Tracker/Features/SystemExperiences/JobSystemExperienceService.swift`).
- Integrated arrival-alert lifecycle into system experiences by publishing monitoring state from `ArrivalAlertManager` on status changes and region-entered events and by broadcasting status changes when monitors update (`Job Tracker/Features/Shared/Services/ArrivalAlertManager.swift`).
- Updated widget code to ignore stale snapshots, surface active arrival-monitoring in the Current Job widget and Live Activity UI, and add a compact `routeStatusText` helper for clearer display (`Job Tracker Widgets/JobTrackerWidgets.swift`).
- Clear sensitive widget/Live Activity data on account deletion and sign-out by invoking the new clearing API inside `AuthViewModel` (`Job Tracker/Features/Authentication/AuthViewModel.swift`).

### Testing
- Ran the repository Firebase rules tests with `npm run test:firebase-rules`, and they passed (1 test file executed, 1 passed, 3 skipped). 
- Ran `git diff --check` to ensure there were no whitespace/format issues and it passed. 
- Attempted to run the iOS XCTest suite via `xcodebuild ... test` but it could not run in this environment because `xcodebuild` is not available, so Xcode tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cab645f90832d9ea277e8d6f5a6e9)