### PR TITLE
Add Meta Smart Glasses capture assistant (UI, service, intents, docs)

### DIFF
--- a/Documentation/Features/MetaSmartGlasses.md
+++ b/Documentation/Features/MetaSmartGlasses.md
@@ -1,0 +1,60 @@
+# Meta Smart Glasses Capture Assistant
+
+Job Tracker includes a production-safe Meta Smart Glasses capture assistant that prepares the app for Meta's Wearables Device Access Toolkit while still working when the gated SDK package is not present in the build. The assistant treats the glasses as a field capture accessory and keeps the iPhone app responsible for job selection, technician review, Firebase uploads, and sync status.
+
+## What Works Now
+
+- Settings exposes a **Meta Smart Glasses** section where technicians can enable the capture assistant, keep review-before-upload on, prefer the nearest/current job for voice workflows, and see whether the current build is ready for the SDK package.
+- Job detail screens include a **Meta Smart Glasses** capture panel with House, NID, and CAN evidence categories.
+- If Meta's SDK is not linked, the panel automatically falls back to phone camera/photo-library capture so the same evidence-routing workflow remains usable today.
+- Captured images populate the existing job photo slots and are queued through `JobPhotoUploadQueue` when the technician taps **Save**.
+- The queue persists image files locally, retries uploads, patches the correct Firestore photo field, and reports progress through the existing dashboard sync banner.
+- Siri/Shortcuts includes a **Meta Evidence** shortcut for hands-free notes such as footage comments, NID/CAN observations, or house-photo context on the current/nearest job.
+
+## SDK Adapter Boundary
+
+`MetaSmartGlassesService` owns the future SDK boundary through the `MetaSmartGlassesCapturing` protocol. The current `MetaSmartGlassesSDKAdapter` intentionally reports that the SDK is unavailable so the app can compile, ship, and be tested without private or preview binaries. Once the team has access to Meta's iOS package, replace the adapter internals with the real connect/disconnect/capture calls and keep the rest of the app unchanged.
+
+The adapter boundary keeps SDK churn isolated from:
+
+- `JobDetailView`, which only receives `UIImage` captures for a selected `JobPhotoSlot`.
+- `SettingsView`, which only displays connection state and preference toggles.
+- `JobPhotoUploadQueue`, which remains the single durable upload pipeline for job evidence.
+- App Intents, which continue to resolve the current/nearest job and append structured evidence notes.
+
+## Field Workflow
+
+1. Open **Settings** and enable **Meta Smart Glasses → Enable capture assistant**.
+2. Open a job from Dashboard, Search, Yellow Sheet, or Timesheets.
+3. In **Meta Smart Glasses**, choose **House Photo**, **NID Photo**, or **CAN Photo**.
+4. Tap **Capture from Glasses**. If the SDK is not available, Job Tracker explains the limitation and opens the phone fallback capture choices.
+5. Review the image in the normal job photo slot.
+6. Tap **Save** to queue the upload and patch Firestore through the existing sync pipeline.
+
+## Voice Workflow
+
+Use Shortcuts/Siri phrases such as:
+
+- "Meta add evidence to my current job in Job Tracker."
+- "Add Meta glasses note with Job Tracker."
+- "Add this footage to my current job with Job Tracker."
+
+The intent resolves the nearest pending job for today when location is available; otherwise it falls back to the next pending job and includes that fallback reason in the spoken response. It appends notes in this format:
+
+```text
+[Meta Glasses • Footage • Jun 13, 10:45 AM] Added 130 feet from CAN to NID.
+```
+
+## Guardrails
+
+- The feature is off by default.
+- Review-before-upload is on by default.
+- Capture is explicit and tied to a visible job/address.
+- Photos reuse existing Firebase Storage and Firestore rules instead of introducing a new storage path.
+- The SDK adapter can fail gracefully without blocking phone capture.
+- The app Info.plist includes camera, photo-library, microphone, and MWDAT analytics opt-out keys needed for the capture workflow and future SDK swap-in.
+- Voice notes do not upload media; they only append structured text to the resolved job.
+
+## Next SDK Swap-In Step
+
+When Meta grants SDK access, implement `MetaSmartGlassesSDKAdapter` in `Job Tracker/Features/MetaSmartGlasses/MetaSmartGlassesService.swift` by importing the package and mapping its device connection/photo APIs into `connect()`, `disconnect()`, and `capturePhoto()`. No other Job Tracker screens should need to change unless Meta requires additional permission UI.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -12,6 +12,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 - [Dashboard](Features/Dashboard.md)
 - [Help](Features/Help.md)
 - [Jobs](Features/Jobs.md)
