### PR TITLE
Add Map Design photo slot and Weekly Map Designs screen

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -104,6 +104,7 @@ private let jobPlacementChoices = ["OH", "UG"]
     @State private var housePhotoImage: UIImage?
     @State private var nidPhotoImage: UIImage?
     @State private var canPhotoImage: UIImage?
+    @State private var mapDesignPhotoImage: UIImage?
 
     // Full-screen viewer state
     @State private var fullScreenImageURL: URL? = nil
@@ -410,6 +411,8 @@ private let jobPlacementChoices = ["OH", "UG"]
                                 nidPhotoImage = newImage
                             case .can:
                                 canPhotoImage = newImage
+                            case .mapDesign:
+                                mapDesignPhotoImage = newImage
                             case .none:
                                 break
                             }
@@ -590,6 +593,7 @@ extension JobDetailView {
             jobPhotoSlotCard(title: "House Picture", urlString: job.housePhotoURL, image: housePhotoImage, slot: .house)
             jobPhotoSlotCard(title: "NID Picture", urlString: job.nidPhotoURL, image: nidPhotoImage, slot: .nid)
             jobPhotoSlotCard(title: "CAN Picture", urlString: job.canPhotoURL, image: canPhotoImage, slot: .can)
+            jobPhotoSlotCard(title: "Map Design", urlString: job.mapDesignPhotoURL, image: mapDesignPhotoImage, slot: .mapDesign)
 
             if !job.photos.isEmpty {
                 legacyPhotosSection
@@ -995,7 +999,8 @@ extension JobDetailView {
         let pending: [(slot: JobPhotoSlot, image: UIImage)] = [
             housePhotoImage.map { (.house, $0) },
             nidPhotoImage.map { (.nid, $0) },
-            canPhotoImage.map { (.can, $0) }
+            canPhotoImage.map { (.can, $0) },
+            mapDesignPhotoImage.map { (.mapDesign, $0) }
         ].compactMap { $0 }
 
         guard !pending.isEmpty else { return }

--- a/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
+++ b/Job Tracker/Features/Shared/Services/JobPhotoUploadQueue.swift
@@ -10,6 +10,7 @@ enum JobPhotoSlot: String, Codable, CaseIterable {
     case house
     case nid
     case can
+    case mapDesign
 
     var firestoreField: String {
         switch self {
@@ -19,6 +20,8 @@ enum JobPhotoSlot: String, Codable, CaseIterable {
             return "nidPhotoURL"
         case .can:
             return "canPhotoURL"
+        case .mapDesign:
+            return "mapDesignPhotoURL"
         }
     }
 
@@ -30,6 +33,8 @@ enum JobPhotoSlot: String, Codable, CaseIterable {
             return "NID Photo"
         case .can:
             return "CAN Photo"
+        case .mapDesign:
+            return "Map Design"
         }
     }
 }

--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -8,6 +8,7 @@ final class AppNavigationViewModel: ObservableObject {
         case yellowSheet
         case maps
         case recentCrewJobs
+        case mapDesigns
         case search
         case more
         case profile
@@ -28,6 +29,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .yellowSheet: return "Yellow Sheet"
             case .maps:        return "Route Mapper"
             case .recentCrewJobs: return "Recent Crew Jobs"
+            case .mapDesigns: return "Map Designs"
             case .search:      return "Job Search"
             case .more:        return "More"
             case .profile:     return "Profile"
@@ -48,6 +50,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .yellowSheet: return "doc.text"
             case .maps:        return "map"
             case .recentCrewJobs: return "clock.arrow.circlepath"
+            case .mapDesigns: return "map.fill"
             case .search:      return "magnifyingglass"
             case .more:        return "ellipsis.circle"
             case .profile:     return "person.crop.circle"
@@ -68,6 +71,7 @@ final class AppNavigationViewModel: ObservableObject {
             case .yellowSheet: return .yellowSheet
             case .maps:        return .more
             case .recentCrewJobs: return .more
+            case .mapDesigns: return .more
             case .search:      return .search
             case .more,
                  .profile,
@@ -84,7 +88,7 @@ final class AppNavigationViewModel: ObservableObject {
 
         var isMoreStackDestination: Bool {
             switch self {
-            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs, .spliceAssist, .gibsonPortal:
+            case .more, .profile, .findPartner, .supervisor, .admin, .settings, .helpCenter, .maps, .recentCrewJobs, .mapDesigns, .spliceAssist, .gibsonPortal:
                 return true
             default:
                 return false

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct MainTabView: View {
     var body: some View {
@@ -120,6 +121,10 @@ private struct MoreMenuList: View {
                     Label(AppNavigationViewModel.Destination.recentCrewJobs.title,
                           systemImage: AppNavigationViewModel.Destination.recentCrewJobs.systemImage)
                 }
+                NavigationLink(value: AppNavigationViewModel.Destination.mapDesigns) {
+                    Label(AppNavigationViewModel.Destination.mapDesigns.title,
+                          systemImage: AppNavigationViewModel.Destination.mapDesigns.systemImage)
+                }
             }
 
             Section("Resources") {
@@ -190,6 +195,8 @@ private struct MoreDestinationView: View {
             HelpCenterView()
         case .recentCrewJobs:
             RecentCrewJobsView()
+        case .mapDesigns:
+            WeeklyMapDesignsView()
         case .spliceAssist:
             SpliceAssistView()
         case .gibsonPortal:
@@ -714,5 +721,173 @@ struct AdminUpdateLogsView: View {
             }
         }
         .navigationTitle("Update Logs")
+    }
+}
+
+// MARK: - Weekly Map Designs
+
+struct WeeklyMapDesignsView: View {
+    @StateObject private var timesheetJobsVM = TimesheetJobsViewModel()
+    @State private var selectedDate = Date()
+    @State private var shareItems: [Any] = []
+    @State private var isPreparingShare = false
+    @State private var isShowingShareSheet = false
+    @State private var shareErrorMessage: String?
+
+    private var completedJobs: [Job] {
+        timesheetJobsVM.jobs
+            .filter { $0.isDone }
+            .sorted { $0.date < $1.date }
+    }
+
+    private var jobsWithMapDesigns: [Job] {
+        completedJobs.filter { $0.mapDesignPhotoURL?.isEmpty == false }
+    }
+
+    var body: some View {
+        List {
+            Section {
+                DatePicker("Week", selection: $selectedDate, displayedComponents: .date)
+                    .datePickerStyle(.compact)
+                    .onChange(of: selectedDate) { _, newValue in
+                        timesheetJobsVM.fetchJobsForWeek(selectedDate: newValue)
+                    }
+            } footer: {
+                Text("Shows done jobs for the selected week, using the same weekly job window as timesheets.")
+            }
+
+            Section {
+                Button {
+                    Task { await prepareShare() }
+                } label: {
+                    if isPreparingShare {
+                        Label("Preparing Map Designs…", systemImage: "hourglass")
+                    } else {
+                        Label("Share Weekly Map Designs", systemImage: "square.and.arrow.up")
+                    }
+                }
+                .disabled(isPreparingShare || jobsWithMapDesigns.isEmpty)
+
+                if jobsWithMapDesigns.isEmpty {
+                    Text("No done jobs with map designs for this week yet.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Done Jobs") {
+                if completedJobs.isEmpty {
+                    Text("No done jobs found for this week.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(completedJobs) { job in
+                        WeeklyMapDesignJobRow(job: job)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(JTGradients.background(stops: 4).ignoresSafeArea())
+        .navigationTitle("Map Designs")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { timesheetJobsVM.fetchJobsForWeek(selectedDate: selectedDate) }
+        .sheet(isPresented: $isShowingShareSheet) {
+            ActivityView(activityItems: shareItems, subject: "Weekly Map Designs")
+        }
+        .alert("Map Designs", isPresented: Binding(
+            get: { shareErrorMessage != nil },
+            set: { if !$0 { shareErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { shareErrorMessage = nil }
+        } message: {
+            Text(shareErrorMessage ?? "")
+        }
+    }
+
+    @MainActor
+    private func prepareShare() async {
+        isPreparingShare = true
+        defer { isPreparingShare = false }
+
+        var items: [Any] = ["Map Designs for \(formattedWeekRange(containing: selectedDate))"]
+        for job in jobsWithMapDesigns {
+            guard let urlString = job.mapDesignPhotoURL, let url = URL(string: urlString) else { continue }
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                if let image = UIImage(data: data) {
+                    items.append("\(job.shortAddress) — \(job.date.formatted(date: .abbreviated, time: .omitted))")
+                    items.append(image)
+                }
+            } catch {
+                #if DEBUG
+                print("[WeeklyMapDesignsView] Failed to load map design: \(error.localizedDescription)")
+                #endif
+            }
+        }
+
+        guard items.count > 1 else {
+            shareErrorMessage = "No map design images could be loaded for sharing."
+            return
+        }
+
+        shareItems = items
+        isShowingShareSheet = true
+    }
+
+    private func formattedWeekRange(containing date: Date) -> String {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 1
+        guard let interval = calendar.dateInterval(of: .weekOfYear, for: date),
+              let end = calendar.date(byAdding: .day, value: -1, to: interval.end) else {
+            return date.formatted(date: .abbreviated, time: .omitted)
+        }
+        return "\(interval.start.formatted(date: .abbreviated, time: .omitted)) – \(end.formatted(date: .abbreviated, time: .omitted))"
+    }
+}
+
+private struct WeeklyMapDesignJobRow: View {
+    let job: Job
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(job.shortAddress)
+                        .font(.headline)
+                    Text(job.date, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(job.displayStatus)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            if let urlString = job.mapDesignPhotoURL, let url = URL(string: urlString) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                            .frame(maxWidth: .infinity, minHeight: 160)
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    case .failure:
+                        Label("Map design failed to load", systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.secondary)
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+            } else {
+                Label("No map design uploaded", systemImage: "photo.badge.plus")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 6)
     }
 }

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -17,6 +17,7 @@ struct Job: Identifiable, Codable {
     var housePhotoURL: String?
     var nidPhotoURL: String?
     var canPhotoURL: String?
+    var mapDesignPhotoURL: String?
     var participants: [String]?     // userIDs who can see this job (visibility list)
     // Geographic coordinates (optional; filled when geocoded or user-entered)
     var latitude: Double?
@@ -46,6 +47,7 @@ struct Job: Identifiable, Codable {
         housePhotoURL: String? = nil,
         nidPhotoURL: String? = nil,
         canPhotoURL: String? = nil,
+        mapDesignPhotoURL: String? = nil,
         participants: [String]? = nil,
         hours: Double = 0.0,
         nidFootage: String? = nil,
@@ -70,6 +72,7 @@ struct Job: Identifiable, Codable {
         self.housePhotoURL = housePhotoURL
         self.nidPhotoURL = nidPhotoURL
         self.canPhotoURL = canPhotoURL
+        self.mapDesignPhotoURL = mapDesignPhotoURL
         self.participants = participants
         self.hours = hours
         self.nidFootage = nidFootage


### PR DESCRIPTION
### Motivation

- Add first-class support for a "Map Design" photo per job so map designs can be uploaded, stored, queued for upload, viewed and shared by crews.
- Expose a weekly UI to review and share map design images for completed jobs to streamline weekly map handoffs.

### Description

- Add `mapDesignPhotoURL` to the `Job` model and include it in the initializer to persist per-job map design URLs.
- Extend `JobPhotoSlot` with a `.mapDesign` case and wire its `firestoreField` and `displayTitle` values so the upload queue can target the new slot.
- Update `JobDetailView` to support picking, previewing and enqueuing a `mapDesign` photo by adding `mapDesignPhotoImage`, handling the `.mapDesign` slot in the image picker, showing a photo card, and enqueuing it alongside other job photos in `enqueuePendingPhotosIfNeeded()`.
- Add a new `WeeklyMapDesignsView` (and its `WeeklyMapDesignJobRow`) and register it in the navigation (`AppNavigationViewModel` and `More` menu) to list done jobs, preview map design images, and prepare/share a weekly aggregate via an activity sheet.
- Small UI/supporting changes: add `import UIKit` in `MainTabView` for `UIImage` usage and add navigation entries and icons for the new screen.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3189561ac4832da00448ed0ea7c696)