### PR TITLE
Detect duplicates while typing addresses and allow adding existing jobs to dashboard

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -174,6 +174,50 @@ private struct AddressDraft: Identifiable, Equatable {
     }
 }
 
+private struct DuplicateJobCandidate: Identifiable, Hashable {
+    let entry: JobSearchIndexEntry
+    let reasons: [String]
+    let score: Int
+
+    var id: String { entry.id }
+
+    var label: String {
+        let trimmedJobNumber = entry.jobNumber?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmedJobNumber.isEmpty { return entry.address }
+        return "\(entry.address) • Job #\(trimmedJobNumber)"
+    }
+}
+
+private struct AddressDuplicateConfirmation: Identifiable {
+    let id = UUID()
+    let addressID: AddressDraft.ID
+    let address: String
+    let matches: [DuplicateJobCandidate]
+
+    var message: String {
+        let matchSummary = matches.prefix(3).map { candidate in
+            "• \(candidate.label) (\(candidate.reasons.joined(separator: ", ")))"
+        }.joined(separator: "\n")
+
+        return "Existing job(s) already match this address. Add one to your dashboard so everyone shares the same notes, or continue creating your own separate job.\n\n\(matchSummary)"
+    }
+}
+
+private struct DuplicateJobConfirmation: Identifiable {
+    let id = UUID()
+    let newJob: Job
+    let matches: [DuplicateJobCandidate]
+    let remainingJobs: [Job]
+
+    var message: String {
+        let matchSummary = matches.prefix(3).map { candidate in
+            "• \(candidate.label) (\(candidate.reasons.joined(separator: ", ")))"
+        }.joined(separator: "\n")
+
+        return "This may already be in Job Tracker. Add the existing job to your dashboard so everyone shares notes, or create a separate job if this is truly different.\n\n\(matchSummary)"
+    }
+}
+
 struct CreateJobView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var jobsViewModel: JobsViewModel
@@ -196,6 +240,11 @@ struct CreateJobView: View {
     @StateObject private var locationProvider = LocationProvider()
 
     @State private var alertMessage: String?
+    @State private var duplicateConfirmation: DuplicateJobConfirmation?
+    @State private var addressDuplicateConfirmation: AddressDuplicateConfirmation?
+    @State private var addressDuplicateCheckTask: Task<Void, Never>?
+    @State private var ignoredDuplicateAddressIDs: Set<AddressDraft.ID> = []
+    @State private var ignoredDuplicateAddressKeys: Set<String> = []
 
     let statusOptions = ["Pending","OH","UG","Nid","Can","Done","Talk to Rick","Custom"]
 
@@ -426,6 +475,38 @@ struct CreateJobView: View {
                     Text(alertMessage)
                 }
             })
+            .confirmationDialog("Existing Job Found", isPresented: addressDuplicateConfirmationBinding, presenting: addressDuplicateConfirmation, titleVisibility: .visible, actions: { confirmation in
+                ForEach(confirmation.matches.prefix(5)) { candidate in
+                    Button("Add to Dashboard: \(candidate.label)") {
+                        addExistingJobToDashboard(candidate.entry.id, addressID: confirmation.addressID)
+                    }
+                }
+                Button("Continue Creating My Own", role: .destructive) {
+                    ignoredDuplicateAddressIDs.insert(confirmation.addressID)
+                    ignoredDuplicateAddressKeys.insert(normalizedAddressKey(confirmation.address))
+                    addressDuplicateConfirmation = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    addressDuplicateConfirmation = nil
+                }
+            }, message: { confirmation in
+                Text(confirmation.message)
+            })
+            .confirmationDialog("Possible Duplicate Job", isPresented: duplicateConfirmationBinding, presenting: duplicateConfirmation, titleVisibility: .visible, actions: { confirmation in
+                ForEach(confirmation.matches.prefix(5)) { candidate in
+                    Button("Add to Dashboard: \(candidate.label)") {
+                        joinExistingJob(candidate.entry.id, remainingJobs: confirmation.remainingJobs)
+                    }
+                }
+                Button("Create Separate Job", role: .destructive) {
+                    createJobAndContinue(confirmation.newJob, remainingJobs: confirmation.remainingJobs)
+                }
+                Button("Cancel", role: .cancel) {
+                    duplicateConfirmation = nil
+                }
+            }, message: { confirmation in
+                Text(confirmation.message)
+            })
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
                     if focusedAddressID != nil {
@@ -452,6 +533,9 @@ struct CreateJobView: View {
                 }
                 let current = addresses.first(where: { $0.id == newValue })?.text ?? ""
                 handleAddressQueryChange(current)
+            }
+            .onAppear {
+                jobsViewModel.startSearchIndexForAllJobs()
             }
         }
     }
