### PR TITLE
Fix embedded bundle identifier prefixes and watch target product type

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -243,7 +243,7 @@
 			);
 			productName = "Job Tracker Companion Watch App";
 			productReference = CD1C8C772E5BBB140001CE7E /* Job Tracker Companion Watch App.app */;
-			productType = "com.apple.product-type.application";
+			productType = "com.apple.product-type.application.watchapp2";
 		};
 		CDDA111C2D579EC0007BADFF /* Job Tracker */ = {
 			isa = PBXNativeTarget;
@@ -843,7 +843,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -869,7 +869,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -889,7 +889,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 3.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25UITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.ui-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -909,7 +909,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 3.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25UITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.ui-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
### Motivation
- Xcode reported "Embedded binary's bundle identifier is not prefixed with the parent app's bundle identifier" because embedded targets used identifiers that were not dotted children of the main app identifier and the watch companion was declared as a generic application product type.
- The project needs embedded targets to use dotted bundle identifier prefixes under the parent `com.quinton.Job-Tracker-CS25` so App Store / Xcode validation accepts them.

### Description
- Change the companion watch target `productType` to `com.apple.product-type.application.watchapp2` in `Job Tracker.xcodeproj/project.pbxproj` so Xcode recognizes it as watch content.
- Update the unit test target `PRODUCT_BUNDLE_IDENTIFIER` from `com.quinton.Job-Tracker-CS25Tests` to `com.quinton.Job-Tracker-CS25.tests` in `Job Tracker.xcodeproj/project.pbxproj` so it is a dotted child of the app bundle ID.
- Update the UI test target `PRODUCT_BUNDLE_IDENTIFIER` from `com.quinton.Job-Tracker-CS25UITests` to `com.quinton.Job-Tracker-CS25.ui-tests` in `Job Tracker.xcodeproj/project.pbxproj` for the same prefix rule.

### Testing
- Ran `plutil -lint -- 'Job Tracker.xcodeproj/project.pbxproj' 'Job-Tracker-Info.plist' 'Job Tracker Widgets/Info.plist' 'imessage cs/Info.plist'` which returned `OK` for the files tested.
- Executed a `python3` validation script that verifies every `PRODUCT_BUNDLE_IDENTIFIER` is either equal to `com.quinton.Job-Tracker-CS25` or begins with `com.quinton.Job-Tracker-CS25.` and it reported all identifiers as `OK`.
- Ran `git diff --check` which produced no whitespace or diff errors.
- Attempted `xcodebuild` in this Linux container but `xcodebuild` is not available here, so a full Xcode build and signing validation should be run on macOS/Xcode to complete end-to-end verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ccf86fa88832d81683c9faa1837d9)