+- [Meta Smart Glasses Integration Concept](Features/MetaSmartGlasses.md)
 - [Search](Features/Search.md)
 - [Settings](Features/Settings.md)
 - [Shared](Features/Shared.md)

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -104,6 +104,7 @@ private let jobPlacementChoices = ["OH", "UG"]
     @State private var housePhotoImage: UIImage?
     @State private var nidPhotoImage: UIImage?
     @State private var canPhotoImage: UIImage?
+    @State private var selectedMetaGlassesSlot: JobPhotoSlot = .house
 
     // Full-screen viewer state
     @State private var fullScreenImageURL: URL? = nil
@@ -327,6 +328,16 @@ private let jobPlacementChoices = ["OH", "UG"]
                     }
 
                     Section(header: Text("Job Photos")) { jobPhotoSlotsSection }
+
+                    Section(header: Text("Meta Smart Glasses")) {
+                        MetaSmartGlassesCapturePanel(
+                            job: job,
+                            selectedSlot: $selectedMetaGlassesSlot,
+                            onPhotoCaptured: applyMetaSmartGlassesCapture
+                        )
+                        .glassCard()
+                        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                    }
                 }
                 .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)   // keep gradient visible
@@ -987,6 +998,17 @@ extension JobDetailView {
                 enqueuePendingPhotosIfNeeded()
                 finalizeJobSave()
             }
+        }
+    }
+
+    private func applyMetaSmartGlassesCapture(slot: JobPhotoSlot, image: UIImage) {
+        switch slot {
+        case .house:
+            housePhotoImage = image
+        case .nid:
+            nidPhotoImage = image
+        case .can:
+            canPhotoImage = image
         }
     }
 

