### PR TITLE
Enhance widgets and live activity with richer job fields and improved UI/actions

### DIFF
--- a/Job Tracker Widgets/JobTrackerWidgets.swift
+++ b/Job Tracker Widgets/JobTrackerWidgets.swift
@@ -12,6 +12,10 @@ struct JobSystemSnapshot: Codable, Hashable {
         var assignment: String?
         var jobNumber: String?
         var notes: String?
+        var materialsUsed: String?
+        var nidFootage: String?
+        var canFootage: String?
+        var jobPlacement: String?
         var scheduledDate: Date
         var distanceText: String?
 
@@ -146,51 +150,181 @@ struct TodayJobsWidgetView: View {
     @Environment(\.widgetFamily) private var family
     let entry: JobSnapshotEntry
 
+    private var completionRatio: Double {
+        guard entry.snapshot.totalCount > 0 else { return 0 }
+        return Double(entry.snapshot.completedCount) / Double(entry.snapshot.totalCount)
+    }
+
+    private var pendingLabel: String {
+        entry.snapshot.pendingCount == 1 ? "1 pending" : "\(entry.snapshot.pendingCount) pending"
+    }
+
+    private var dateLabel: String {
+        if Calendar.current.isDateInToday(entry.snapshot.selectedDate) {
+            return "Today"
+        }
+        return entry.snapshot.selectedDate.formatted(.dateTime.weekday(.abbreviated).month(.abbreviated).day())
+    }
+
     var body: some View {
         switch family {
         case .accessoryRectangular:
             accessoryBody
+        case .systemMedium:
+            mediumBody
         default:
-            VStack(alignment: .leading, spacing: 8) {
-                Label("Today", systemImage: "calendar")
-                    .font(.caption.bold())
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text("\(entry.snapshot.pendingCount)")
-                        .font(.system(size: 36, weight: .heavy, design: .rounded))
-                    Text("pending")
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                }
-                if let next = entry.snapshot.nextJob {
-                    Divider()
-                    Text(next.shortAddress)
-                        .font(.headline)
-                        .lineLimit(1)
-                    Text(next.assignment ?? next.status)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                } else {
-                    Spacer()
-                    Text("No jobs scheduled")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .widgetURL(URL(string: "jobtracker://dashboard"))
+            smallBody
         }
     }
 
-    private var accessoryBody: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text("Today")
-                Text("\(entry.snapshot.pendingCount) pending")
+    private var smallBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Text("\(entry.snapshot.pendingCount)")
+                    .font(.system(size: 38, weight: .heavy, design: .rounded))
+                    .contentTransition(.numericText())
+                Text("left")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
             }
-            Spacer()
-            Image(systemName: "briefcase.fill")
+            progressBar
+            if let next = entry.snapshot.nextJob {
+                nextStopSummary(next)
+            } else {
+                emptyState
+            }
         }
         .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+
+    private var mediumBody: some View {
+        HStack(alignment: .top, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                header
+                Text(pendingLabel)
+                    .font(.title2.bold())
+                Text("\(entry.snapshot.completedCount) done • \(entry.snapshot.totalCount) total")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                progressBar
+                arrivalMonitoringBadge
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 8) {
+                if let next = entry.snapshot.nextJob {
+                    Text("NEXT STOP")
+                        .font(.caption2.bold())
+                        .foregroundStyle(.secondary)
+                    nextStopSummary(next)
+                    let upcoming = Array(entry.snapshot.jobs.dropFirst().prefix(2))
+                    if !upcoming.isEmpty {
+                        Divider()
+                        ForEach(upcoming) { upcomingJob in
+                            HStack(spacing: 6) {
+                                Image(systemName: "arrow.turn.down.right")
+                                    .font(.caption2)
+                                Text(upcomingJob.shortAddress)
+                                    .font(.caption)
+                                    .lineLimit(1)
+                                Spacer(minLength: 0)
+                                if let distance = upcomingJob.distanceText {
+                                    Text(distance)
+                                        .font(.caption2.bold())
+                                }
+                            }
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                    jobActionLinks(for: next, includeDashboard: true)
+                } else {
+                    emptyState
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+
+    private var accessoryBody: some View {
+        HStack(spacing: 8) {
+            Image(systemName: entry.snapshot.pendingCount == 0 ? "checkmark.seal.fill" : "briefcase.fill")
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(dateLabel): \(pendingLabel)")
+                    .font(.headline)
+                Text(entry.snapshot.nextJob?.shortAddress ?? "All caught up")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Label(dateLabel, systemImage: "calendar.badge.clock")
+                .font(.caption.bold())
+            Spacer(minLength: 0)
+            Text(entry.snapshot.generatedAt, style: .time)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var progressBar: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(.white.opacity(0.22))
+                Capsule()
+                    .fill(entry.snapshot.pendingCount == 0 ? .green : .orange)
+                    .frame(width: max(6, proxy.size.width * completionRatio))
+            }
+        }
+        .frame(height: 6)
+        .accessibilityLabel("\(entry.snapshot.completedCount) of \(entry.snapshot.totalCount) jobs complete")
+    }
+
+    @ViewBuilder
+    private var arrivalMonitoringBadge: some View {
+        switch entry.snapshot.arrivalMonitoring.state {
+        case .active:
+            Label("Arrival alerts on", systemImage: "location.badge.checkmark")
+                .foregroundStyle(.green)
+                .font(.caption2.bold())
+        case .warning, .error:
+            Label("Check arrival alerts", systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+                .font(.caption2.bold())
+        case .inactive:
+            EmptyView()
+        }
+    }
+
+    private func nextStopSummary(_ job: JobSystemSnapshot.Item) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(job.shortAddress)
+                .font(.headline)
+                .lineLimit(2)
+            Text([job.assignment, job.distanceText, job.jobNumber].compactMap { $0 }.joined(separator: " • "))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            Text("All caught up")
+                .font(.headline)
+            Text("No pending jobs for this day")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 
@@ -202,46 +336,232 @@ struct CurrentJobWidgetView: View {
         entry.snapshot.activeJob ?? entry.snapshot.nextJob
     }
 
+    private var statusColor: Color {
+        switch entry.snapshot.arrivalMonitoring.state {
+        case .active: return .green
+        case .warning: return .yellow
+        case .error: return .red
+        case .inactive: return job?.isPending == true ? .orange : .blue
+        }
+    }
+
     var body: some View {
         Group {
             if let job {
-                VStack(alignment: .leading, spacing: 8) {
-                    Label(job.status, systemImage: job.isPending ? "location.fill" : "checkmark.circle.fill")
-                        .font(.caption.bold())
-                    Text(job.shortAddress)
-                        .font(family == .systemSmall ? .headline : .title3.bold())
-                        .lineLimit(2)
-                    if family != .accessoryRectangular {
-                        Text([job.assignment, job.distanceText].compactMap { $0 }.joined(separator: " • "))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    Spacer(minLength: 0)
-                    if entry.snapshot.arrivalMonitoring.state == .active {
-                        Label("Monitoring arrivals", systemImage: "location.badge.checkmark")
-                            .font(.caption2.bold())
-                            .foregroundStyle(.green)
-                    } else {
-                        Text("Open Job Tracker")
-                            .font(.caption2.bold())
-                            .foregroundStyle(.tint)
-                    }
+                switch family {
+                case .accessoryRectangular:
+                    accessoryBody(job)
+                case .systemMedium:
+                    mediumBody(job)
+                default:
+                    smallBody(job)
                 }
-                .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
             } else {
-                VStack(alignment: .leading) {
-                    Image(systemName: "checkmark.seal.fill")
-                    Text("All caught up")
-                        .font(.headline)
-                    Text("No active job")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .widgetURL(URL(string: "jobtracker://dashboard"))
+                noJobBody
             }
         }
     }
+
+    private func smallBody(_ job: JobSystemSnapshot.Item) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            statusPill(job)
+            Text(job.shortAddress)
+                .font(.headline)
+                .lineLimit(2)
+            Text(job.assignment ?? job.jobNumber ?? "Open Job Tracker for details")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            if let fieldSummary = fieldSummary(for: job) {
+                Text(fieldSummary)
+                    .font(.caption2.bold())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if let notes = trimmed(job.notes) {
+                Text(notes)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 0)
+            jobActionLinks(for: job, includeDashboard: false)
+            footer(job)
+        }
+        .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
+    }
+
+    private func mediumBody(_ job: JobSystemSnapshot.Item) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                statusPill(job)
+                Text(job.shortAddress)
+                    .font(.title3.bold())
+                    .lineLimit(2)
+                Text([job.assignment, job.jobNumber].compactMap { $0 }.joined(separator: " • "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                if let fieldSummary = fieldSummary(for: job) {
+                    Label(fieldSummary, systemImage: "ruler")
+                        .font(.caption2.bold())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                if let notes = trimmed(job.notes) {
+                    Label(notes, systemImage: "note.text")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                if let materials = trimmed(job.materialsUsed) {
+                    Label(materials, systemImage: "shippingbox")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                footer(job)
+                jobActionLinks(for: job, includeDashboard: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 7) {
+                metricTile(icon: "point.topleft.down.curvedto.point.bottomright.up", title: "Distance", value: job.distanceText ?? "Open map")
+                metricTile(icon: "clock", title: "Scheduled", value: job.scheduledDate.formatted(.dateTime.hour().minute()))
+                metricTile(icon: "bell.badge", title: "Alerts", value: alertSummary)
+                if let placement = trimmed(job.jobPlacement) {
+                    metricTile(icon: "wrench.and.screwdriver", title: "Type", value: placement)
+                }
+            }
+            .frame(width: 125)
+        }
+        .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
+    }
+
+    private func accessoryBody(_ job: JobSystemSnapshot.Item) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: entry.snapshot.arrivalMonitoring.state == .active ? "location.badge.checkmark" : "location.fill")
+                .foregroundStyle(statusColor)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(job.shortAddress)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text([job.status, job.distanceText].compactMap { $0 }.joined(separator: " • "))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .widgetURL(URL(string: "jobtracker://job?id=\(job.id)"))
+    }
+
+    private func statusPill(_ job: JobSystemSnapshot.Item) -> some View {
+        Label(job.status, systemImage: job.isPending ? "figure.walk" : "checkmark.circle.fill")
+            .font(.caption.bold())
+            .foregroundStyle(statusColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(statusColor.opacity(0.16), in: Capsule())
+    }
+
+    private func metricTile(icon: String, title: String, value: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .frame(width: 18)
+                .foregroundStyle(statusColor)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.caption.bold())
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private func footer(_ job: JobSystemSnapshot.Item) -> some View {
+        Label(alertSummary, systemImage: entry.snapshot.arrivalMonitoring.state == .inactive ? "arrow.up.forward.app" : "location.badge.checkmark")
+            .font(.caption2.bold())
+            .foregroundStyle(statusColor)
+            .lineLimit(1)
+    }
+
+    private var alertSummary: String {
+        switch entry.snapshot.arrivalMonitoring.state {
+        case .active: return "Arrival alerts on"
+        case .warning: return "Needs attention"
+        case .error: return "Alert issue"
+        case .inactive: return "Tap for job"
+        }
+    }
+
+    private var noJobBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.title2)
+                .foregroundStyle(.green)
+            Text("All caught up")
+                .font(.headline)
+            Text("No active or pending job")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            Text("Updated \(entry.snapshot.generatedAt.formatted(date: .omitted, time: .shortened))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .widgetURL(URL(string: "jobtracker://dashboard"))
+    }
+}
+
+
+private func jobActionLinks(for job: JobSystemSnapshot.Item, includeDashboard: Bool) -> some View {
+    HStack(spacing: 6) {
+        Link(destination: jobDeepLink(for: job)) {
+            actionChip(title: "Details", systemImage: "doc.text.magnifyingglass")
+        }
+        Link(destination: directionsURL(for: job)) {
+            actionChip(title: "Route", systemImage: "arrow.triangle.turn.up.right.diamond.fill")
+        }
+        if includeDashboard {
+            Link(destination: URL(string: "jobtracker://dashboard")!) {
+                actionChip(title: "Board", systemImage: "rectangle.grid.2x2")
+            }
+        }
+    }
+    .buttonStyle(.plain)
+}
+
+private func actionChip(title: String, systemImage: String) -> some View {
+    Label(title, systemImage: systemImage)
+        .font(.caption2.bold())
+        .lineLimit(1)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 5)
+        .background(.thinMaterial, in: Capsule())
+}
+
+private func jobDeepLink(for job: JobSystemSnapshot.Item) -> URL {
+    URL(string: "jobtracker://job?id=\(job.id.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? job.id)")!
+}
+
+private func directionsURL(for job: JobSystemSnapshot.Item) -> URL {
+    let encodedAddress = job.address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? job.address
+    return URL(string: "http://maps.apple.com/?daddr=\(encodedAddress)&dirflg=d")!
+}
+
+private func fieldSummary(for job: JobSystemSnapshot.Item) -> String? {
+    var pieces: [String] = []
+    if let can = trimmed(job.canFootage) { pieces.append("CAN \(can)") }
+    if let nid = trimmed(job.nidFootage) { pieces.append("NID \(nid)") }
+    return pieces.isEmpty ? nil : pieces.joined(separator: " • ")
+}
+
+private func trimmed(_ value: String?) -> String? {
+    let text = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    return text.isEmpty ? nil : text
 }
 
 struct JobLiveActivityWidget: Widget {
@@ -253,28 +573,50 @@ struct JobLiveActivityWidget: Widget {
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    Label(context.state.status, systemImage: "briefcase.fill")
-                        .font(.caption.bold())
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.state.distanceText ?? context.state.etaText ?? "Active")
-                        .font(.caption)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(context.attributes.shortAddress)
-                            .font(.headline)
-                        Text(context.attributes.assignment ?? context.attributes.jobNumber ?? "Open Job Tracker")
-                            .font(.caption)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Label(context.state.status, systemImage: liveActivityIcon(for: context))
+                            .font(.caption.bold())
+                        Text(context.attributes.scheduledDate, style: .time)
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                 }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack(alignment: .trailing, spacing: 3) {
+                        Text(context.state.distanceText ?? context.state.etaText ?? "Active")
+                            .font(.caption.bold())
+                        Text(context.state.lastUpdated, style: .time)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(context.attributes.shortAddress)
+                            .font(.headline)
+                            .lineLimit(1)
+                        HStack(spacing: 8) {
+                            Text(context.attributes.assignment ?? context.attributes.jobNumber ?? "Open Job Tracker")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                            Label(liveActivityAlertText(for: context), systemImage: "bell.badge")
+                                .font(.caption2.bold())
+                                .foregroundStyle(liveActivityTint(for: context))
+                        }
+                    }
+                }
             } compactLeading: {
-                Image(systemName: "briefcase.fill")
+                Image(systemName: liveActivityIcon(for: context))
+                    .foregroundStyle(liveActivityTint(for: context))
             } compactTrailing: {
-                Text(context.state.status.prefix(1))
+                Text(context.state.distanceText ?? String(context.state.status.prefix(3)))
+                    .font(.caption2.bold())
+                    .lineLimit(1)
             } minimal: {
-                Image(systemName: "location.fill")
+                Image(systemName: liveActivityIcon(for: context))
+                    .foregroundStyle(liveActivityTint(for: context))
             }
             .widgetURL(URL(string: "jobtracker://job?id=\(context.attributes.jobID)"))
         }
@@ -285,32 +627,39 @@ struct LiveActivityLockScreenView: View {
     let context: ActivityViewContext<JobLiveActivityAttributes>
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "location.north.line.fill")
-                .font(.title2)
-                .foregroundStyle(.blue)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(context.attributes.shortAddress)
-                    .font(.headline)
-                    .lineLimit(1)
-                Text(routeStatusText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                if let monitoringMessage = context.state.arrivalMonitoringMessage,
-                   context.state.arrivalMonitoringState == "active" {
-                    Label(monitoringMessage, systemImage: "location.badge.checkmark")
-                        .font(.caption2)
-                        .foregroundStyle(.green)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Image(systemName: liveActivityIcon(for: context))
+                    .font(.title2)
+                    .foregroundStyle(liveActivityTint(for: context))
+                    .frame(width: 34, height: 34)
+                    .background(liveActivityTint(for: context).opacity(0.16), in: Circle())
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(context.attributes.shortAddress)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text(routeStatusText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
+                Spacer()
+                Text(context.state.status)
+                    .font(.caption.bold())
+                    .foregroundStyle(liveActivityTint(for: context))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(liveActivityTint(for: context).opacity(0.16), in: Capsule())
             }
-            Spacer()
-            Text(context.state.status)
-                .font(.caption.bold())
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .background(.thinMaterial, in: Capsule())
+
+            HStack(spacing: 10) {
+                Label(context.attributes.scheduledDate.formatted(date: .omitted, time: .shortened), systemImage: "clock")
+                Label(liveActivityAlertText(for: context), systemImage: "bell.badge")
+                Spacer(minLength: 0)
+                Text("Updated \(context.state.lastUpdated.formatted(date: .omitted, time: .shortened))")
+            }
+            .font(.caption2.bold())
+            .foregroundStyle(.secondary)
         }
         .padding()
         .widgetURL(URL(string: "jobtracker://job?id=\(context.attributes.jobID)"))
@@ -322,6 +671,30 @@ struct LiveActivityLockScreenView: View {
             .joined(separator: " • ")
         return text.isEmpty ? context.state.status : text
     }
+}
+
+private func liveActivityTint(for context: ActivityViewContext<JobLiveActivityAttributes>) -> Color {
+    switch context.state.arrivalMonitoringState {
+    case "active": return .green
+    case "warning": return .yellow
+    case "error": return .red
+    default: return .blue
+    }
+}
+
+private func liveActivityIcon(for context: ActivityViewContext<JobLiveActivityAttributes>) -> String {
+    switch context.state.arrivalMonitoringState {
+    case "active": return "location.badge.checkmark"
+    case "warning", "error": return "exclamationmark.triangle.fill"
+    default: return "location.north.line.fill"
+    }
+}
+
+private func liveActivityAlertText(for context: ActivityViewContext<JobLiveActivityAttributes>) -> String {
+    guard let message = context.state.arrivalMonitoringMessage, !message.isEmpty else {
+        return "Tap for job"
+    }
+    return message
 }
 
 @main

--- a/Job Tracker/Features/SystemExperiences/JobSystemSnapshot.swift
+++ b/Job Tracker/Features/SystemExperiences/JobSystemSnapshot.swift
@@ -9,6 +9,10 @@ struct JobSystemSnapshot: Codable, Hashable {
         var assignment: String?
         var jobNumber: String?
         var notes: String?
+        var materialsUsed: String?
+        var nidFootage: String?
+        var canFootage: String?
+        var jobPlacement: String?
         var scheduledDate: Date
         var distanceText: String?
 
@@ -67,6 +71,10 @@ extension JobSystemSnapshot.Item {
             assignment: job.assignments,
             jobNumber: job.jobNumber,
             notes: job.notes,
+            materialsUsed: job.materialsUsed,
+            nidFootage: job.nidFootage,
+            canFootage: job.canFootage,
+            jobPlacement: job.jobPlacement,
             scheduledDate: job.date,
             distanceText: distanceText
         )


### PR DESCRIPTION
### Motivation
- Surface additional job metadata (materials, footage, placement) to widgets and activities so summaries and tiles can show more useful field information.
- Improve the visual hierarchy and utility of Today/Current widgets with progress, status coloring, and actionable links to jump into the app or maps.
- Make Live Activity and Dynamic Island provide clearer, contextual status, timestamps, and alert hints for arrival monitoring.

### Description
- Added new fields to `JobSystemSnapshot.Item`: `materialsUsed`, `nidFootage`, `canFootage`, and `jobPlacement`, and propagated these from `Job` in the `init(job:distanceText:)` mapping.
- Reworked `TodayJobsWidget` view to split layouts by family, add `completionRatio`, `progressBar`, `header` with date/time, arrival monitoring badge, richer medium layout with upcoming jobs list, and an `emptyState` UI; added helper views `nextStopSummary`, `jobActionLinks`, `actionChip`, `jobDeepLink`, `directionsURL`, `fieldSummary`, and `trimmed`.
- Refactored `CurrentJobWidgetView` into family-specific renderers (`smallBody`, `mediumBody`, `accessoryBody`), added `statusColor`, `statusPill`, metric tiles, field/materials display, `footer`, and re-used `jobActionLinks` for direct links to details, route, and dashboard.
- Enhanced `JobLiveActivityWidget` and `LiveActivityLockScreenView` to show icons/tints based on `arrivalMonitoringState`, include timestamps and alert text, and added helper functions `liveActivityTint`, `liveActivityIcon`, and `liveActivityAlertText` to centralize logic.

### Testing
- Built the project in Xcode to ensure widgets, Live Activities, and helper functions compile successfully and render for different widget families; the build succeeded.
- Executed the existing automated test suite for the app and widgets; all existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d75cbf87c832da4bc44ccfd4638c4)