### PR TITLE
Fix CarPlay directions launch

### DIFF
--- a/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
+++ b/Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift
@@ -215,12 +215,10 @@ final class JobDispatchCarPlaySceneDelegate: NSObject, CPTemplateApplicationScen
     }
 
     private func openAppleMaps(coordinate: CLLocationCoordinate2D, name: String) {
-        MapKitGeocoding.openDrivingDirections(to: coordinate)
+        MapKitGeocoding.openDrivingDirections(to: coordinate, name: name)
     }
 
     private func openAppleMapsAddress(_ address: String) {
-        guard let encoded = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: "maps://?saddr=Current%20Location&daddr=\(encoded)&dirflg=d") else { return }
-        UIApplication.shared.open(url)
+        MapKitGeocoding.openDrivingDirections(to: address)
     }
 }

--- a/Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import Contacts
 import MapKit
 import UIKit
 
@@ -29,11 +30,32 @@ enum MapKitGeocoding {
         }
     }
 
-    static func openDrivingDirections(to coordinate: CLLocationCoordinate2D, with application: UIApplication = .shared) {
-        let destination = "\(coordinate.latitude),\(coordinate.longitude)"
-        guard let encodedDestination = destination.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: "maps://?saddr=Current%20Location&daddr=\(encodedDestination)&dirflg=d") else { return }
-        application.open(url)
+    @discardableResult
+    static func openDrivingDirections(
+        to coordinate: CLLocationCoordinate2D,
+        name: String? = nil,
+        with application: UIApplication = .shared
+    ) -> Bool {
+        let placemark = MKPlacemark(coordinate: coordinate)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = name
+        return mapItem.openInMaps(launchOptions: drivingLaunchOptions)
+    }
+
+    @discardableResult
+    static func openDrivingDirections(to address: String, name: String? = nil) -> Bool {
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAddress.isEmpty else { return false }
+
+        let geocoderDictionary = [CNPostalAddressStreetKey: trimmedAddress]
+        let placemark = MKPlacemark(coordinate: kCLLocationCoordinate2DInvalid, addressDictionary: geocoderDictionary)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = name ?? trimmedAddress
+        return mapItem.openInMaps(launchOptions: drivingLaunchOptions)
+    }
+
+    private static var drivingLaunchOptions: [String: Any] {
+        [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
     }
 
     @available(iOS, introduced: 2.0, deprecated: 26.0, message: "Use MKMapItem.location instead.")


### PR DESCRIPTION
### Motivation
- The CarPlay “Start Directions” action could fail to hand off navigation because destinations were launched via raw `maps://` URLs instead of MapKit destinations, preventing CarPlay from starting turn-by-turn navigation reliably.
- Use MapKit-backed launch so Maps receives an `MKMapItem` (with a name) and starts driving directions correctly in CarPlay.

### Description
- Replace `maps://` URL-based Apple Maps opens with `MKMapItem.openInMaps` in `MapKitGeocoding` and add two helpers: `openDrivingDirections(to: CLLocationCoordinate2D, name: String? = nil, ...) -> Bool` and `openDrivingDirections(to: String, name: String? = nil) -> Bool` that use driving launch options.
- Import `Contacts` and add a `drivingLaunchOptions` helper in `Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift` to centralize Map launch behavior and allow naming the destination.
- Update the CarPlay flow in `Job Tracker/Features/CarPlay/JobDispatchCarPlaySceneDelegate.swift` to pass the job title into the MapKit launch for coordinate-based destinations and to use the new address fallback helper for address-only cases.
- Leave Google Maps handling unchanged and only adjust Apple Maps handoff logic.

### Testing
- Ran `git diff --check` to validate whitespace and simple diff issues, which completed without errors.
- Attempted to run `swiftformat` on the modified files but the `swiftformat` tool was not available in this environment so formatting was not applied here.
- Attempted to run `xcodebuild` to build the app but `xcodebuild` is not available in this environment so an iOS build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a353ee0f870832db0f5f1e545b0e46d)