### PR TITLE
Fix job duplicate detection flow

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -576,6 +576,9 @@ struct CreateJobView: View {
             .onAppear {
                 jobsViewModel.startSearchIndexForAllJobs()
             }
+            .onDisappear {
+                cancelDuplicateReviewTasks()
+            }
         }
     }
 
@@ -677,8 +680,18 @@ struct CreateJobView: View {
 
     private func createJobAndContinue(_ job: Job, remainingJobs: [Job]) {
         duplicatePrompt = nil
-        jobsViewModel.createJob(job) { _ in
-            processPreparedJobs(remainingJobs)
+        jobsViewModel.createJob(job) { success in
+            guard success else {
+                alertMessage = "Could not create this job. Please try again."
+                return
+            }
+
+            if remainingJobs.isEmpty {
+                onAddedToDashboard?(job)
+                dismiss()
+            } else {
+                processPreparedJobs(remainingJobs)
+            }
         }
     }
 
@@ -716,15 +729,20 @@ struct CreateJobView: View {
 
     private func handleDuplicateJoinResult(success: Bool, dashboardJob: Job, prompt: DuplicateJobPrompt) {
         if success {
-            onAddedToDashboard?(dashboardJob)
-
             if prompt.joinsAndContinuesSave {
-                processPreparedJobs(prompt.remainingJobs)
-            } else if let addressID = prompt.addressID {
-                removeAddress(id: addressID)
+                if prompt.remainingJobs.isEmpty {
+                    onAddedToDashboard?(dashboardJob)
+                    dismiss()
+                } else {
+                    processPreparedJobs(prompt.remainingJobs)
+                }
+            } else {
+                onAddedToDashboard?(dashboardJob)
+                if let addressID = prompt.addressID {
+                    removeAddress(id: addressID)
+                }
+                dismiss()
             }
-
-            dismiss()
         } else {
             alertMessage = "Could not add this duplicate job to your dashboard. Please try again or create a separate job."
         }
@@ -758,7 +776,19 @@ struct CreateJobView: View {
                 score += 100
             }
 
-            if let distance = coordinateDistance(from: job, to: entry) {
+            let addressComparison = compareAddresses(job.address, entry.address)
+            let hasStrongIdentifierMatch = !reasons.isEmpty
+
+            if addressComparison.isExact {
+                reasons.append("address")
+                score += 80
+            } else if addressComparison.isClose {
+                reasons.append("similar address")
+                score += 35
+            }
+
+            if addressComparison.isExact || addressComparison.isClose || hasStrongIdentifierMatch,
+               let distance = coordinateDistance(from: job, to: entry) {
                 if distance <= 50 {
                     reasons.append("same coordinates")
                     score += 90
@@ -766,15 +796,6 @@ struct CreateJobView: View {
                     reasons.append("nearby coordinates")
                     score += 45
                 }
-            }
-
-            let addressComparison = compareAddresses(job.address, entry.address)
-            if addressComparison.isExact {
-                reasons.append("address")
-                score += 80
-            } else if addressComparison.isClose {
-                reasons.append("similar address")
-                score += 35
             }
 
             guard !reasons.isEmpty, score >= 35 else { return nil }
@@ -975,6 +996,11 @@ struct CreateJobView: View {
         if addresses.isEmpty {
             addresses = [AddressDraft()]
         }
+    }
+
+    private func cancelDuplicateReviewTasks() {
+        duplicateCheckTasks.values.forEach { $0.cancel() }
+        duplicateCheckTasks.removeAll()
     }
 
     private func scheduleDuplicateReview(for addressID: AddressDraft.ID, address: String) {


### PR DESCRIPTION
### Motivation
- Prevent false duplicate prompts when geocoding places a new job near an existing job but the typed address does not match. 
- Make the Create Job flow resilient so creating a separate job or joining an existing job reliably notifies the dashboard and dismisses the sheet at the correct time. 
- Avoid leftover asynchronous duplicate-review work after the Create Job sheet is closed to stop stale prompts and UI churn.

### Description
- Tightened `duplicateMatches(for:)` in `CreateJobView.swift` so coordinate distance is only considered when the address comparison is `isExact`/`isClose` or there is a strong identifier match (portal/location ID), preventing coordinate-only matches from triggering duplicates. 
- Updated `createJobAndContinue(_:,remainingJobs:)` to handle the `createJob` completion result, show an error when creation fails, and call `onAddedToDashboard` + `dismiss()` when there are no remaining jobs to process. 
- Reworked `handleDuplicateJoinResult(...)` to ensure the UI only dismisses after the duplicate-join/continue flow is complete and to consistently notify the dashboard when appropriate. 
- Added `cancelDuplicateReviewTasks()` and call it from the create-sheet `.onDisappear` to cancel pending duplicate-check `Task`s and clear `duplicateCheckTasks`.

### Testing
- Ran `git diff --check` to validate diffs with no whitespace errors and it passed. 
- Attempted `swift test`, but the environment lacks SwiftPM `Package.swift`, so full unit test execution could not be run here. 
- Attempted `xcodebuild test` for the app scheme, but `xcodebuild` is not available in this environment so iOS simulator tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32a07f8500832da944c44187af045b)