### PR TITLE
Fix iOS 26 MapKit coordinate lookup

### DIFF
--- a/Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift
@@ -23,9 +23,9 @@ enum MapKitGeocoding {
 
     static func coordinate(for mapItem: MKMapItem) -> CLLocationCoordinate2D? {
         if #available(iOS 26.0, *) {
-            return mapItem.location?.coordinate
+            return mapItem.location.coordinate
         } else {
-            return legacyCoordinate(for: mapItem)
+            return legacyPlacemarkCoordinate(for: mapItem)
         }
     }
 
@@ -36,8 +36,8 @@ enum MapKitGeocoding {
         application.open(url)
     }
 
-    @available(iOS, introduced: 2.0, obsoleted: 26.0, message: "Use MKMapItem.location instead.")
-    private static func legacyCoordinate(for mapItem: MKMapItem) -> CLLocationCoordinate2D? {
+    @available(iOS, introduced: 2.0, deprecated: 26.0, message: "Use MKMapItem.location instead.")
+    private static func legacyPlacemarkCoordinate(for mapItem: MKMapItem) -> CLLocationCoordinate2D? {
         mapItem.placemark.location?.coordinate
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure coordinate extraction uses the iOS 26+ `MKMapItem.location` API and isolate legacy `placemark` usage to pre-iOS-26 code paths to avoid unavailable/deprecated APIs and optional-chaining errors.

### Description
- Updated `Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift` so `coordinate(for:)` uses `mapItem.location.coordinate` when `#available(iOS 26.0, *)`, and renamed the legacy helper to `legacyPlacemarkCoordinate` marked `deprecated` for the pre-iOS-26 path to keep `placemark` usage isolated.

### Testing
- Ran `git diff --check` (clean), `swift --version` (reported Swift 6.1.3), and attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` which is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cccdc4510832d85d8e64012d9dee2)