### PR TITLE
Improve job widgets and live activities

### DIFF
--- a/Job Tracker Widgets/JobTrackerWidgets.swift
+++ b/Job Tracker Widgets/JobTrackerWidgets.swift
@@ -146,51 +146,172 @@ struct TodayJobsWidgetView: View {
     @Environment(\.widgetFamily) private var family
     let entry: JobSnapshotEntry
 
+    private var completionRatio: Double {
+        guard entry.snapshot.totalCount > 0 else { return 0 }
+        return Double(entry.snapshot.completedCount) / Double(entry.snapshot.totalCount)
+    }
+
+    private var pendingLabel: String {
+        entry.snapshot.pendingCount == 1 ? "1 pending" : "\(entry.snapshot.pendingCount) pending"
+    }
+
+    private var dateLabel: String {
+        if Calendar.current.isDateInToday(entry.snapshot.selectedDate) {
+            return "Today"
+        }
+        return entry.snapshot.selectedDate.formatted(.dateTime.weekday(.abbreviated).month(.abbreviated).day())
+    }
+
     var body: some View {
         switch family {
         case .accessoryRectangular:
             accessoryBody
+        case .systemMedium:
+            mediumBody
         default:
-            VStack(alignment: .leading, spacing: 8) {
-                Label("Today", systemImage: "calendar")
-                    .font(.caption.bold())
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text("\(entry.snapshot.pendingCount)")
-                        .font(.system(size: 36, weight: .heavy, design: .rounded))
-                    Text("pending")
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                }
-                if let next = entry.snapshot.nextJob {
-                    Divider()
-                    Text(next.shortAddress)
-                        .font(.headline)
-                        .lineLimit(1)
-                    Text(next.assignment ?? next.status)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                } else {
-                    Spacer()
-                    Text("No jobs scheduled")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .widgetURL(URL(string: "jobtracker://dashboard"))
+            smallBody
         }
     }
 
-    private var accessoryBody: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text("Today")
-                Text("\(entry.snapshot.pendingCount) pending")
+    private var smallBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Text("\(entry.snapshot.pendingCount)")
+                    .font(.system(size: 38, weight: .heavy, design: .rounded))
+                    .contentTransition(.numericText())
+                Text("left")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
             }
-            Spacer()
-            Image(systemName: "briefcase.fill")
+            progressBar
+            if let next = entry.snapshot.nextJob {
+                nextStopSummary(next)
+            } else {
+                emptyState
+            }
         }
         .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+
