### PR TITLE
Add Meta Wearables DAT SPM and link MWDATCore/MWDATCamera; enable background modes

### DIFF
--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		CDDA11702D579F85007BADFF /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA116F2D579F85007BADFF /* FirebaseFirestore */; };
 		CD7E5700000000000000010C /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA116F2D579F85007BADFF /* FirebaseFirestore */; };
 		CDDA11722D579F85007BADFF /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA11712D579F85007BADFF /* FirebaseStorage */; };
+		CDFACE000000000000000001 /* MWDATCore in Frameworks */ = {isa = PBXBuildFile; productRef = CDFACE000000000000000004 /* MWDATCore */; };
+		CDFACE000000000000000002 /* MWDATCamera in Frameworks */ = {isa = PBXBuildFile; productRef = CDFACE000000000000000005 /* MWDATCamera */; };
 		CDFE39FE2FA3624A00AEEAAB /* WebMaps in Resources */ = {isa = PBXBuildFile; fileRef = CDFE39FD2FA3624A00AEEAAB /* WebMaps */; };
 		AA0000000000000000000003 /* Job Tracker Widgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000002 /* Job Tracker Widgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -142,6 +144,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDFACE000000000000000001 /* MWDATCore in Frameworks */,
+				CDFACE000000000000000002 /* MWDATCamera in Frameworks */,
 				CDDA116E2D579F85007BADFF /* FirebaseDatabase in Frameworks */,
 				CDDA11702D579F85007BADFF /* FirebaseFirestore in Frameworks */,
 				CDDA116C2D579F85007BADFF /* FirebaseCore in Frameworks */,
@@ -271,6 +275,8 @@
 				CDDA116D2D579F85007BADFF /* FirebaseDatabase */,
 				CDDA116F2D579F85007BADFF /* FirebaseFirestore */,
 				CDDA11712D579F85007BADFF /* FirebaseStorage */,
+				CDFACE000000000000000004 /* MWDATCore */,
+				CDFACE000000000000000005 /* MWDATCamera */,
 			);
 			productName = "Job Tracker";
 			productReference = CDDA111D2D579EC0007BADFF /* Job Tracker.app */;
@@ -385,6 +391,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				CDDA11682D579F85007BADFF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				CDFACE000000000000000003 /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CDDA111E2D579EC0007BADFF /* Products */;
@@ -704,7 +711,7 @@
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UIBackgroundModes = location;
+				INFOPLIST_KEY_UIBackgroundModes = "location bluetooth-peripheral external-accessory";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -749,7 +756,7 @@
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UIBackgroundModes = location;
+				INFOPLIST_KEY_UIBackgroundModes = "location bluetooth-peripheral external-accessory";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -988,6 +995,14 @@
 				minimumVersion = 11.8.1;
 			};
 		};
+		CDFACE000000000000000003 /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/facebook/meta-wearables-dat-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1015,6 +1030,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CDDA11682D579F85007BADFF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseStorage;
+		};
+		CDFACE000000000000000004 /* MWDATCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDFACE000000000000000003 /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
+			productName = MWDATCore;
+		};
+		CDFACE000000000000000005 /* MWDATCamera */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDFACE000000000000000003 /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
+			productName = MWDATCamera;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
### Motivation
- Add the Meta Wearables DAT Swift package to the Xcode project and expose its products to the main app so the Job Tracker app can use the DAT functionality.
- Link `MWDATCore` and `MWDATCamera` into the main app target so those modules are available at build time.
- Enable additional Background Modes required by the package and peripherals for runtime behavior.

### Description
- Updated `Job Tracker.xcodeproj/project.pbxproj` to add an `XCRemoteSwiftPackageReference` for `https://github.com/facebook/meta-wearables-dat-ios` with `upToNextMajorVersion` minimum `0.7.0`.
- Added `MWDATCore` and `MWDATCamera` as `XCSwiftPackageProductDependency` entries and linked them in the main `Job Tracker` target's `packageProductDependencies` and `Frameworks` build phase.
- Added PBXBuildFile entries for the two products and ensured their IDs are valid; updated the `packageReferences` list to include the new package.
- Updated the `INFOPLIST_KEY_UIBackgroundModes` build setting in both Debug and Release configurations to include `location`, `bluetooth-peripheral`, and `external-accessory`.

### Testing
- Ran `plutil -- 'Job Tracker.xcodeproj/project.pbxproj'` and it reported the project file is syntactically OK.
- Verified package and product entries with `rg -n "MWDAT|meta-wearables|UIBackgroundModes" 'Job Tracker.xcodeproj/project.pbxproj'` and confirmed the new references are present.
- Attempted `xcodebuild -resolvePackageDependencies -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker'` but it could not be run in this environment because `xcodebuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dda75ce6c832dbb2fe1bddc8f9dcb)