### PR TITLE
Add JobSearchIndexEntry photo/assignment fields and always create dashboard copy when joining duplicates

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -705,25 +705,7 @@ struct CreateJobView: View {
     private func joinExistingJob(_ match: DuplicateJobMatch, prompt: DuplicateJobPrompt) {
         duplicatePrompt = nil
         let dashboardDate = prompt.newJob?.job.date ?? date
-        let calendar = Calendar.current
-
-        if calendar.isDate(match.entry.date, inSameDayAs: dashboardDate) {
-            jobsViewModel.addCurrentUserAsParticipant(to: match.entry.id) { success in
-                handleDuplicateJoinResult(
-                    success: success,
-                    dashboardJob: match.entry.makePartialJob(),
-                    prompt: prompt
-                )
-            }
-            return
-        }
-
-        var dashboardCopy = match.entry.makePartialJob()
-        dashboardCopy.id = UUID().uuidString
-        dashboardCopy.date = dashboardDate
-        dashboardCopy.createdBy = authViewModel.currentUser?.id ?? dashboardCopy.createdBy
-        dashboardCopy.assignedTo = nil
-        dashboardCopy.participants = authViewModel.currentUser.map { [$0.id] }
+        let dashboardCopy = dashboardCopyForCurrentUser(from: match.entry, scheduledDate: dashboardDate)
 
         jobsViewModel.createJob(dashboardCopy) { success in
             handleDuplicateJoinResult(
@@ -732,6 +714,17 @@ struct CreateJobView: View {
                 prompt: prompt
             )
         }
+    }
+
+    private func dashboardCopyForCurrentUser(from entry: JobSearchIndexEntry, scheduledDate: Date) -> Job {
+        var dashboardCopy = entry.makePartialJob()
+        dashboardCopy.id = UUID().uuidString
+        dashboardCopy.date = scheduledDate
+        dashboardCopy.status = "Pending"
+        dashboardCopy.createdBy = authViewModel.currentUser?.id ?? dashboardCopy.createdBy
+        dashboardCopy.assignedTo = nil
+        dashboardCopy.participants = authViewModel.currentUser.map { [$0.id] }
+        return dashboardCopy
     }
 
     private func handleDuplicateJoinResult(success: Bool, dashboardJob: Job, prompt: DuplicateJobPrompt) {

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -233,6 +233,13 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
     var notes: String?
     var assignments: String?
     var materialsUsed: String?
+    var assignedTo: String?
+    var photos: [String]?
+    var housePhotoURL: String?
+    var nidPhotoURL: String?
+    var canPhotoURL: String?
+    var mapDesignPhotoURL: String?
+    var hours: Double?
     var nidFootage: String?
     var canFootage: String?
     var jobPlacement: String?
@@ -251,6 +258,13 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         notes: String? = nil,
         assignments: String? = nil,
         materialsUsed: String? = nil,
+        assignedTo: String? = nil,
+        photos: [String]? = nil,
+        housePhotoURL: String? = nil,
+        nidPhotoURL: String? = nil,
+        canPhotoURL: String? = nil,
+        mapDesignPhotoURL: String? = nil,
+        hours: Double? = nil,
         nidFootage: String? = nil,
         canFootage: String? = nil,
         jobPlacement: String? = nil,
@@ -268,6 +282,13 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
         self.notes = notes
         self.assignments = assignments
         self.materialsUsed = materialsUsed
+        self.assignedTo = assignedTo
+        self.photos = photos
+        self.housePhotoURL = housePhotoURL
+        self.nidPhotoURL = nidPhotoURL
+        self.canPhotoURL = canPhotoURL
+        self.mapDesignPhotoURL = mapDesignPhotoURL
+        self.hours = hours
         self.nidFootage = nidFootage
         self.canFootage = canFootage
         self.jobPlacement = jobPlacement
@@ -288,6 +309,13 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             notes: job.notes,
             assignments: job.assignments,
             materialsUsed: job.materialsUsed,
+            assignedTo: job.assignedTo,
+            photos: job.photos,
+            housePhotoURL: job.housePhotoURL,
+            nidPhotoURL: job.nidPhotoURL,
+            canPhotoURL: job.canPhotoURL,
+            mapDesignPhotoURL: job.mapDesignPhotoURL,
+            hours: job.hours,
             nidFootage: job.nidFootage,
             canFootage: job.canFootage,
             jobPlacement: job.jobPlacement,
@@ -309,15 +337,20 @@ struct JobSearchIndexEntry: Identifiable, Codable, Hashable, Sendable, JobSearch
             locationNumber: locationNumber,
             assignments: assignments,
             materialsUsed: materialsUsed,
-            photos: [],
+            photos: photos ?? [],
+            housePhotoURL: housePhotoURL,
+            nidPhotoURL: nidPhotoURL,
+            canPhotoURL: canPhotoURL,
+            mapDesignPhotoURL: mapDesignPhotoURL,
             participants: nil,
-            hours: 0.0,
+            hours: hours ?? 0.0,
             nidFootage: nidFootage,
             canFootage: canFootage,
             jobPlacement: jobPlacement,
             latitude: latitude,
             longitude: longitude
         )
+        job.assignedTo = assignedTo
         job.notes = notes
         job.assignments = assignments
         job.materialsUsed = materialsUsed


### PR DESCRIPTION
### Motivation

- Preserve additional job metadata (photos, assigned person, hours, and photo URLs) from search index entries when converting them into dashboard jobs. 
- Simplify and standardize duplicate-join behavior so the current user receives a personal dashboard job copy instead of conditionally mutating an existing job. 

### Description

- Added new properties to `JobSearchIndexEntry`: `assignedTo`, `photos`, `housePhotoURL`, `nidPhotoURL`, `canPhotoURL`, `mapDesignPhotoURL`, and `hours`, and wired them into the initializers and `init(job:)` mapping. 
- Updated `makePartialJob()` to populate `photos`, photo URL fields, `hours`, and `assignedTo` on the returned `Job`. 
- Removed the special-case branch that attempted to add the current user as a participant when the matching job was on the same day, and introduced `dashboardCopyForCurrentUser(from:scheduledDate:)` in `CreateJobView` which creates a new `Job` copy with a new `id`, `date`, `status = "Pending"`, `assignedTo = nil`, and `participants` set to the current user. 

### Testing

- Ran the project's unit tests in Xcode and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8c20420c832d8facfce5b5e2d66d)