### PR TITLE
Open Gibson portal in-app using SFSafariViewController

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -84,7 +84,6 @@ private struct DashboardJobSectionHeader: View {
 }
 
 struct JobCard: View {
-    @Environment(\.openURL) private var openURL
 
     let job: Job
     let isHere: Bool
@@ -99,6 +98,7 @@ struct JobCard: View {
     @State private var showStatusDialog = false
     @State private var showCustomStatusEntry = false
     @State private var customStatusText = ""
+    @State private var portalPage: GibsonPortalPage?
 
     init(
         job: Job,
@@ -150,6 +150,9 @@ struct JobCard: View {
         .alert("Delete this job?", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive, action: onDelete)
             Button("Cancel", role: .cancel) { }
+        }
+        .sheet(item: $portalPage) { page in
+            GibsonPortalView(url: page.url)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(houseNumber(job.address)), \(DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))")
@@ -322,7 +325,7 @@ struct JobCard: View {
 
     private func openPortal() {
         guard let url = job.gibsonPortalURL else { return }
-        openURL(url)
+        portalPage = GibsonPortalPage(url: url)
     }
 
     private func statusBackground(for status: String) -> Color {

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -18,6 +18,7 @@ struct JobSearchDetailView: View {
     @State private var isAdding = false
     @State private var errorMessage: String? = nil
     @State private var alertState: AlertState?
+    @State private var portalPage: GibsonPortalPage?
 
     private struct AlertState: Identifiable {
         enum Kind {
@@ -148,6 +149,9 @@ struct JobSearchDetailView: View {
                 ActivityView(activityItems: shareItems, subject: "Job link for \(subject)")
             }
         }
+        .sheet(item: $portalPage) { page in
+            GibsonPortalView(url: page.url)
+        }
         .alert(item: $alertState) { state in
             Alert(
                 title: Text(state.title),
@@ -244,7 +248,7 @@ struct JobSearchDetailView: View {
 
     private func openPortal(job: Job) {
         guard let url = job.gibsonPortalURL else { return }
-        UIApplication.shared.open(url)
+        portalPage = GibsonPortalPage(url: url)
     }
 
     private func openInMaps(job: Job) {
@@ -648,6 +652,7 @@ struct UniversalJobDetailView: View {
     @EnvironmentObject private var usersViewModel: UsersViewModel
     @Environment(\.dismiss) private var dismiss
     @AppStorage("addressSuggestionProvider") private var suggestionProviderRaw = "apple"
+    @State private var portalPage: GibsonPortalPage?
 
     private var summaryTitle: String {
         displayValue(job.shortAddress).flatMap { $0.isEmpty ? nil : $0 } ?? displayValue(job.address) ?? "Job"
@@ -754,6 +759,9 @@ struct UniversalJobDetailView: View {
             }
         }
         .jtNavigationBarStyle()
+        .sheet(item: $portalPage) { page in
+            GibsonPortalView(url: page.url)
+        }
     }
 
     private var summaryCard: some View {
@@ -824,7 +832,7 @@ struct UniversalJobDetailView: View {
 
     private func openPortal(job: Job) {
         guard let url = job.gibsonPortalURL else { return }
-        UIApplication.shared.open(url)
+        portalPage = GibsonPortalPage(url: url)
     }
 
     private func openInMaps(job: Job) {

--- a/Job Tracker/Features/Shared/Components/GibsonPortalView.swift
+++ b/Job Tracker/Features/Shared/Components/GibsonPortalView.swift
@@ -1,0 +1,36 @@
+import SafariServices
+import SwiftUI
+
+struct GibsonPortalPage: Identifiable {
+    let url: URL
+
+    var id: String { url.absoluteString }
+
+    static let login = GibsonPortalPage(url: Job.gibsonPortalLoginURL)
+}
+
+struct GibsonPortalView: View {
+    let url: URL
+
+    var body: some View {
+        SafariView(url: url)
+            .ignoresSafeArea()
+    }
+}
+
+private struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let configuration = SFSafariViewController.Configuration()
+        configuration.entersReaderIfAvailable = false
+        configuration.barCollapsingEnabled = true
+        let controller = SFSafariViewController(url: url, configuration: configuration)
+        controller.dismissButtonStyle = .done
+        controller.preferredBarTintColor = UIColor.systemBackground
+        controller.preferredControlTintColor = UIColor.systemBlue
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) { }
+}

--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -17,6 +17,7 @@ final class AppNavigationViewModel: ObservableObject {
         case settings
         case helpCenter
         case spliceAssist
+        case gibsonPortal
 
         var id: String { title }
 
@@ -36,6 +37,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .settings:    return "Settings"
             case .helpCenter:  return "Help Center"
             case .spliceAssist: return "Splice Assist"
+            case .gibsonPortal: return "Gibson Portal"
         }
         }
 
@@ -55,6 +57,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .settings:    return "gearshape"
             case .helpCenter:  return "questionmark.circle"
             case .spliceAssist: return "wand.and.stars"
+            case .gibsonPortal: return "safari"
         }
         }
 
@@ -73,14 +76,15 @@ final class AppNavigationViewModel: ObservableObject {
                  .admin,
                  .settings,
                  .helpCenter,
-                 .spliceAssist:
+                 .spliceAssist,
+                 .gibsonPortal:
                 return .more
         }
         }
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs, .spliceAssist:
+            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs, .spliceAssist, .gibsonPortal:
                 return true
             default:
                 return false

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -127,6 +127,10 @@ private struct MoreMenuList: View {
                     Label(AppNavigationViewModel.Destination.maps.title,
                           systemImage: AppNavigationViewModel.Destination.maps.systemImage)
                 }
+                NavigationLink(value: AppNavigationViewModel.Destination.gibsonPortal) {
+                    Label(AppNavigationViewModel.Destination.gibsonPortal.title,
+                          systemImage: AppNavigationViewModel.Destination.gibsonPortal.systemImage)
+                }
             }
 
             Section("Splice Assist") {
@@ -188,6 +192,10 @@ private struct MoreDestinationView: View {
             RecentCrewJobsView()
         case .spliceAssist:
             SpliceAssistView()
+        case .gibsonPortal:
+            GibsonPortalView(url: Job.gibsonPortalLoginURL)
+                .navigationTitle(AppNavigationViewModel.Destination.gibsonPortal.title)
+                .navigationBarTitleDisplayMode(.inline)
         case .more:
             MoreMenuList()
         default:

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -122,6 +122,11 @@ extension Job {
 extension Job {
     static let portalBaseURLString = "https://portal.gibsonemc.com/edit"
     static let locationSearchBaseURLString = "https://portal.gibsonemc.com/consumers/search/"
+    static let portalLoginURL = "https://portal.gibsonemc.com/accounts/login/?next=/"
+
+    static var gibsonPortalLoginURL: URL {
+        URL(string: portalLoginURL)!
+    }
 
     /// Accepts either a plain portal ID (for example, "97087") or a full Gibson portal URL
     /// and returns the numeric edit ID that should be stored on the job.


### PR DESCRIPTION
### Motivation
- Allow users to open the Gibson portal inside the app instead of leaving to the external browser and provide a manual entry point to the portal from More → Resources. 

### Description
- Add an in-app portal wrapper `GibsonPortalView` that hosts `SFSafariViewController` for presenting Gibson pages. 
- Replace direct external opens with an in-app presentation by introducing `GibsonPortalPage` state and presenting `GibsonPortalView` via `.sheet(item:)` from job list and job detail UI. 
- Add a `Gibson Portal` destination to the More > Resources menu and wire it to open the portal login URL using `GibsonPortalView`. 
- Centralize the portal login URL on the `Job` model as `portalLoginURL` / `gibsonPortalLoginURL` for reuse.

### Testing
- Attempted an Xcode build with `xcodebuild -scheme 'Job Tracker' -project 'Job Tracker.xcodeproj' -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation -skipMacroValidation build`, which failed because `xcodebuild` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de40e4db4832db8db0fde9e87a280)