### PR TITLE
Fix duplicate Xcode project object ID causing target-proxy lookup crash

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -89,7 +89,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		AA000000000000000000000C /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */ = {
+		AA000000000000000000000E /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -122,7 +122,7 @@
 		AA0000000000000000000004 /* Job Tracker Widgets */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				AA000000000000000000000C /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */,
+				AA000000000000000000000E /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */,
 			);
 			path = "Job Tracker Widgets";
 			sourceTree = "<group>";


### PR DESCRIPTION
### Motivation
- xcodebuild was crashing with an unrecognized selector on `remoteContainerItem` because a project object ID collision caused a `PBXTargetDependency` lookup to resolve to the wrong object type.
- The duplicate object ID appeared in the `Job Tracker` project file's filesystem-synchronized exception set for the widgets target, which can confuse Xcode's package/target dependency resolution.

### Description
- Updated `Job Tracker.xcodeproj/project.pbxproj` to assign a unique object ID to the `PBXFileSystemSynchronizedBuildFileExceptionSet` for the Job Tracker Widgets entry (replaced the old `...000C` ID with a new `...000E` ID in the exception-set definition).
- Updated the `Job Tracker Widgets` synchronized root group `exceptions` reference to point at the new exception-set ID while leaving the target dependency proxy ID unchanged.
- Changes are limited to the `project.pbxproj` file and only affect the two collided references that caused the type mix-up.

### Testing
- Ran a Python duplicate-ID check (`python3` script that scans `project.pbxproj` for duplicate 24-hex object IDs) and confirmed no duplicates were found after the change.
- Ran `git diff --check -- "Job Tracker.xcodeproj/project.pbxproj"` to verify there are no whitespace or diff-check issues (no problems reported).
- Attempted to run `xcodebuild -resolvePackageDependencies -project "Job Tracker.xcodeproj" -scheme "Job Tracker" -derivedDataPath /tmp/JobTrackerDerivedData -hideShellScriptEnvironment` but `xcodebuild` is not available in this environment, so dependency-resolution could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cc226b1c8832dbd66566489fc7a30)