### PR TITLE
Avoid duplicate-job confirmation on save path; rely on address-entry duplicate handling

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -676,19 +676,10 @@ struct CreateJobView: View {
         }
 
         let remaining = Array(jobs.dropFirst())
-        let matches = duplicateMatches(for: next.job)
-        if !matches.isEmpty {
-            duplicatePrompt = DuplicateJobPrompt(
-                addressID: next.addressID,
-                address: next.job.address,
-                newJob: next,
-                matches: matches,
-                remainingJobs: remaining,
-                joinsAndContinuesSave: true
-            )
-            return
-        }
 
+        // Duplicate detection is intentionally handled as part of address entry
+        // review instead of the save path, so users do not have to confirm the
+        // same duplicate twice after they already responded to the address prompt.
         createJobAndContinue(next, remainingJobs: remaining)
     }
 


### PR DESCRIPTION
### Motivation
- Prevent users from being prompted twice for duplicate jobs by removing duplicate detection from the save path and relying on duplicate handling performed during address entry review.

### Description
- Removed the duplicate-match check and early return in `CreateJobView.processPreparedJobs(_:)`, so prepared jobs proceed directly to `createJobAndContinue` instead of re-showing a duplicate prompt. 
- Added a clarifying comment indicating duplicate detection is intentionally handled during address entry review rather than on save.

### Testing
- Ran the existing automated test suite (unit and UI tests) against this change and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a393064ca5c832d951a221f0f1ba27b)