### PR TITLE
Preserve historical dates when adding duplicate jobs

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -685,22 +685,48 @@ struct CreateJobView: View {
     private func joinExistingJob(_ match: DuplicateJobMatch, prompt: DuplicateJobPrompt) {
         duplicatePrompt = nil
         let dashboardDate = prompt.newJob?.date ?? date
-        jobsViewModel.addCurrentUserAsParticipant(to: match.entry.id, scheduledDate: dashboardDate) { success in
-            if success {
-                var dashboardJob = match.entry.makePartialJob()
-                dashboardJob.date = dashboardDate
-                onAddedToDashboard?(dashboardJob)
+        let calendar = Calendar.current
 
-                if prompt.joinsAndContinuesSave {
-                    processPreparedJobs(prompt.remainingJobs)
-                } else if let addressID = prompt.addressID {
-                    removeAddress(id: addressID)
-                }
-
-                dismiss()
-            } else {
-                alertMessage = "Could not add you to the existing job. Please try again or create a separate job."
+        if calendar.isDate(match.entry.date, inSameDayAs: dashboardDate) {
+            jobsViewModel.addCurrentUserAsParticipant(to: match.entry.id) { success in
+                handleDuplicateJoinResult(
+                    success: success,
+                    dashboardJob: match.entry.makePartialJob(),
+                    prompt: prompt
+                )
             }
+            return
+        }
+
+        var dashboardCopy = match.entry.makePartialJob()
+        dashboardCopy.id = UUID().uuidString
+        dashboardCopy.date = dashboardDate
+        dashboardCopy.createdBy = authViewModel.currentUser?.id ?? dashboardCopy.createdBy
+        dashboardCopy.assignedTo = nil
+        dashboardCopy.participants = authViewModel.currentUser?.id.map { [$0] }
+
+        jobsViewModel.createJob(dashboardCopy) { success in
+            handleDuplicateJoinResult(
+                success: success,
+                dashboardJob: dashboardCopy,
+                prompt: prompt
+            )
+        }
+    }
+
+    private func handleDuplicateJoinResult(success: Bool, dashboardJob: Job, prompt: DuplicateJobPrompt) {
+        if success {
+            onAddedToDashboard?(dashboardJob)
+
+            if prompt.joinsAndContinuesSave {
+                processPreparedJobs(prompt.remainingJobs)
+            } else if let addressID = prompt.addressID {
+                removeAddress(id: addressID)
+            }
+
+            dismiss()
+        } else {
+            alertMessage = "Could not add this duplicate job to your dashboard. Please try again or create a separate job."
         }
     }
 


### PR DESCRIPTION
### Motivation
- Fix a bug where joining a duplicate job could change the original job's `date`, removing it from the historical day and breaking timesheet records. 
- Ensure a job can appear for a user on both the original scheduled day and the day they add it to their dashboard for logging purposes. 
- Keep user-visible semantics simple: same-day joins should update participants, cross-day joins should create a new dated dashboard copy. 

### Description
- Updated `joinExistingJob` in `Job Tracker/Features/Jobs/Editor/CreateJobView.swift` to detect whether the matched job's `date` is the same day as the dashboard target date and branch accordingly. 
- When the match is the same day, the code now calls `jobsViewModel.addCurrentUserAsParticipant(to:)` so the existing job keeps its original `date`. 
- When the match is for a different day, the code creates a new `Job` copy with a fresh `id`, sets its `date` to the dashboard date, clears `assignedTo`, sets `participants` to the current user, and calls `jobsViewModel.createJob(_)` to persist a dated dashboard copy. 
- Centralized success/failure handling in a new helper `handleDuplicateJoinResult(success:dashboardJob:prompt:)` and updated the failure message to reflect the new behavior. 

### Testing
- Ran `git diff --check` to validate the working tree and whitespace issues, which completed successfully. 
- Attempted to run the full iOS test plan with `xcodebuild test -scheme "Job Tracker" -testPlan "Job Tracker Safety Net"`, but `xcodebuild` is not available in this environment so the UI test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329ae51ff8832dac1cdf986340598a)