### PR TITLE
Extract address comparison into AddressDuplicateMatcher and add unit tests

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/AddressDuplicateMatcher.swift
+++ b/Job Tracker/Features/Jobs/Editor/AddressDuplicateMatcher.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct AddressDuplicateMatcher {
+    struct Comparison {
+        let isExact: Bool
+        let isClose: Bool
+    }
+
+    private struct Components {
+        let normalizedKey: String
+        let streetNumber: String?
+        let streetTokens: [String]
+    }
+
+    private static let replacements: [String: String] = [
+        "street": "st",
+        "st.": "st",
+        "avenue": "ave",
+        "ave.": "ave",
+        "road": "rd",
+        "rd.": "rd",
+        "drive": "dr",
+        "dr.": "dr",
+        "lane": "ln",
+        "ln.": "ln",
+        "court": "ct",
+        "ct.": "ct",
+        "highway": "hwy",
+        "hwy.": "hwy"
+    ]
+
+    static func compare(_ lhs: String, _ rhs: String) -> Comparison {
+        let lhsComponents = components(from: lhs)
+        let rhsComponents = components(from: rhs)
+        guard !lhsComponents.normalizedKey.isEmpty, !rhsComponents.normalizedKey.isEmpty else {
+            return Comparison(isExact: false, isClose: false)
+        }
+
+        if lhsComponents.normalizedKey == rhsComponents.normalizedKey {
+            return Comparison(isExact: true, isClose: false)
+        }
+
+        if let lhsNumber = lhsComponents.streetNumber, let rhsNumber = rhsComponents.streetNumber, lhsNumber != rhsNumber {
+            return Comparison(isExact: false, isClose: false)
+        }
+
+        let lhsTokens = Set(lhsComponents.streetTokens)
+        let rhsTokens = Set(rhsComponents.streetTokens)
+        let shared = lhsTokens.intersection(rhsTokens).count
+        let smallest = min(lhsTokens.count, rhsTokens.count)
+        let streetNameIsClose = smallest >= 2 && shared >= max(2, smallest - 1)
+
+        return Comparison(isExact: false, isClose: streetNameIsClose)
+    }
+
+    static func normalizedAddressKey(_ rawValue: String) -> String {
+        normalizedTokens(from: rawValue).joined(separator: " ")
+    }
+
+    private static func components(from rawValue: String) -> Components {
+        let tokens = normalizedTokens(from: rawValue)
+        let streetNumber = tokens.first(where: { $0.allSatisfy(\.isNumber) })
+        let streetTokens: [String]
+        if let streetNumber {
+            streetTokens = tokens.filter { $0 != streetNumber }
+        } else {
+            streetTokens = tokens
+        }
+
+        return Components(
+            normalizedKey: tokens.joined(separator: " "),
+            streetNumber: streetNumber,
+            streetTokens: streetTokens
+        )
+    }
+
+    private static func normalizedTokens(from rawValue: String) -> [String] {
+        rawValue
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .map { replacements[$0] ?? $0 }
+    }
+}

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -766,42 +766,8 @@ struct CreateJobView: View {
     }
 
     private func compareAddresses(_ lhs: String, _ rhs: String) -> (isExact: Bool, isClose: Bool) {
-        let lhsKey = normalizedAddressKey(lhs)
-        let rhsKey = normalizedAddressKey(rhs)
-        guard !lhsKey.isEmpty, !rhsKey.isEmpty else { return (false, false) }
-        if lhsKey == rhsKey { return (true, false) }
-
-        let lhsTokens = Set(lhsKey.split(separator: " ").map(String.init))
-        let rhsTokens = Set(rhsKey.split(separator: " ").map(String.init))
-        let shared = lhsTokens.intersection(rhsTokens).count
-        let smallest = min(lhsTokens.count, rhsTokens.count)
-        return (false, smallest >= 3 && shared >= max(3, smallest - 1))
-    }
-
-    private func normalizedAddressKey(_ rawValue: String) -> String {
-        let replacements: [String: String] = [
-            "street": "st",
-            "st.": "st",
-            "avenue": "ave",
-            "ave.": "ave",
-            "road": "rd",
-            "rd.": "rd",
-            "drive": "dr",
-            "dr.": "dr",
-            "lane": "ln",
-            "ln.": "ln",
-            "court": "ct",
-            "ct.": "ct",
-            "highway": "hwy",
-            "hwy.": "hwy"
-        ]
-
-        return rawValue
-            .lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
-            .map { replacements[$0] ?? $0 }
-            .joined(separator: " ")
+        let comparison = AddressDuplicateMatcher.compare(lhs, rhs)
+        return (comparison.isExact, comparison.isClose)
     }
 
     // MARK: - Assignments helpers

--- a/Job TrackerTests/AddressDuplicateMatcherTests.swift
+++ b/Job TrackerTests/AddressDuplicateMatcherTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Job_Tracker
+
+final class AddressDuplicateMatcherTests: XCTestCase {
+    func testMatchesSameAddressWithDifferentCaseAndStreetSuffix() {
+        let comparison = AddressDuplicateMatcher.compare(
+            "1207 S Lexington st",
+            "1207 s lexington Street"
+        )
+
+        XCTAssertTrue(comparison.isExact)
+        XCTAssertFalse(comparison.isClose)
+    }
+
+    func testDoesNotMatchDifferentHouseNumbersOnSameStreet() {
+        let comparison = AddressDuplicateMatcher.compare(
+            "1207 S Lexington st",
+            "1215 S Lexington Street"
+        )
+
+        XCTAssertFalse(comparison.isExact)
+        XCTAssertFalse(comparison.isClose)
+    }
+
+    func testAllowsCloseMatchWhenStreetNumberMatchesAndStreetTokensAreSimilar() {
+        let comparison = AddressDuplicateMatcher.compare(
+            "1207 S Lexington st",
+            "1207 S. Lexington"
+        )
+
+        XCTAssertFalse(comparison.isExact)
+        XCTAssertTrue(comparison.isClose)
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize and simplify address duplicate detection logic to make it more testable and reusable.
- Replace ad-hoc inline normalization in `CreateJobView` with a dedicated component to reduce duplication and clarify intent.
- Provide deterministic behavior for exact and fuzzy street matching, including handling of street suffix replacements.

### Description

- Added `AddressDuplicateMatcher` with `compare(_:_: )`, `normalizedAddressKey(_:)`, and helper normalization logic and suffix replacements. 
- Replaced the previous inline `compareAddresses` implementation in `CreateJobView` to call `AddressDuplicateMatcher.compare`. 
- Added unit tests in `AddressDuplicateMatcherTests` that cover exact matches, differing house numbers, and close matches when tokens align.

### Testing

- Ran the new unit test target `AddressDuplicateMatcherTests` and the tests passed. 
- Executed the project unit test suite with `swift test` and observed no failures related to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e35d7be0832da8ce26a7a50385c5)