### PR TITLE
Fix watch app duplicate universal binary output

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -243,7 +243,7 @@
 			);
 			productName = "Job Tracker Companion Watch App";
 			productReference = CD1C8C772E5BBB140001CE7E /* Job Tracker Companion Watch App.app */;
-			productType = "com.apple.product-type.application.watchapp2";
+			productType = "com.apple.product-type.application";
 		};
 		CDDA111C2D579EC0007BADFF /* Job Tracker */ = {
 			isa = PBXNativeTarget;


### PR DESCRIPTION
### Motivation
- Prevent Xcode from producing duplicate CreateUniversalBinary outputs for the companion Watch app by correcting the target product type to the generic application type.

### Description
- Change `productType` for the "Job Tracker Companion Watch App" target in `Job Tracker.xcodeproj/project.pbxproj` from `com.apple.product-type.application.watchapp2` to `com.apple.product-type.application`.

### Testing
- Ran `git diff --check` and a search with `rg -n 'productType = "com\.apple\.product-type\.application";|productType = "com\.apple\.product-type\.application\.watchapp2";' Job Tracker.xcodeproj/project.pbxproj` which show the updated product type; `xcodebuild -list -project 'Job Tracker.xcodeproj'` could not be executed because `xcodebuild` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cd1a9c798832d9811d56361f0e846)