@@ -501,17 +585,12 @@ struct CreateJobView: View {
         let portalIDValue = Job.normalizedPortalID(from: portalID)
         let locationNumberValue = Job.normalizedLocationNumber(from: locationNumber)
 
-        func processAddress(at index: Int) {
-            if index >= addressesToSave.count {
-                DispatchQueue.main.async { dismiss() }
-                return
-            }
-
-            let currentAddress = addressesToSave[index]
-            Task {
+        Task {
+            var preparedJobs: [Job] = []
+            for currentAddress in addressesToSave {
                 let coord = await MapKitGeocoding.coordinate(for: currentAddress)
 
-                let job = Job(
+                preparedJobs.append(Job(
                     address: currentAddress,
                     date: date,
                     status: finalStatus,
@@ -525,20 +604,163 @@ struct CreateJobView: View {
                     materialsUsed: materialsUsed,
                     latitude: coord?.latitude,
                     longitude: coord?.longitude
-                )
+                ))
+            }
 
-                DispatchQueue.main.async {
-                    jobsViewModel.createJob(job)
-                    if index == addressesToSave.count - 1 {
-                        dismiss()
-                    } else {
-                        processAddress(at: index + 1)
-                    }
-                }
+            await MainActor.run {
+                processPreparedJobs(preparedJobs)
             }
         }
+    }
 
-        processAddress(at: 0)
+    private func processPreparedJobs(_ jobs: [Job]) {
+        guard let next = jobs.first else {
+            dismiss()
+            return
+        }
+
+        let remaining = Array(jobs.dropFirst())
+        let matches = ignoredDuplicateAddressKeys.contains(normalizedAddressKey(next.address)) ? [] : duplicateMatches(for: next)
+        if !matches.isEmpty {
+            duplicateConfirmation = DuplicateJobConfirmation(
+                newJob: next,
+                matches: matches,
+                remainingJobs: remaining
+            )
+            return
+        }
+
+        createJobAndContinue(next, remainingJobs: remaining)
+    }
+
+    private func createJobAndContinue(_ job: Job, remainingJobs: [Job]) {
+        duplicateConfirmation = nil
+        jobsViewModel.createJob(job) { _ in
+            processPreparedJobs(remainingJobs)
+        }
+    }
+
+    private func joinExistingJob(_ jobID: String, remainingJobs: [Job]) {
+        duplicateConfirmation = nil
+        jobsViewModel.addCurrentUserAsParticipant(to: jobID) { success in
+            if success {
+                processPreparedJobs(remainingJobs)
+            } else {
+                alertMessage = "Could not add that existing job to your dashboard. Please try again or create a separate job."
+            }
+        }
+    }
+
+    private func addExistingJobToDashboard(_ jobID: String, addressID: AddressDraft.ID) {
+        addressDuplicateConfirmation = nil
+        jobsViewModel.addCurrentUserAsParticipant(to: jobID) { success in
+            if success {
+                removeAddress(id: addressID)
+                alertMessage = "Existing job added to your dashboard. No duplicate job was created."
+            } else {
+                alertMessage = "Could not add that existing job to your dashboard. Please try again or continue creating your own."
+            }
+        }
+    }
+
+    private func duplicateMatches(for job: Job) -> [DuplicateJobCandidate] {
+        let candidates = jobsViewModel.allSearchEntries.compactMap { entry -> DuplicateJobCandidate? in
+            var reasons: [String] = []
+            var score = 0
+
+            if let jobPortalID = job.normalizedPortalID,
+               let entryPortalID = Job.normalizedPortalID(from: entry.portalID),
+               jobPortalID == entryPortalID {
+                reasons.append("Portal ID")
+                score += 100
+            }
+
+            if let jobLocationNumber = job.normalizedLocationNumber,
+               let entryLocationNumber = Job.normalizedLocationNumber(from: entry.locationNumber),
+               jobLocationNumber == entryLocationNumber {
+                reasons.append("Location Number")
+                score += 100
+            }
+
+            if let distance = coordinateDistance(from: job, to: entry) {
+                if distance <= 50 {
+                    reasons.append("same coordinates")
+                    score += 90
+                } else if distance <= 200 {
+                    reasons.append("nearby coordinates")
+                    score += 45
+                }
+            }
+
+            let addressComparison = compareAddresses(job.address, entry.address)
+            if addressComparison.isExact {
+                reasons.append("address")
+                score += 80
+            } else if addressComparison.isClose {
+                reasons.append("similar address")
+                score += 35
+            }
+
+            guard !reasons.isEmpty, score >= 35 else { return nil }
+            return DuplicateJobCandidate(entry: entry, reasons: reasons, score: score)
+        }
+
+        return candidates.sorted { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.entry.date > rhs.entry.date
+        }
+    }
+
+    private func coordinateDistance(from job: Job, to entry: JobSearchIndexEntry) -> CLLocationDistance? {
+        guard let jobLatitude = job.latitude,
+              let jobLongitude = job.longitude,
+              let entryLatitude = entry.latitude,
+              let entryLongitude = entry.longitude else {
+            return nil
+        }
+
+        let newLocation = CLLocation(latitude: jobLatitude, longitude: jobLongitude)
+        let existingLocation = CLLocation(latitude: entryLatitude, longitude: entryLongitude)
+        return newLocation.distance(from: existingLocation)
+    }
+
+    private func compareAddresses(_ lhs: String, _ rhs: String) -> (isExact: Bool, isClose: Bool) {
+        let lhsKey = normalizedAddressKey(lhs)
+        let rhsKey = normalizedAddressKey(rhs)
+        guard !lhsKey.isEmpty, !rhsKey.isEmpty else { return (false, false) }
+        if lhsKey == rhsKey { return (true, false) }
+
+        let lhsTokens = Set(lhsKey.split(separator: " ").map(String.init))
+        let rhsTokens = Set(rhsKey.split(separator: " ").map(String.init))
+        let shared = lhsTokens.intersection(rhsTokens).count
+        let smallest = min(lhsTokens.count, rhsTokens.count)
+        return (false, smallest >= 3 && shared >= max(3, smallest - 1))
+    }
+
+    private func normalizedAddressKey(_ rawValue: String) -> String {
+        let replacements: [String: String] = [
+            "street": "st",
+            "st.": "st",
+            "avenue": "ave",
+            "ave.": "ave",
+            "road": "rd",
+            "rd.": "rd",
+            "drive": "dr",
+            "dr.": "dr",
+            "lane": "ln",
+            "ln.": "ln",
+            "court": "ct",
+            "ct.": "ct",
+            "highway": "hwy",
+            "hwy.": "hwy"
+        ]
+
+        return rawValue
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .map { replacements[$0] ?? $0 }
+            .joined(separator: " ")
     }
 
     // MARK: - Assignments helpers
@@ -577,7 +799,10 @@ struct CreateJobView: View {
     }
 
     private var alertTitle: String {
-        "Cannot Save"
+        if alertMessage == "Existing job added to your dashboard. No duplicate job was created." {
+            return "Added to Dashboard"
+        }
+        return "Cannot Save"
     }
 
     private var alertBinding: Binding<Bool> {
@@ -585,6 +810,24 @@ struct CreateJobView: View {
             get: { alertMessage != nil },
             set: { newValue in
                 if !newValue { alertMessage = nil }
+            }
+        )
+    }
+
+    private var duplicateConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { duplicateConfirmation != nil },
+            set: { newValue in
+                if !newValue { duplicateConfirmation = nil }
+            }
+        )
+    }
+
+    private var addressDuplicateConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { addressDuplicateConfirmation != nil },
+            set: { newValue in
+                if !newValue { addressDuplicateConfirmation = nil }
             }
         )
     }
