### PR TITLE
Fix Meta glasses parameter summary

### DIFF
--- a/Job Tracker/intent/MetaSmartGlassesIntents.swift
+++ b/Job Tracker/intent/MetaSmartGlassesIntents.swift
@@ -33,7 +33,7 @@ struct AddMetaSmartGlassesJobNoteIntent: AppIntent {
     var details: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Add \(AddMetaSmartGlassesJobNoteIntent.$evidenceType) note: \(AddMetaSmartGlassesJobNoteIntent.$details)")
+        Summary("Add \(\AddMetaSmartGlassesJobNoteIntent.$evidenceType) note: \(\AddMetaSmartGlassesJobNoteIntent.$details)")
     }
 
     func perform() async throws -> some ProvidesDialog {


### PR DESCRIPTION
### Motivation
- Fix incorrect AppIntent parameter interpolation in `AddMetaSmartGlassesJobNoteIntent.parameterSummary` to match the `ParameterSummary` style used elsewhere and address the compile error reported at `MetaSmartGlassesIntents.swift:36`.

### Description
- Replace `Summary("Add \(AddMetaSmartGlassesJobNoteIntent.$evidenceType) note: \(AddMetaSmartGlassesJobNoteIntent.$details)")` with `Summary("Add \(\AddMetaSmartGlassesJobNoteIntent.$evidenceType) note: \(\AddMetaSmartGlassesJobNoteIntent.$details)")` in `Job Tracker/intent/MetaSmartGlassesIntents.swift`.

### Testing
- Committed the change and verified the file diff with `git`, which succeeded, but `xcodebuild` is not available in this environment so the iOS build/compile could not be run to confirm the error is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de273e5a8832d891bf9033220b5e2)