+    private var mediumBody: some View {
+        HStack(alignment: .top, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                header
+                Text(pendingLabel)
+                    .font(.title2.bold())
+                Text("\(entry.snapshot.completedCount) done • \(entry.snapshot.totalCount) total")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                progressBar
+                arrivalMonitoringBadge
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 8) {
+                if let next = entry.snapshot.nextJob {
+                    Text("NEXT STOP")
+                        .font(.caption2.bold())
+                        .foregroundStyle(.secondary)
+                    nextStopSummary(next)
+                    if let second = entry.snapshot.jobs.dropFirst().first {
+                        Divider()
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.turn.down.right")
+                                .font(.caption2)
+                            Text(second.shortAddress)
+                                .font(.caption)
+                                .lineLimit(1)
+                        }
+                        .foregroundStyle(.secondary)
+                    }
+                } else {
+                    emptyState
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+
+    private var accessoryBody: some View {
+        HStack(spacing: 8) {
+            Image(systemName: entry.snapshot.pendingCount == 0 ? "checkmark.seal.fill" : "briefcase.fill")
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(dateLabel): \(pendingLabel)")
+                    .font(.headline)
+                Text(entry.snapshot.nextJob?.shortAddress ?? "All caught up")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Label(dateLabel, systemImage: "calendar.badge.clock")
+                .font(.caption.bold())
+            Spacer(minLength: 0)
+            Text(entry.snapshot.generatedAt, style: .time)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var progressBar: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(.white.opacity(0.22))
+                Capsule()
+                    .fill(entry.snapshot.pendingCount == 0 ? .green : .orange)
+                    .frame(width: max(6, proxy.size.width * completionRatio))
+            }
+        }
+        .frame(height: 6)
+        .accessibilityLabel("\(entry.snapshot.completedCount) of \(entry.snapshot.totalCount) jobs complete")
+    }
+
+    @ViewBuilder
+    private var arrivalMonitoringBadge: some View {
+        switch entry.snapshot.arrivalMonitoring.state {
+        case .active:
+            Label("Arrival alerts on", systemImage: "location.badge.checkmark")
+                .foregroundStyle(.green)
+                .font(.caption2.bold())
+        case .warning, .error:
+            Label("Check arrival alerts", systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+                .font(.caption2.bold())
+        case .inactive:
+            EmptyView()
+        }
+    }
+
+    private func nextStopSummary(_ job: JobSystemSnapshot.Item) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(job.shortAddress)
+                .font(.headline)
+                .lineLimit(2)
+            Text([job.assignment, job.distanceText, job.jobNumber].compactMap { $0 }.joined(separator: " • "))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            Text("All caught up")
+                .font(.headline)
+            Text("No pending jobs for this day")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 
@@ -202,45 +323,148 @@ struct CurrentJobWidgetView: View {
         entry.snapshot.activeJob ?? entry.snapshot.nextJob
     }
 
+    private var statusColor: Color {
+        switch entry.snapshot.arrivalMonitoring.state {
+        case .active: return .green
+        case .warning: return .yellow
+        case .error: return .red
+        case .inactive: return job?.isPending == true ? .orange : .blue
+        }
+    }
+
     var body: some View {
         Group {
             if let job {
-                VStack(alignment: .leading, spacing: 8) {
-                    Label(job.status, systemImage: job.isPending ? "location.fill" : "checkmark.circle.fill")
-                        .font(.caption.bold())
-                    Text(job.shortAddress)
-                        .font(family == .systemSmall ? .headline : .title3.bold())
-                        .lineLimit(2)
-                    if family != .accessoryRectangular {
-                        Text([job.assignment, job.distanceText].compactMap { $0 }.joined(separator: " • "))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    Spacer(minLength: 0)
-                    if entry.snapshot.arrivalMonitoring.state == .active {
-                        Label("Monitoring arrivals", systemImage: "location.badge.checkmark")
-                            .font(.caption2.bold())
-                            .foregroundStyle(.green)
-                    } else {
-                        Text("Open Job Tracker")
-                            .font(.caption2.bold())
-                            .foregroundStyle(.tint)
-                    }
+                switch family {
+                case .accessoryRectangular:
+                    accessoryBody(job)
+                case .systemMedium:
+                    mediumBody(job)
+                default:
+                    smallBody(job)
                 }
-                .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
             } else {
-                VStack(alignment: .leading) {
-                    Image(systemName: "checkmark.seal.fill")
-                    Text("All caught up")
-                        .font(.headline)
-                    Text("No active job")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .widgetURL(URL(string: "jobtracker://dashboard"))
+                noJobBody
             }
         }
+    }
+
+    private func smallBody(_ job: JobSystemSnapshot.Item) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            statusPill(job)
+            Text(job.shortAddress)
+                .font(.headline)
+                .lineLimit(2)
+            Text(job.assignment ?? job.jobNumber ?? "Open Job Tracker for details")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+            footer(job)
+        }
+        .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
+    }
+
+    private func mediumBody(_ job: JobSystemSnapshot.Item) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                statusPill(job)
+                Text(job.shortAddress)
+                    .font(.title3.bold())
+                    .lineLimit(2)
+                Text([job.assignment, job.jobNumber].compactMap { $0 }.joined(separator: " • "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                footer(job)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 7) {
+                metricTile(icon: "point.topleft.down.curvedto.point.bottomright.up", title: "Distance", value: job.distanceText ?? "Open map")
+                metricTile(icon: "clock", title: "Scheduled", value: job.scheduledDate.formatted(.dateTime.hour().minute()))
+                metricTile(icon: "bell.badge", title: "Alerts", value: alertSummary)
+            }
+            .frame(width: 125)
+        }
+        .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
+    }
+
+    private func accessoryBody(_ job: JobSystemSnapshot.Item) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: entry.snapshot.arrivalMonitoring.state == .active ? "location.badge.checkmark" : "location.fill")
+                .foregroundStyle(statusColor)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(job.shortAddress)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text([job.status, job.distanceText].compactMap { $0 }.joined(separator: " • "))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
+    }
+
+    private func statusPill(_ job: JobSystemSnapshot.Item) -> some View {
+        Label(job.status, systemImage: job.isPending ? "figure.walk" : "checkmark.circle.fill")
+            .font(.caption.bold())
+            .foregroundStyle(statusColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(statusColor.opacity(0.16), in: Capsule())
+    }
+
+    private func metricTile(icon: String, title: String, value: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .frame(width: 18)
+                .foregroundStyle(statusColor)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.caption.bold())
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private func footer(_ job: JobSystemSnapshot.Item) -> some View {
+        Label(alertSummary, systemImage: entry.snapshot.arrivalMonitoring.state == .inactive ? "arrow.up.forward.app" : "location.badge.checkmark")
+            .font(.caption2.bold())
+            .foregroundStyle(statusColor)
+            .lineLimit(1)
+    }
+
+    private var alertSummary: String {
+        switch entry.snapshot.arrivalMonitoring.state {
+        case .active: return "Arrival alerts on"
+        case .warning: return "Needs attention"
+        case .error: return "Alert issue"
+        case .inactive: return "Tap for job"
+        }
+    }
+
+    private var noJobBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.title2)
+                .foregroundStyle(.green)
+            Text("All caught up")
+                .font(.headline)
+            Text("No active or pending job")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            Text("Updated \(entry.snapshot.generatedAt.formatted(date: .omitted, time: .shortened))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .widgetURL(URL(string: "jobtracker://dashboard"))
     }
 }
 