@@ -598,9 +841,12 @@ struct CreateJobView: View {
                 get: { address.wrappedValue.text },
                 set: { newValue in
                     address.wrappedValue.text = newValue
+                    ignoredDuplicateAddressIDs.remove(addressID)
+                    ignoredDuplicateAddressKeys.remove(normalizedAddressKey(newValue))
                     if focusedAddressID == addressID {
                         handleAddressQueryChange(newValue)
                     }
+                    scheduleDuplicateCheck(for: addressID, address: newValue)
                 }
             ))
             .disableAutocorrection(true)
@@ -622,9 +868,12 @@ struct CreateJobView: View {
                         Button {
                             let composed = item.subtitle.isEmpty ? item.title : "\(item.title) \(item.subtitle)"
                             address.wrappedValue.text = composed
+                            ignoredDuplicateAddressIDs.remove(addressID)
+                            ignoredDuplicateAddressKeys.remove(normalizedAddressKey(composed))
                             addressSearch.results = []
                             focusedAddressID = nil
                             UIApplication.shared.endEditing()
+                            scheduleDuplicateCheck(for: addressID, address: composed, delayNanoseconds: 100_000_000)
                         } label: {
                             HStack(alignment: .center, spacing: 10) {
                                 VStack(alignment: .leading, spacing: 2) {
@@ -679,6 +928,41 @@ struct CreateJobView: View {
                 }
                 .padding(8)
                 .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func scheduleDuplicateCheck(for addressID: AddressDraft.ID, address: String, delayNanoseconds: UInt64 = 700_000_000) {
+        addressDuplicateCheckTask?.cancel()
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        let addressKey = normalizedAddressKey(trimmedAddress)
+        guard trimmedAddress.count >= 8, !ignoredDuplicateAddressIDs.contains(addressID), !ignoredDuplicateAddressKeys.contains(addressKey) else { return }
+
+        addressDuplicateCheckTask = Task {
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+            guard !Task.isCancelled else { return }
+            let coordinate = await MapKitGeocoding.coordinate(for: trimmedAddress)
+            await MainActor.run {
+                guard addresses.contains(where: { $0.id == addressID && $0.text.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedAddress }),
+                      !ignoredDuplicateAddressIDs.contains(addressID),
+                      !ignoredDuplicateAddressKeys.contains(addressKey) else { return }
+
+                let probe = Job(
+                    address: trimmedAddress,
+                    date: date,
+                    status: "Pending",
+                    createdBy: authViewModel.currentUser?.id,
+                    notes: "",
+                    jobNumber: jobNumber.isEmpty ? nil : jobNumber,
+                    portalID: Job.normalizedPortalID(from: portalID),
+                    locationNumber: Job.normalizedLocationNumber(from: locationNumber),
+                    latitude: coordinate?.latitude,
+                    longitude: coordinate?.longitude
+                )
+                let matches = duplicateMatches(for: probe)
+                if !matches.isEmpty {
+                    addressDuplicateConfirmation = AddressDuplicateConfirmation(addressID: addressID, address: trimmedAddress, matches: matches)
+                }
             }
         }
     }

--- a/Job Tracker/Features/Jobs/JobsViewModel.swift
+++ b/Job Tracker/Features/Jobs/JobsViewModel.swift
@@ -376,6 +376,34 @@ class JobsViewModel: ObservableObject {
         }
     }
 
+    func addCurrentUserAsParticipant(to jobID: String, completion: @escaping (Bool) -> Void = { _ in }) {
+        guard let userID = currentUserID(), !userID.isEmpty else {
+            completion(false)
+            return
+        }
+
+        db.collection("jobs").document(jobID).updateData([
+            "participants": FieldValue.arrayUnion([userID])
+        ]) { [weak self] error in
+            if let error = error {
+                print("Error joining existing job: \(error)")
+                DispatchQueue.main.async { completion(false) }
+                return
+            }
+
+            DispatchQueue.main.async {
+                if let index = self?.jobs.firstIndex(where: { $0.id == jobID }) {
+                    var participants = Set(self?.jobs[index].participants ?? [])
+                    participants.insert(userID)
+                    self?.jobs[index].participants = Array(participants).sorted()
+                    self?.rebuildSearchIndexEntries()
+                    self?.notifyJobsChanged()
+                }
+                completion(true)
+            }
+        }
+    }
+
     // MARK: - Update
 
     func updateJob(_ job: Job, documentID: String) {

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -209,6 +209,8 @@ protocol JobSearchMatchable {
     var nidFootage: String? { get }
     var canFootage: String? { get }
     var jobPlacement: String? { get }
+    var latitude: Double? { get }
+    var longitude: Double? { get }
 }
 
 extension Job: JobSearchMatchable {
@@ -231,6 +233,8 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
     var nidFootage: String?
     var canFootage: String?
     var jobPlacement: String?
+    var latitude: Double?
+    var longitude: Double?
 
     init(
         id: String,
@@ -246,7 +250,9 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         materialsUsed: String? = nil,
         nidFootage: String? = nil,
         canFootage: String? = nil,
-        jobPlacement: String? = nil
+        jobPlacement: String? = nil,
+        latitude: Double? = nil,
+        longitude: Double? = nil
     ) {
         self.id = id
         self.address = address
@@ -262,6 +268,8 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         self.nidFootage = nidFootage
         self.canFootage = canFootage
         self.jobPlacement = jobPlacement
+        self.latitude = latitude
+        self.longitude = longitude
     }
 
     init(job: Job) {
@@ -279,7 +287,9 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             materialsUsed: job.materialsUsed,
             nidFootage: job.nidFootage,
             canFootage: job.canFootage,
-            jobPlacement: job.jobPlacement
+            jobPlacement: job.jobPlacement,
+            latitude: job.latitude,
+            longitude: job.longitude
         )
     }
 
@@ -301,7 +311,9 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             hours: 0.0,
             nidFootage: nidFootage,
             canFootage: canFootage,
-            jobPlacement: jobPlacement
+            jobPlacement: jobPlacement,
+            latitude: latitude,
+            longitude: longitude
         )
         job.notes = notes
         job.assignments = assignments
@@ -312,6 +324,8 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         job.jobNumber = jobNumber
         job.portalID = Job.normalizedPortalID(from: portalID)
         job.locationNumber = Job.normalizedLocationNumber(from: locationNumber)
+        job.latitude = latitude
+        job.longitude = longitude
         job.createdBy = createdBy
         return job
     }


### PR DESCRIPTION
### Motivation
- Prevent duplicate job creation by detecting existing jobs immediately when a technician enters or selects an address so crews are auto-joined to the canonical job instead of creating separate records.

### Description
- Run a debounced duplicate probe as addresses are typed or selected from autocomplete and score candidates by Portal ID, Location Number, coordinate proximity, and normalized address, returning multiple sorted matches.
- Show an "Existing Job Found" confirmation dialog listing top matches with actions to "Add to Dashboard" (adds the current user to the existing job's `participants`) or to continue creating a separate job, and keep a save-time duplicate guard as a fallback that also surfaces multiple matches.
- Add client-side plumbing and UI types: `DuplicateJobCandidate`, `AddressDuplicateConfirmation`, `duplicateMatches(for:)`, `scheduleDuplicateCheck`, address ignore-keys/IDs to suppress repeated prompts, and join/remove behavior so adding an existing job removes that address from the create form.
- Extend search/index model and view-model support by exposing `latitude`/`longitude` on `JobSearchMatchable`/`JobSearchIndexEntry` and adding `addCurrentUserAsParticipant(to:)` to `JobsViewModel`.

### Testing
- Ran `git diff --check` to validate whitespace/style issues and it passed. (succeeded)
- Attempted `xcodebuild -list -project 'Job Tracker.xcodeproj'` but `xcodebuild` is not available in this environment, so a project build was not executed. (could not run)
- No unit or UI test suites were added or executed with this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318a2a9644832d88ecfa9c696f0d77)