### PR TITLE
Make job widgets actionable

### DIFF
--- a/Job Tracker Widgets/JobTrackerWidgets.swift
+++ b/Job Tracker Widgets/JobTrackerWidgets.swift
@@ -147,6 +147,29 @@ struct OpenDashboardWidgetIntent: AppIntent {
     }
 }
 
+struct OpenWidgetDirectionsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Directions to Job"
+    static var description = IntentDescription("Opens Apple Maps directions to the selected job address.")
+    static var openAppWhenRun: Bool = true
+
+    @Parameter(title: "Address")
+    var address: String
+
+    init() {
+        self.address = ""
+    }
+
+    init(address: String) {
+        self.address = address
+    }
+
+    func perform() async throws -> some IntentResult & OpensIntent {
+        let encodedAddress = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? address
+        let url = URL(string: "http://maps.apple.com/?daddr=\(encodedAddress)&dirflg=d") ?? URL(string: "jobtracker://dashboard")!
+        return .result(opensIntent: OpenURLIntent(url))
+    }
+}
+
 struct TodayJobsWidget: Widget {
     let kind = "TodayJobsWidget"
 
@@ -512,9 +535,15 @@ struct CurrentJobWidgetView: View {
                 Label(compact ? "Open" : "Open job", systemImage: "arrow.up.forward.app")
                     .lineLimit(1)
             }
-            Button(intent: OpenDashboardWidgetIntent()) {
-                Label("Today", systemImage: "rectangle.grid.2x2")
+            Button(intent: OpenWidgetDirectionsIntent(address: job.address)) {
+                Label(compact ? "Route" : "Directions", systemImage: "map")
                     .lineLimit(1)
+            }
+            if !compact {
+                Button(intent: OpenDashboardWidgetIntent()) {
+                    Label("Today", systemImage: "rectangle.grid.2x2")
+                        .lineLimit(1)
+                }
             }
         }
         .font(.caption2.bold())

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -218,6 +218,11 @@ struct DashboardView: View {
                 viewModel.handleJobsListChange(newJobs, currentLocation: locationService.current)
                 publishSystemExperiencesSnapshot()
             }
+
+            .onReceive(NotificationCenter.default.publisher(for: .jobDeepLinkRequested)) { note in
+                guard let jobID = note.userInfo?["jobID"] as? String else { return }
+                viewModel.selectedJob = jobsViewModel.jobs.first { $0.id == jobID }
+            }
             .onReceive(NotificationCenter.default.publisher(for: .jobImportSucceeded)) { _ in
                 viewModel.presentImportSuccessToast()
             }

--- a/Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift
+++ b/Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift
@@ -86,6 +86,7 @@ enum DeepLinkRouter {
 }
 
 extension Notification.Name {
+    static let jobDeepLinkRequested = Notification.Name("jobDeepLinkRequested")
     static let jobImportSucceeded = Notification.Name("jobImportSucceeded")
     static let jobImportFailed = Notification.Name("jobImportFailed")
 }

--- a/Job Tracker/Job_TrackerApp.swift
+++ b/Job Tracker/Job_TrackerApp.swift
@@ -195,8 +195,15 @@ struct JobTrackerApp: App {
                 guard let route = DeepLinkRouter.handle(url) else { return }
 
                 switch route {
-                case .dashboard, .job(_):
-                    break
+                case .dashboard:
+                    navigationViewModel.navigate(to: .dashboard)
+                case let .job(id):
+                    navigationViewModel.navigate(to: .dashboard)
+                    NotificationCenter.default.post(
+                        name: .jobDeepLinkRequested,
+                        object: nil,
+                        userInfo: ["jobID": id]
+                    )
                 case let .importJob(token):
                     Task {
                         await MainActor.run {

--- a/Job TrackerTests/DeepLinkRouterTests.swift
+++ b/Job TrackerTests/DeepLinkRouterTests.swift
@@ -27,6 +27,11 @@ final class DeepLinkRouterTests: XCTestCase {
         XCTAssertEqual(DeepLinkRouter.handle(url), .job(id: "job-123"))
     }
 
+    func testHandlesSingleSlashJobURL() throws {
+        let url = try XCTUnwrap(URL(string: "jobtracker:/job?id=job-456"))
+        XCTAssertEqual(DeepLinkRouter.handle(url), .job(id: "job-456"))
+    }
+
     func testRejectsUnknownRoute() throws {
         let url = try XCTUnwrap(URL(string: "jobtracker://help?token=ABC123"))
         XCTAssertNil(DeepLinkRouter.handle(url))


### PR DESCRIPTION
### Motivation
- Widgets and deep links were being ignored or offered only read-only behavior, so widget buttons needed to actually open app destinations and provide quick actions like directions.
- Dashboard needed a way to receive widget-driven job deep-links and present the matching job detail when the app is opened.

### Description
- Added a shared notification `jobDeepLinkRequested` in `DeepLinkRouter.swift` to hand off job deep-link IDs to the app.  
- Wired `.onOpenURL` in `Job_TrackerApp.swift` to navigate to the dashboard and post `jobDeepLinkRequested` when receiving `jobtracker://job?id=...`.  
- Added a listener in `DashboardView.swift` to consume `jobDeepLinkRequested` and set `viewModel.selectedJob` to the matching `Job` so the job detail sheet opens.  
- Added an `OpenWidgetDirectionsIntent` AppIntent in `JobTrackerWidgets.swift` and surfaced a Directions/Route button in the Current Job widget that opens Apple Maps with the job address, alongside the existing Open/Today actions, and extended the deep-link router tests to cover single-slash job URLs. 

### Testing
- Ran `git diff --check` with no issues.  
- Updated `Job TrackerTests/DeepLinkRouterTests.swift` to add coverage for single-slash job URLs, but unit tests were not executed in this environment.  
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` but `xcodebuild` is not available in the CI container so workspace build verification could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d8cee4bf0832dafca19d1bfc4fb60)