@@ -253,28 +477,50 @@ struct JobLiveActivityWidget: Widget {
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    Label(context.state.status, systemImage: "briefcase.fill")
-                        .font(.caption.bold())
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.state.distanceText ?? context.state.etaText ?? "Active")
-                        .font(.caption)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(context.attributes.shortAddress)
-                            .font(.headline)
-                        Text(context.attributes.assignment ?? context.attributes.jobNumber ?? "Open Job Tracker")
-                            .font(.caption)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Label(context.state.status, systemImage: liveActivityIcon(for: context))
+                            .font(.caption.bold())
+                        Text(context.attributes.scheduledDate, style: .time)
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                 }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack(alignment: .trailing, spacing: 3) {
+                        Text(context.state.distanceText ?? context.state.etaText ?? "Active")
+                            .font(.caption.bold())
+                        Text(context.state.lastUpdated, style: .time)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(context.attributes.shortAddress)
+                            .font(.headline)
+                            .lineLimit(1)
+                        HStack(spacing: 8) {
+                            Text(context.attributes.assignment ?? context.attributes.jobNumber ?? "Open Job Tracker")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                            Label(liveActivityAlertText(for: context), systemImage: "bell.badge")
+                                .font(.caption2.bold())
+                                .foregroundStyle(liveActivityTint(for: context))
+                        }
+                    }
+                }
             } compactLeading: {
-                Image(systemName: "briefcase.fill")
+                Image(systemName: liveActivityIcon(for: context))
+                    .foregroundStyle(liveActivityTint(for: context))
             } compactTrailing: {
-                Text(context.state.status.prefix(1))
+                Text(context.state.distanceText ?? String(context.state.status.prefix(3)))
+                    .font(.caption2.bold())
+                    .lineLimit(1)
             } minimal: {
-                Image(systemName: "location.fill")
+                Image(systemName: liveActivityIcon(for: context))
+                    .foregroundStyle(liveActivityTint(for: context))
             }
             .widgetURL(URL(string: "jobtracker://job?id=\(context.attributes.jobID)"))
         }
