### PR TITLE
Fix Xcode project dependency proxy UUID collision

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -89,7 +89,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		AA000000000000000000000C /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */ = {
+		AA000000000000000000000E /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -122,7 +122,7 @@
 		AA0000000000000000000004 /* Job Tracker Widgets */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				AA000000000000000000000C /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */,
+				AA000000000000000000000E /* Exceptions for "Job Tracker Widgets" folder in "Job Tracker Widgets" target */,
 			);
 			path = "Job Tracker Widgets";
 			sourceTree = "<group>";


### PR DESCRIPTION
### Motivation
- Prevent an Xcode crash during Swift Package resolution caused by a UUID collision in the project file where a `PBXTargetDependency` resolved its `targetProxy` to the wrong object type.

### Description
- Renamed the `PBXFileSystemSynchronizedBuildFileExceptionSet` object UUID from `AA000000000000000000000C` to `AA000000000000000000000E` in `Job Tracker.xcodeproj/project.pbxproj`.
- Updated the `Job Tracker Widgets` `PBXFileSystemSynchronizedRootGroup` `exceptions` reference to point at the new UUID so the `Info.plist` membership exclusion is preserved.
- Left the widget `PBXTargetDependency` `targetProxy` referencing the existing `PBXContainerItemProxy` unchanged.

### Testing
- Ran `plutil -lint -- "Job Tracker.xcodeproj/project.pbxproj"` and it returned `OK`.
- Ran a `python3` validation script that checks for duplicate object IDs and that every `targetProxy` resolves to `PBXContainerItemProxy`, and it passed with no issues.
- Attempted to run `xcodebuild -resolvePackageDependencies` but `xcodebuild` is not available in this environment so that step was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cc2a7d548832db70c3798db207ab7)