### PR TITLE
Fix dashboard duplicate participants assignment

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -732,7 +732,7 @@ struct CreateJobView: View {
         dashboardCopy.date = dashboardDate
         dashboardCopy.createdBy = authViewModel.currentUser?.id ?? dashboardCopy.createdBy
         dashboardCopy.assignedTo = nil
-        dashboardCopy.participants = authViewModel.currentUser?.id.map { [$0] }
+        dashboardCopy.participants = authViewModel.currentUser.map { [$0.id] }
 
         jobsViewModel.createJob(dashboardCopy) { success in
             handleDuplicateJoinResult(


### PR DESCRIPTION
### Motivation
- Fix the Swift type error when copying a job to the dashboard so `participants` is set to a single-element `[String]` containing the user ID instead of mapping the `String` into characters.

### Description
- Replace `dashboardCopy.participants = authViewModel.currentUser?.id.map { [$0] }` with `dashboardCopy.participants = authViewModel.currentUser.map { [$0.id] }` in `Job Tracker/Features/Jobs/Editor/CreateJobView.swift` so the optional `currentUser` is mapped to a `[String]`.

### Testing
- Ran `git diff --check -- 'Job Tracker/Features/Jobs/Editor/CreateJobView.swift'` which passed; attempted `xcodebuild -project 'Job Tracker.xcodeproj' -list` but `xcodebuild` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33df2780d4832db4066f96696d3aea)