@@ -285,32 +531,39 @@ struct LiveActivityLockScreenView: View {
     let context: ActivityViewContext<JobLiveActivityAttributes>
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "location.north.line.fill")
-                .font(.title2)
-                .foregroundStyle(.blue)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(context.attributes.shortAddress)
-                    .font(.headline)
-                    .lineLimit(1)
-                Text(routeStatusText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                if let monitoringMessage = context.state.arrivalMonitoringMessage,
-                   context.state.arrivalMonitoringState == "active" {
-                    Label(monitoringMessage, systemImage: "location.badge.checkmark")
-                        .font(.caption2)
-                        .foregroundStyle(.green)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Image(systemName: liveActivityIcon(for: context))
+                    .font(.title2)
+                    .foregroundStyle(liveActivityTint(for: context))
+                    .frame(width: 34, height: 34)
+                    .background(liveActivityTint(for: context).opacity(0.16), in: Circle())
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(context.attributes.shortAddress)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text(routeStatusText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
+                Spacer()
+                Text(context.state.status)
+                    .font(.caption.bold())
+                    .foregroundStyle(liveActivityTint(for: context))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(liveActivityTint(for: context).opacity(0.16), in: Capsule())
             }
-            Spacer()
-            Text(context.state.status)
-                .font(.caption.bold())
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .background(.thinMaterial, in: Capsule())
+
+            HStack(spacing: 10) {
+                Label(context.attributes.scheduledDate.formatted(date: .omitted, time: .shortened), systemImage: "clock")
+                Label(liveActivityAlertText(for: context), systemImage: "bell.badge")
+                Spacer(minLength: 0)
+                Text("Updated \(context.state.lastUpdated.formatted(date: .omitted, time: .shortened))")
+            }
+            .font(.caption2.bold())
+            .foregroundStyle(.secondary)
         }
         .padding()
         .widgetURL(URL(string: "jobtracker://job?id=\(context.attributes.jobID)"))
@@ -322,6 +575,30 @@ struct LiveActivityLockScreenView: View {
             .joined(separator: " • ")
         return text.isEmpty ? context.state.status : text
     }
+}
+
+private func liveActivityTint(for context: ActivityViewContext<JobLiveActivityAttributes>) -> Color {
+    switch context.state.arrivalMonitoringState {
+    case "active": return .green
+    case "warning": return .yellow
+    case "error": return .red
+    default: return .blue
+    }
+}
+
+private func liveActivityIcon(for context: ActivityViewContext<JobLiveActivityAttributes>) -> String {
+    switch context.state.arrivalMonitoringState {
+    case "active": return "location.badge.checkmark"
+    case "warning", "error": return "exclamationmark.triangle.fill"
+    default: return "location.north.line.fill"
+    }
+}
+
+private func liveActivityAlertText(for context: ActivityViewContext<JobLiveActivityAttributes>) -> String {
+    guard let message = context.state.arrivalMonitoringMessage, !message.isEmpty else {
+        return "Tap for job"
+    }
+    return message
 }
 
 @main


### PR DESCRIPTION
### Motivation
- Make Home Screen widgets and Live Activities provide more actionable, glanceable information (progress, next stop, alerts) rather than a bland summary.
- Surface arrival-monitoring state, schedule and freshness so drivers can quickly see if action is required.

### Description
- Overhauled `TodayJobsWidget` layouts with family-specific views (`small`, `medium`, `accessoryRectangular`), added a completion progress bar, generated-time header, improved next-stop summary and a second-stop hint. The view now shows arrival-monitoring badges and a clearer empty state. (file: `Job Tracker Widgets/JobTrackerWidgets.swift`)
- Reworked `CurrentJobWidget` to use family-specific layouts, added `statusPill` and `statusColor`, metric tiles (distance, scheduled time, alerts), improved accessory layout, and a more informative empty state and footer. (file: `Job Tracker Widgets/JobTrackerWidgets.swift`)
- Enhanced Live Activity / Dynamic Island UI with scheduled and last-updated times, distance/ETA emphasis, alert context, and state-aware icons/tinting via helper functions `liveActivityTint`, `liveActivityIcon`, and `liveActivityAlertText`. Also improved the lock-screen activity view layout and routing text. (file: `Job Tracker Widgets/JobTrackerWidgets.swift`)
- Small quality-of-life additions: accessibility label for progress, numeric content transition for pending count, consistent `widgetURL` deep links, and layout refinements across widget families. (file: `Job Tracker Widgets/JobTrackerWidgets.swift`)

### Testing
- Parsed the updated widget file with `swiftc -parse 'Job Tracker Widgets/JobTrackerWidgets.swift'`, which succeeded.
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` but it could not run in this environment because `xcodebuild` is not installed, so full Xcode build/Target tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d75cbf87c832da4bc44ccfd4638c4)