### PR TITLE
Enable CarPlay Driving Task entitlement and update documentation

### DIFF
--- a/Documentation/CarPlayEntitlementRequest.md
+++ b/Documentation/CarPlayEntitlementRequest.md
@@ -6,7 +6,7 @@ Use this packet when submitting Job Tracker for Apple CarPlay entitlement review
 
 Request the **Driving Task** CarPlay category. Job Tracker is not a turn-by-turn navigation provider, media app, messaging app, parking app, EV charging app, or quick-ordering app. The CarPlay surface is limited to a short, read-only dispatch workflow that helps a technician choose the next assigned job and hand directions to Maps.
 
-Do **not** add a CarPlay entitlement key to `Job Tracker/Job Tracker.entitlements` before Apple approves the managed capability and the provisioning profile has been regenerated. Apple requires the entitlement in the App ID, provisioning profile, and app entitlements file to match after approval.
+Apple has approved the managed Driving Task capability for Job Tracker. Keep the App ID, regenerated provisioning profile, and `Job Tracker/Job Tracker.entitlements` aligned with the approved `com.apple.developer.carplay-driving-task` entitlement.
 
 ## Copy/Paste Use-Case Summary
 
@@ -33,14 +33,14 @@ Do **not** add a CarPlay entitlement key to `Job Tracker/Job Tracker.entitlement
 
 - [ ] Apple Developer Program account is active and the bundle ID matches `com.quinton.Job-Tracker-CS25`.
 - [ ] Request text uses the Driving Task positioning above and does not claim Job Tracker is a navigation app.
-- [ ] `Job Tracker/Job Tracker.entitlements` does not contain any CarPlay entitlement until Apple approves the managed capability.
-- [ ] Once Apple approves access, enable the approved CarPlay capability for the App ID, regenerate provisioning profiles, and then add only the approved entitlement key to the app entitlements file.
+- [x] `Job Tracker/Job Tracker.entitlements` contains only the approved Driving Task CarPlay entitlement.
+- [ ] Confirm the App ID has the approved CarPlay Driving Task managed capability enabled and regenerate/download provisioning profiles before archiving.
 - [ ] Run the CarPlay Simulator demo script and capture screenshots/video for the request if Apple asks for supporting material.
 - [ ] Verify the production build does not ship hard-coded service credentials in the app Info.plist.
 
 ## Post-Approval Implementation Step
 
-After Apple grants the managed capability, add the exact approved entitlement key to `Job Tracker/Job Tracker.entitlements` as a Boolean `true`, update signing to use the regenerated provisioning profile, and build on a Mac with Xcode. If Apple grants a specific Driving Task entitlement that is not visible in Xcode's standard CarPlay capability list, use the exact key provided by Apple in the approval response/provisioning profile.
+After Apple grants the managed capability, the app entitlements file must include `com.apple.developer.carplay-driving-task` as a Boolean `true`. Update signing to use the regenerated provisioning profile and build on a Mac with Xcode before submitting a CarPlay-enabled archive.
 
 ## References
 

--- a/Documentation/Features/CarPlay.md
+++ b/Documentation/Features/CarPlay.md
@@ -22,9 +22,7 @@ The CarPlay experience is intentionally limited to safe, driving-focused job dis
 
 ## Entitlement Strategy
 
-Apple grants CarPlay through managed capabilities after reviewing the app category and use case. The project includes the CarPlay scene and implementation code, but the app entitlements file must not add a CarPlay entitlement until Apple approves the managed capability and the provisioning profile is regenerated.
-
-Request the **Driving Task** category because Job Tracker provides a limited dispatch workflow for choosing a job destination and starting directions; it is not a turn-by-turn navigation app. Use the complete request packet in [CarPlayEntitlementRequest.md](../CarPlayEntitlementRequest.md) when submitting the request.
+Apple grants CarPlay through managed capabilities after reviewing the app category and use case. Job Tracker has been approved for the **Driving Task** category, so `Job Tracker/Job Tracker.entitlements` now includes the approved `com.apple.developer.carplay-driving-task` entitlement. The App ID and regenerated provisioning profiles must include the same managed capability before archiving.
 
 Recommended request positioning:
 
@@ -33,5 +31,5 @@ Recommended request positioning:
 ## Testing Notes
 
 - Apple documents CarPlay simulator testing from Xcode by opening Simulator's CarPlay external display after configuring the project.
-- Real-device, TestFlight, and App Store distribution require Apple to approve the appropriate CarPlay managed capability and require a provisioning profile that contains the matching entitlement.
+- Real-device, TestFlight, and App Store distribution require the regenerated provisioning profile to contain the approved `com.apple.developer.carplay-driving-task` entitlement.
 - Because this is a driving-task/job-dispatch experience rather than a navigation app, do not add navigation-only dashboard, instrument-cluster, or map-window scenes.

--- a/Job Tracker/Job Tracker.entitlements
+++ b/Job Tracker/Job Tracker.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>group.com.quinton.Job-Tracker-CS25</string>
 	</array>
+	<key>com.apple.developer.carplay-driving-task</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
### Motivation
- Job Tracker has been approved for the CarPlay Driving Task capability and the project needs to reflect that approval in its entitlements and guidance. 
- Update documentation to instruct maintainers to keep the App ID, regenerated provisioning profiles, and app entitlements aligned with the approved driving-task entitlement.

### Description
- Add the approved entitlement key `com.apple.developer.carplay-driving-task` as a Boolean `true` to `Job Tracker/Job Tracker.entitlements`.
- Update `Documentation/CarPlayEntitlementRequest.md` to mark the entitlements step as completed and to explain post-approval alignment and provisioning requirements.
- Update `Documentation/Features/CarPlay.md` to state the project has Driving Task approval and to clarify distribution/testing requirements for the regenerated provisioning profile.

### Testing
- Verified entitlements and Info plist parse successfully using Python `plistlib` (`python3` plist parsing of `Job Tracker/Job Tracker.entitlements` and `Job-Tracker-Info.plist` returned OK). 
- Attempted to run `xcodebuild -list -project 'Job Tracker.xcodeproj'` but `xcodebuild` is not available in this environment, so Xcode project listing could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a349813f370832dac677b3239d9994b)