--- a/Job Tracker/Features/MetaSmartGlasses/MetaSmartGlassesCapturePanel.swift
+++ b/Job Tracker/Features/MetaSmartGlasses/MetaSmartGlassesCapturePanel.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import UIKit
+
+struct MetaSmartGlassesCapturePanel: View {
+    let job: Job
+    @Binding var selectedSlot: JobPhotoSlot
+    let onPhotoCaptured: (JobPhotoSlot, UIImage) -> Void
+
+    @ObservedObject private var service = MetaSmartGlassesService.shared
+    @AppStorage(MetaSmartGlassesSettings.enabledKey) private var assistantEnabled = false
+    @AppStorage(MetaSmartGlassesSettings.requireReviewKey) private var requireReviewBeforeUpload = true
+    @State private var showFallbackPicker = false
+    @State private var showSourceDialog = false
+    @State private var selectedPhotoSource: UIImagePickerController.SourceType = .camera
+    @State private var statusMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: assistantEnabled ? "eyeglasses" : "eyeglasses.slash")
+                    .font(.title3)
+                    .foregroundStyle(assistantEnabled ? JTColors.accent : .secondary)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Meta Smart Glasses")
+                        .font(.subheadline.weight(.semibold))
+                    Text(service.connectionState.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Text(service.connectionState.title)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.thinMaterial, in: Capsule())
+            }
+
+            Picker("Evidence Type", selection: $selectedSlot) {
+                ForEach(JobPhotoSlot.allCases, id: \.self) { slot in
+                    Text(slot.displayTitle).tag(slot)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            HStack(spacing: 10) {
+                Button {
+                    Task { await captureFromGlasses() }
+                } label: {
+                    Label("Capture from Glasses", systemImage: "camera.viewfinder")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!assistantEnabled)
+
+                Button {
+                    showSourceDialog = true
+                } label: {
+                    Label("Use Phone", systemImage: "iphone")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Text(requireReviewBeforeUpload
+                 ? "Current job: \(job.shortAddress). Captures are reviewed on this screen before Save queues the upload."
+                 : "Current job: \(job.shortAddress). Captures queue for upload immediately.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let statusMessage {
+                Text(statusMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear { service.refreshState() }
+        .confirmationDialog("Capture Evidence", isPresented: $showSourceDialog, titleVisibility: .visible) {
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button("Take Phone Photo") {
+                    selectedPhotoSource = .camera
+                    showFallbackPicker = true
+                }
+            }
+            Button("Choose Existing Photo") {
+                selectedPhotoSource = .photoLibrary
+                showFallbackPicker = true
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Use this fallback until the Meta SDK package is present in this build.")
+        }
+        .sheet(isPresented: $showFallbackPicker) {
+            ImagePicker(
+                image: Binding(
+                    get: { nil },
+                    set: { newImage in
+                        guard let newImage else { return }
+                        handleCapturedImage(newImage)
+                    }
+                ),
+                sourceType: selectedPhotoSource
+            )
+        }
+    }
+
+    private func handleCapturedImage(_ image: UIImage, source: String = "phone") {
+        if requireReviewBeforeUpload {
+            onPhotoCaptured(selectedSlot, image)
+            statusMessage = "Queued \(selectedSlot.displayTitle.lowercased()) from \(source) for review."
+        } else {
+            JobPhotoUploadQueue.shared.enqueue([(slot: selectedSlot, image: image)], for: job.id)
+            statusMessage = "Queued \(selectedSlot.displayTitle.lowercased()) from \(source) for upload."
+        }
+    }
+
+    private func captureFromGlasses() async {
+        do {
+            let image = try await service.capturePhoto()
+            handleCapturedImage(image, source: "Meta glasses")
+        } catch {
+            statusMessage = error.localizedDescription
+            showSourceDialog = true
+        }
+    }
+}

--- a/Job Tracker/Features/MetaSmartGlasses/MetaSmartGlassesService.swift
+++ b/Job Tracker/Features/MetaSmartGlasses/MetaSmartGlassesService.swift
@@ -1,0 +1,146 @@
+import Combine
+import Foundation
+import UIKit
+
+extension Notification.Name {
+    static let metaSmartGlassesSettingsDidChange = Notification.Name("metaSmartGlassesSettingsDidChange")
+}
+
+enum MetaSmartGlassesConnectionState: String, Equatable {
+    case disabled
+    case readyForSDK
+    case connected
+    case unavailable
+
+    var title: String {
+        switch self {
+        case .disabled: return "Off"
+        case .readyForSDK: return "Ready"
+        case .connected: return "Connected"
+        case .unavailable: return "SDK Needed"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .disabled:
+            return "Enable the assistant before pairing glasses."
+        case .readyForSDK:
+            return "Job Tracker is ready for the Meta SDK package and can already route field captures into job photos."
+        case .connected:
+            return "Meta glasses are connected and available for capture."
+        case .unavailable:
+            return "Add Meta's Wearables Device Access Toolkit package to enable direct glasses capture."
+        }
+    }
+}
+
+enum MetaSmartGlassesSettings {
+    static let enabledKey = "metaSmartGlassesAssistantEnabled"
+    static let requireReviewKey = "metaSmartGlassesRequireReviewBeforeUpload"
+    static let useNearestJobKey = "metaSmartGlassesUseNearestJob"
+
+    static var isEnabled: Bool { UserDefaults.standard.bool(forKey: enabledKey) }
+    static var requiresReviewBeforeUpload: Bool { UserDefaults.standard.object(forKey: requireReviewKey) as? Bool ?? true }
+    static var usesNearestJob: Bool { UserDefaults.standard.object(forKey: useNearestJobKey) as? Bool ?? true }
+
+    static func publishChange() {
+        NotificationCenter.default.post(name: .metaSmartGlassesSettingsDidChange, object: nil)
+    }
+}
+
+protocol MetaSmartGlassesCapturing {
+    var isSDKAvailable: Bool { get }
+    func connect() async throws
+    func disconnect() async
+    func capturePhoto() async throws -> UIImage
+}
+
+struct MetaSmartGlassesSDKAdapter: MetaSmartGlassesCapturing {
+    var isSDKAvailable: Bool { false }
+
+    func connect() async throws {
+        throw MetaSmartGlassesServiceError.sdkUnavailable
+    }
+
+    func disconnect() async {}
+
+    func capturePhoto() async throws -> UIImage {
+        throw MetaSmartGlassesServiceError.sdkUnavailable
+    }
+}
+
+enum MetaSmartGlassesServiceError: LocalizedError, Equatable {
+    case disabled
+    case sdkUnavailable
+    case captureFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .disabled:
+            return "Meta Smart Glasses capture is turned off in Settings."
+        case .sdkUnavailable:
+            return "Meta's Wearables Device Access Toolkit SDK has not been added to this build yet."
+        case .captureFailed:
+            return "The glasses did not return a usable photo."
+        }
+    }
+}
+
+@MainActor
+final class MetaSmartGlassesService: ObservableObject {
+    static let shared = MetaSmartGlassesService()
+
+    @Published private(set) var connectionState: MetaSmartGlassesConnectionState
+    @Published private(set) var lastErrorMessage: String?
+
+    private let adapter: MetaSmartGlassesCapturing
+    private var cancellable: AnyCancellable?
+
+    init(adapter: MetaSmartGlassesCapturing = MetaSmartGlassesSDKAdapter()) {
+        self.adapter = adapter
+        self.connectionState = Self.state(isEnabled: MetaSmartGlassesSettings.isEnabled, sdkAvailable: adapter.isSDKAvailable)
+        cancellable = NotificationCenter.default.publisher(for: .metaSmartGlassesSettingsDidChange)
+            .sink { [weak self] _ in
+                Task { @MainActor in self?.refreshState() }
+            }
+    }
+
+    func refreshState() {
+        connectionState = Self.state(isEnabled: MetaSmartGlassesSettings.isEnabled, sdkAvailable: adapter.isSDKAvailable)
+    }
+
+    func connect() async {
+        guard MetaSmartGlassesSettings.isEnabled else {
+            lastErrorMessage = MetaSmartGlassesServiceError.disabled.localizedDescription
+            refreshState()
+            return
+        }
+
+        do {
+            try await adapter.connect()
+            connectionState = .connected
+            lastErrorMessage = nil
+        } catch {
+            connectionState = adapter.isSDKAvailable ? .readyForSDK : .unavailable
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    func disconnect() async {
+        await adapter.disconnect()
+        lastErrorMessage = nil
+        refreshState()
+    }
+
+    func capturePhoto() async throws -> UIImage {
+        guard MetaSmartGlassesSettings.isEnabled else { throw MetaSmartGlassesServiceError.disabled }
+        guard adapter.isSDKAvailable else { throw MetaSmartGlassesServiceError.sdkUnavailable }
+        return try await adapter.capturePhoto()
+    }
+
+    private static func state(isEnabled: Bool, sdkAvailable: Bool) -> MetaSmartGlassesConnectionState {
+        guard isEnabled else { return .disabled }
+        return sdkAvailable ? .readyForSDK : .unavailable
+    }
+}

--- a/Job Tracker/Features/Settings/SettingsView.swift
+++ b/Job Tracker/Features/Settings/SettingsView.swift
@@ -25,6 +25,9 @@ struct SettingsView: View {
     @AppStorage("routingOptimizeBy")   private var optimizeByRaw      = "closest" // or "farthest"
     @AppStorage("arrivalAlertsEnabledToday") private var arrivalAlertsEnabledToday = true
     @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple" // "apple" or "google"
+    @AppStorage(MetaSmartGlassesSettings.enabledKey) private var metaGlassesEnabled = false
+    @AppStorage(MetaSmartGlassesSettings.requireReviewKey) private var metaGlassesRequireReview = true
+    @AppStorage(MetaSmartGlassesSettings.useNearestJobKey) private var metaGlassesUseNearestJob = true
 
     private enum OptimizeBy: String, CaseIterable, Identifiable {
         case closest, farthest
@@ -37,6 +40,7 @@ struct SettingsView: View {
     @State private var isDeleting = false
     @State private var deleteError: String? = nil
     @State private var showThemeEditor = false
+    @ObservedObject private var metaGlassesService = MetaSmartGlassesService.shared
 
     // Update these to your real URLs/emails
     private let privacyURL = URL(string: "https://gist.github.com/Qathom89911/82366354d14a9283d9d1c49f601c8f93")!
@@ -145,6 +149,70 @@ struct SettingsView: View {
                                 ? "Using Google for address lookups."
                                 : "Using Apple Maps for address suggestions."
                             )
+                        }
+                        .padding(16)
+                    }
+                    .padding(.horizontal, 16)
+
+
+                    // Meta Smart Glasses
+                    GlassCard {
+                        VStack(alignment: .leading, spacing: 12) {
+                            SectionHeader(title: "Meta Smart Glasses")
+
+                            Toggle("Enable capture assistant", isOn: $metaGlassesEnabled)
+                                .toggleStyle(.switch)
+                                .onChange(of: metaGlassesEnabled) { _, _ in
+                                    MetaSmartGlassesSettings.publishChange()
+                                }
+                                .accessibilityHint("Allows job detail screens to route glasses or phone fallback captures into job photo slots.")
+
+                            Toggle("Review before upload", isOn: $metaGlassesRequireReview)
+                                .toggleStyle(.switch)
+                                .onChange(of: metaGlassesRequireReview) { _, _ in
+                                    MetaSmartGlassesSettings.publishChange()
+                                }
+                                .accessibilityHint("Keep photos on the job screen for review until you tap Save.")
+
+                            Toggle("Prefer nearest/current job", isOn: $metaGlassesUseNearestJob)
+                                .toggleStyle(.switch)
+                                .onChange(of: metaGlassesUseNearestJob) { _, _ in
+                                    MetaSmartGlassesSettings.publishChange()
+                                }
+                                .accessibilityHint("Voice and glasses workflows should choose the current or nearest job when possible.")
+
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: metaGlassesEnabled ? "eyeglasses" : "eyeglasses.slash")
+                                    .foregroundStyle(metaGlassesEnabled ? JTColors.accent : .secondary)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(metaGlassesService.connectionState.title)
+                                        .font(.subheadline.weight(.semibold))
+                                    Text(metaGlassesService.connectionState.detail)
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+
+                            HStack {
+                                Button("Connect") {
+                                    Task { await metaGlassesService.connect() }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .disabled(!metaGlassesEnabled)
+
+                                Button("Disconnect") {
+                                    Task { await metaGlassesService.disconnect() }
+                                }
+                                .buttonStyle(.bordered)
+                            }
+
+                            if let lastError = metaGlassesService.lastErrorMessage {
+                                Text(lastError)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
                         }
                         .padding(16)
                     }

--- a/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
+++ b/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
@@ -21,6 +21,17 @@ enum JobPhotoSlot: String, Codable, CaseIterable {
             return "canPhotoURL"
         }
     }
+
+    var displayTitle: String {
+        switch self {
+        case .house:
+            return "House Photo"
+        case .nid:
+            return "NID Photo"
+        case .can:
+            return "CAN Photo"
+        }
+    }
 }
 
 private struct PendingJobPhotoUpload: Identifiable, Codable, Equatable {
@@ -88,11 +99,7 @@ struct JobPhotoUploadStatus: Identifiable, Equatable {
     let state: State
 
     var title: String {
-        switch slot {
-        case .house: return "House photo"
-        case .nid: return "NID photo"
-        case .can: return "Can photo"
-        }
+        slot.displayTitle
     }
 
     var subtitle: String {

--- a/Job Tracker/intent/AppShortcuts.swift
+++ b/Job Tracker/intent/AppShortcuts.swift
@@ -108,6 +108,16 @@ struct JobTrackerShortcuts: AppShortcutsProvider {
                 ],
                 shortTitle: "Current Job",
                 systemImageName: "briefcase"
+            ),
+            AppShortcut(
+                intent: AddMetaSmartGlassesJobNoteIntent(),
+                phrases: [
+                    "Meta add evidence to my current job in \(.applicationName)",
+                    "Add Meta glasses note with \(.applicationName)",
+                    "Add this footage to my current job with \(.applicationName)"
+                ],
+                shortTitle: "Meta Evidence",
+                systemImageName: "eyeglasses"
             )
         ]
     }

--- a/Job Tracker/intent/MetaSmartGlassesIntents.swift
+++ b/Job Tracker/intent/MetaSmartGlassesIntents.swift
@@ -1,0 +1,71 @@
+import AppIntents
+import Foundation
+
+@available(iOS 26.0, *)
+enum MetaEvidenceTypeIntentEnum: String, AppEnum {
+    case footage = "Footage"
+    case house = "House Photo"
+    case nid = "NID Photo"
+    case can = "CAN Photo"
+    case note = "Note"
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Evidence Type"
+
+    static var caseDisplayRepresentations: [MetaEvidenceTypeIntentEnum: DisplayRepresentation] = [
+        .footage: "Footage",
+        .house: "House Photo",
+        .nid: "NID Photo",
+        .can: "CAN Photo",
+        .note: "Note"
+    ]
+}
+
+@available(iOS 26.0, *)
+struct AddMetaSmartGlassesJobNoteIntent: AppIntent {
+    static var openAppWhenRun: Bool = false
+    static var title: LocalizedStringResource = "Add Meta Glasses Job Evidence"
+    static var description = IntentDescription("Adds a hands-free Meta smart glasses evidence note to the current or nearest job.")
+
+    @Parameter(title: "Evidence Type")
+    var evidenceType: MetaEvidenceTypeIntentEnum
+
+    @Parameter(title: "Details", requestValueDialog: "What should I add to the job?")
+    var details: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add \(AddMetaSmartGlassesJobNoteIntent.$evidenceType) note: \(AddMetaSmartGlassesJobNoteIntent.$details)")
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        guard MetaSmartGlassesSettings.isEnabled else {
+            return .result(dialog: IntentDialog("Turn on Meta Smart Glasses capture assistant in Job Tracker Settings first."))
+        }
+
+        let resolution = try await JobIntentResolver.nearestJobOrDialog()
+        guard case .success(let target) = resolution else {
+            if case .failure(let dialog) = resolution { return .result(dialog: dialog) }
+            return .result(dialog: IntentDialog("I couldn't find a current job."))
+        }
+
+        let trimmedDetails = details.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDetails.isEmpty else {
+            return .result(dialog: IntentDialog("Please provide details to add."))
+        }
+
+        let timestamp = Date().formatted(.dateTime.month(.abbreviated).day().hour().minute())
+        let entry = "[Meta Glasses • \(evidenceType.rawValue) • \(timestamp)] \(trimmedDetails)"
+        let existing = target.job.notes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let updatedNotes = existing.isEmpty ? entry : "\(existing)\n\(entry)"
+
+        do {
+            try await FirebaseService.shared.updateJobFieldsAsync(jobId: target.job.id, fields: ["notes": updatedNotes])
+            var dialog = "Added \(evidenceType.rawValue.lowercased()) evidence to \(JobIntentFormatter.jobContext(target))."
+            if let fallbackReason = target.fallbackReason {
+                dialog += " \(fallbackReason)"
+            }
+            return .result(dialog: IntentDialog(stringLiteral: dialog))
+        } catch {
+            return .result(dialog: IntentDialog("Couldn't add the Meta glasses note: \(error.localizedDescription)"))
+        }
+    }
+}

--- a/Job TrackerTests/MetaSmartGlassesServiceTests.swift
+++ b/Job TrackerTests/MetaSmartGlassesServiceTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import Job_Tracker
+
+@MainActor
+final class MetaSmartGlassesServiceTests: XCTestCase {
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: MetaSmartGlassesSettings.enabledKey)
+        UserDefaults.standard.removeObject(forKey: MetaSmartGlassesSettings.requireReviewKey)
+        UserDefaults.standard.removeObject(forKey: MetaSmartGlassesSettings.useNearestJobKey)
+        super.tearDown()
+    }
+
+    func testDefaultSettingsKeepAssistantDisabledButReviewEnabled() {
+        XCTAssertFalse(MetaSmartGlassesSettings.isEnabled)
+        XCTAssertTrue(MetaSmartGlassesSettings.requiresReviewBeforeUpload)
+        XCTAssertTrue(MetaSmartGlassesSettings.usesNearestJob)
+    }
+
+    func testServiceReportsSDKNeededWhenEnabledWithoutAdapter() {
+        UserDefaults.standard.set(true, forKey: MetaSmartGlassesSettings.enabledKey)
+        let service = MetaSmartGlassesService(adapter: MetaSmartGlassesSDKAdapter())
+        XCTAssertEqual(service.connectionState, .unavailable)
+    }
+
+    func testPhotoSlotDisplayTitlesAreFieldFriendly() {
+        XCTAssertEqual(JobPhotoSlot.house.displayTitle, "House Photo")
+        XCTAssertEqual(JobPhotoSlot.nid.displayTitle, "NID Photo")
+        XCTAssertEqual(JobPhotoSlot.can.displayTitle, "CAN Photo")
+    }
+}

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -47,5 +47,19 @@
 	<string></string>
 	<key>GEMINI_API_KEY</key>
 	<string></string>
+	<key>NSCameraUsageDescription</key>
+	<string>Job Tracker uses the camera to capture job-site evidence photos, including Meta smart glasses fallback captures.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Job Tracker lets you choose existing job-site evidence photos to attach to a job.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Job Tracker may use the microphone for future Meta smart glasses voice notes and hands-free field evidence workflows.</string>
+	<key>MWDAT</key>
+	<dict>
+		<key>Analytics</key>
+		<dict>
+			<key>OptOut</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
### Motivation

- Introduce a production-safe capture assistant to support future Meta smart glasses integration while keeping current builds functional without the SDK. 
- Surface controls and status in `Settings` and allow capture routing into existing job photo workflows so field capture can be reviewed and uploaded through the established pipeline.

### Description

- Add a new feature module with `MetaSmartGlassesService`, a `MetaSmartGlassesCapturing` protocol, and `MetaSmartGlassesSDKAdapter` which currently reports the SDK as unavailable so the app compiles without private binaries. 
- Add `MetaSmartGlassesCapturePanel` UI and wire it into `JobDetailView` to let technicians pick a `JobPhotoSlot` and capture from glasses or fall back to the phone camera/photo library; captured images are applied to the job and routed into `JobPhotoUploadQueue`. 
- Extend `JobPhotoSlot` with `displayTitle` and update `JobPhotoUploadStatus.title` to use that label. 
- Add Settings toggles for the assistant, review-before-upload, and nearest-job preference, plus connect/disconnect controls and status display using `MetaSmartGlassesService`. 
- Add an App Intent `AddMetaSmartGlassesJobNoteIntent`, register a `Meta Evidence` shortcut, and implement intent logic to append structured notes to the nearest/current job. 
- Add documentation `Documentation/Features/MetaSmartGlasses.md` and link it from `Documentation/README.md`. 
- Update `Info.plist` with `NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription`, `NSMicrophoneUsageDescription`, and an `MWDAT` analytics opt-out key to cover the capture workflow and future SDK swap-in. 

### Testing

- Added unit tests in `Job TrackerTests/MetaSmartGlassesServiceTests.swift` which verify default settings, service state when enabled without the adapter, and `JobPhotoSlot` display titles; these tests passed. 
- Ran the existing unit test suite to ensure the new changes integrate with `JobPhotoUploadQueue` and build-time behavior; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dca24bd68832d81981fa698a3f805)