### PR TITLE
Add root `npm test` script and project `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Dependencies
+node_modules/
+
+# npm logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Xcode user-specific files
+DerivedData/
+*.xcuserstate
+*.xcscmblueprint
+*.moved-aside
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# macOS
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "test:firebase-rules": "vitest run firebase-emulator-tests"
+    "test:firebase-rules": "vitest run firebase-emulator-tests",
+    "test": "npm run test:firebase-rules"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^4.0.1",


### PR DESCRIPTION
### Motivation
- Ensure `npm test` works out-of-the-box and prevent generated artifacts from showing as untracked changes.

### Description
- Add a root `.gitignore` to exclude `node_modules/`, common npm logs, Xcode build/user artifacts, and macOS metadata.
- Add a root `test` script in `package.json` that delegates to the existing Firebase rules test command (`npm run test:firebase-rules`).

### Testing
- Ran `npm test`, which executes the Vitest suite and completed successfully (`1 test file passed, 1 passed | 3 skipped`).
- Ran `npm run test:firebase-rules` directly and it also passed via Vitest.
- Ran `find website -name '*.js' -print0 | xargs -0 -n1 node --check` to syntax-check website JS files and it reported no errors.
- Attempted iOS-related checks but `xcodebuild` is not available in this environment and `swift test` failed due to missing `Package.swift`, so those platform tests were not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f44c0984832d87ba66e54d53c248)