### PR TITLE
Fix iOS 26 deprecation warnings

### DIFF
--- a/Job Tracker/Features/Shared/Components/GibsonPortalView.swift
+++ b/Job Tracker/Features/Shared/Components/GibsonPortalView.swift
@@ -27,8 +27,6 @@ private struct SafariView: UIViewControllerRepresentable {
         configuration.barCollapsingEnabled = true
         let controller = SFSafariViewController(url: url, configuration: configuration)
         controller.dismissButtonStyle = .done
-        controller.preferredBarTintColor = UIColor.systemBackground
-        controller.preferredControlTintColor = UIColor.systemBlue
         return controller
     }
 

--- a/Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapKitGeocoding.swift
@@ -1,5 +1,4 @@
 import CoreLocation
-import Contacts
 import MapKit
 import UIKit
 
@@ -36,10 +35,17 @@ enum MapKitGeocoding {
         name: String? = nil,
         with application: UIApplication = .shared
     ) -> Bool {
-        let placemark = MKPlacemark(coordinate: coordinate)
-        let mapItem = MKMapItem(placemark: placemark)
-        mapItem.name = name
-        return mapItem.openInMaps(launchOptions: drivingLaunchOptions)
+        guard CLLocationCoordinate2DIsValid(coordinate) else { return false }
+
+        var components = URLComponents(string: "http://maps.apple.com/")
+        components?.queryItems = [
+            URLQueryItem(name: "daddr", value: "\(coordinate.latitude),\(coordinate.longitude)"),
+            URLQueryItem(name: "dirflg", value: "d")
+        ]
+
+        guard let url = components?.url else { return false }
+        application.open(url)
+        return true
     }
 
     @discardableResult
@@ -47,15 +53,15 @@ enum MapKitGeocoding {
         let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedAddress.isEmpty else { return false }
 
-        let geocoderDictionary = [CNPostalAddressStreetKey: trimmedAddress]
-        let placemark = MKPlacemark(coordinate: kCLLocationCoordinate2DInvalid, addressDictionary: geocoderDictionary)
-        let mapItem = MKMapItem(placemark: placemark)
-        mapItem.name = name ?? trimmedAddress
-        return mapItem.openInMaps(launchOptions: drivingLaunchOptions)
-    }
+        var components = URLComponents(string: "http://maps.apple.com/")
+        components?.queryItems = [
+            URLQueryItem(name: "daddr", value: trimmedAddress),
+            URLQueryItem(name: "dirflg", value: "d")
+        ]
 
-    private static var drivingLaunchOptions: [String: Any] {
-        [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
+        guard let url = components?.url else { return false }
+        UIApplication.shared.open(url)
+        return true
     }
 
     @available(iOS, introduced: 2.0, deprecated: 26.0, message: "Use MKMapItem.location instead.")

--- a/Job Tracker/intent/DirectionsToNextJobIntent.swift
+++ b/Job Tracker/intent/DirectionsToNextJobIntent.swift
@@ -41,7 +41,7 @@ struct DirectionsToNextJobIntent: AppIntent {
             return .result(dialog: IntentDialog("Couldn't determine a location for that address."))
         }
 
-        await MainActor.run {
+        _ = await MainActor.run {
             MapKitGeocoding.openDrivingDirections(to: coord)
         }
         return .result(dialog: IntentDialog("Opening directions to \(short)."))


### PR DESCRIPTION
### Motivation
- Remove deprecated APIs and silence warnings introduced by iOS 26 so the app uses system-provided bar/control background effects and modern MapKit behavior.
- Avoid using deprecated `MKPlacemark`/`MKMapItem(placemark:)` APIs to construct directions and fix an unused-result warning from an `AppIntent` invocation.

### Description
- Removed `preferredBarTintColor` and `preferredControlTintColor` assignments from the `SFSafariViewController` wrapper so the system-provided background effects are preserved (`GibsonPortalView.swift`).
- Replaced `MKPlacemark`/`MKMapItem(placemark:)`-based directions with Apple Maps URL-based launches for coordinates by validating the coordinate with `CLLocationCoordinate2DIsValid` and building a `URLComponents` `http://maps.apple.com/` URL with `daddr` and `dirflg` query items (`MapKitGeocoding.swift`).
- Replaced address-based placemark directions with Apple Maps URL construction and removed the `Contacts` import and the `drivingLaunchOptions` usage (`MapKitGeocoding.swift`).
- Silenced the unused-result warning by explicitly ignoring the result of `await MainActor.run` with `_ = await MainActor.run { ... }` in the intent (`DirectionsToNextJobIntent.swift`).

### Testing
- Attempted to run a project build with `xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`, but the command failed because `xcodebuild` is not available in this environment, so no automated build/test completed.
- No other automated tests were executed in this environment due to missing build tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3545cbd34c832da5bfeb864c9a0be4)