### PR TITLE
Add mapped-job pins to route mapper and admin backfill for legacy jobs

### DIFF
--- a/Job Tracker/Features/Admin/AdminPanelViewModel.swift
+++ b/Job Tracker/Features/Admin/AdminPanelViewModel.swift
@@ -16,6 +16,11 @@ protocol AdminPanelService: AnyObject {
         completion: @escaping (Result<Int, Error>) -> Void
     )
 
+    func adminBackfillCoordinatesForAllJobs(
+        progress: ((FirebaseService.AdminMaintenanceProgress) -> Void)?,
+        completion: @escaping (Result<Int, Error>) -> Void
+    )
+
     func refreshCustomClaims(for uid: String?, completion: ((Error?) -> Void)?)
 }
 
@@ -59,6 +64,7 @@ final class AdminPanelViewModel: ObservableObject {
     @Published private(set) var deletingUserIDs: Set<String> = []
     @Published var alert: AlertItem?
     @Published private(set) var maintenanceStatus: MaintenanceStatus = .idle
+    @Published private(set) var mapBackfillStatus: MaintenanceStatus = .idle
 
     var onUserFlagsUpdated: ((String) -> Void)?
 
@@ -201,6 +207,46 @@ final class AdminPanelViewModel: ObservableObject {
                     )
                 }
                 self.maintenanceStatus = status
+            }
+        })
+    }
+
+
+    func runMapCoordinateBackfill() {
+        guard !mapBackfillStatus.isRunning else { return }
+
+        mapBackfillStatus = MaintenanceStatus(
+            isRunning: true,
+            progress: MaintenanceStatus.Progress(processed: 0, total: 0, message: "Preparing map backfill…"),
+            lastRunCount: mapBackfillStatus.lastRunCount,
+            lastErrorMessage: nil
+        )
+
+        service.adminBackfillCoordinatesForAllJobs(progress: { [weak self] update in
+            guard let self else { return }
+            Task { @MainActor in
+                var status = self.mapBackfillStatus
+                status.isRunning = true
+                status.progress = MaintenanceStatus.Progress(processed: update.processed, total: update.total, message: update.message)
+                status.lastErrorMessage = nil
+                self.mapBackfillStatus = status
+            }
+        }, completion: { [weak self] result in
+            guard let self else { return }
+            Task { @MainActor in
+                var status = self.mapBackfillStatus
+                status.isRunning = false
+                status.progress = nil
+                switch result {
+                case .success(let count):
+                    status.lastRunCount = count
+                    status.lastErrorMessage = nil
+                    self.alert = AlertItem(title: "Map Backfill Complete", message: "Added coordinates to \(count) old job\(count == 1 ? "" : "s").", kind: .success)
+                case .failure(let error):
+                    status.lastErrorMessage = error.localizedDescription
+                    self.alert = AlertItem(title: "Map Backfill Failed", message: error.localizedDescription, kind: .error)
+                }
+                self.mapBackfillStatus = status
             }
         })
     }

--- a/Job Tracker/Features/Shared/Mapping/LeafletWebMapView.swift
+++ b/Job Tracker/Features/Shared/Mapping/LeafletWebMapView.swift
@@ -74,6 +74,11 @@ struct LeafletWebMapView: UIViewRepresentable {
                 .sink { [weak self] _ in self?.sendSnapshotIfReady() }
                 .store(in: &cancellables)
 
+            viewModel.$jobs
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.sendSnapshotIfReady() }
+                .store(in: &cancellables)
+
             viewModel.$visibleLayers
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in self?.sendVisibleLayers() }
@@ -191,7 +196,30 @@ struct WebMapSnapshot: Codable {
     let poles: [WebPole]
     let splices: [WebSplice]
     let lines: [WebLine]
+    let jobs: [WebJob]
     let visibleLayers: [String]
+}
+
+struct WebJob: Codable {
+    let id: String
+    let name: String
+    let lat: Double
+    let lng: Double
+    let address: String
+    let jobNumber: String?
+    let status: String
+    let date: Date
+    let notes: String?
+    let assignments: String?
+    let materialsUsed: String?
+    let hours: Double?
+    let nidFootage: String?
+    let canFootage: String?
+    let jobPlacement: String?
+    let housePhotoURL: String?
+    let nidPhotoURL: String?
+    let canPhotoURL: String?
+    let mapDesignPhotoURL: String?
 }
 
 struct WebPole: Codable {
@@ -281,6 +309,30 @@ extension FiberMapViewModel {
                     notes: line.notes
                 )
             },
+            jobs: jobs.compactMap { job in
+                guard let latitude = job.latitude, let longitude = job.longitude else { return nil }
+                return WebJob(
+                    id: job.id,
+                    name: job.shortDisplayTitle,
+                    lat: latitude,
+                    lng: longitude,
+                    address: job.address,
+                    jobNumber: job.jobNumber,
+                    status: job.status,
+                    date: job.date,
+                    notes: job.notes,
+                    assignments: job.assignments,
+                    materialsUsed: job.materialsUsed,
+                    hours: job.hours,
+                    nidFootage: job.nidFootage,
+                    canFootage: job.canFootage,
+                    jobPlacement: job.jobPlacement,
+                    housePhotoURL: job.housePhotoURL,
+                    nidPhotoURL: job.nidPhotoURL,
+                    canPhotoURL: job.canPhotoURL,
+                    mapDesignPhotoURL: job.mapDesignPhotoURL
+                )
+            },
             visibleLayers: visibleLayers.map { $0.rawValue }
         )
     }
@@ -296,5 +348,15 @@ extension FiberMapViewModel {
                 zoom: mapCamera.zoom
             )
         )
+    }
+}
+
+private extension JobSearchIndexEntry {
+    var shortDisplayTitle: String {
+        if let jobNumber, !jobNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Job #\(jobNumber)"
+        }
+        let first = address.split(separator: ",").first.map(String.init) ?? address
+        return first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Mapped Job" : first.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -352,6 +352,7 @@ class FiberMapViewModel: ObservableObject {
     @Published var poles: [Pole] = []
     @Published var splices: [SpliceEnclosure] = []
     @Published var lines: [FiberLine] = []
+    @Published var jobs: [JobSearchIndexEntry] = []
 
     private let dataService: FiberAssetSyncService
     private let searchProvider: MapSearchProviding
@@ -366,7 +367,7 @@ class FiberMapViewModel: ObservableObject {
     @Published var selectedAsset: AnyHashable?
     @Published var lineStartPole: Pole?
     @Published var editInstruction: String?
-    @Published var visibleLayers: Set<MapLayer> = [.poles, .splices, .lines]
+    @Published var visibleLayers: Set<MapLayer> = [.jobs, .poles, .splices, .lines]
     @Published var mapCamera: MapCameraState
     @Published private(set) var pendingCenterCommand: MapCenterCommand?
     @Published var searchResults: [MapSearchResult] = []
@@ -375,6 +376,7 @@ class FiberMapViewModel: ObservableObject {
     @Published private(set) var isLoadingSnapshot = false
     @Published private(set) var isSavingSnapshot = false
     @Published var syncError: String?
+    @Published private(set) var mappedJobCount = 0
 
     // Sheet presentation
     @Published var itemToEdit: AnyIdentifiable?
@@ -383,6 +385,7 @@ class FiberMapViewModel: ObservableObject {
     private var locationServiceIdentifier: ObjectIdentifier?
     private var pendingSaveTask: Task<Void, Never>?
     private var didReceiveInitialSnapshot = false
+    private var jobUpdatesCancellable: AnyCancellable?
 
     init(dataService: FiberAssetSyncService = FirestoreFiberAssetSyncService(), searchProvider: MapSearchProviding = AppleMapSearchProvider()) {
         self.dataService = dataService
@@ -399,6 +402,25 @@ class FiberMapViewModel: ObservableObject {
     // Asset lookup for drawing lines
     func pole(for id: Pole.ID) -> Pole? {
         poles.first { $0.id == id }
+    }
+
+    func bindJobs(_ jobsPublisher: AnyPublisher<[JobSearchIndexEntry], Never>) {
+        jobUpdatesCancellable = jobsPublisher
+            .map { entries in
+                entries.filter { entry in
+                    guard let latitude = entry.latitude, let longitude = entry.longitude else { return false }
+                    return CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: latitude, longitude: longitude))
+                }
+                .sorted { lhs, rhs in
+                    lhs.date > rhs.date
+                }
+            }
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mappedJobs in
+                self?.jobs = mappedJobs
+                self?.mappedJobCount = mappedJobs.count
+            }
     }
     
     // UI Interaction
@@ -780,11 +802,12 @@ enum EditTool: String, CaseIterable, Identifiable {
 }
 
 enum MapLayer: String, CaseIterable, Identifiable {
-    case poles, splices, lines
+    case jobs, poles, splices, lines
     var id: String { rawValue }
     
     var label: String {
         switch self {
+        case .jobs: "Jobs"
         case .poles: "Poles"
         case .splices: "Splices"
         case .lines: "Lines"
@@ -800,6 +823,7 @@ struct MapsView: View {
     @State private var controlPanelWidth: CGFloat = 280
     @State private var collapsedDrawerWidth: CGFloat = 72
     @EnvironmentObject private var locationService: LocationService
+    @EnvironmentObject private var jobsViewModel: JobsViewModel
 
     var body: some View {
         ZStack {
@@ -893,7 +917,11 @@ struct MapsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
         .animation(.spring(response: 0.35, dampingFraction: 0.85), value: showControls)
-        .onAppear { viewModel.bindLocationService(locationService) }
+        .onAppear {
+            viewModel.bindLocationService(locationService)
+            viewModel.bindJobs(jobsViewModel.$allSearchEntries.eraseToAnyPublisher())
+            jobsViewModel.startSearchIndexForAllJobs()
+        }
         .sheet(item: $viewModel.itemToEdit) { itemWrapper in
             let item = itemWrapper.value
             if let pole = item as? Pole {
@@ -1105,7 +1133,15 @@ struct ControlPanelView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             VStack(alignment: .leading, spacing: 10) {
-                DrawerSectionHeader(title: "Layers")
+                HStack {
+                    DrawerSectionHeader(title: "Layers")
+                    Spacer()
+                    if viewModel.mappedJobCount > 0 {
+                        Label("\(viewModel.mappedJobCount)", systemImage: "mappin.and.ellipse")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
 
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(MapLayer.allCases) { layer in

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -820,6 +820,70 @@ class FirebaseService {
         }
     }
 
+    /// Adds latitude/longitude to legacy jobs that have an address but no stored coordinates.
+    /// Existing mapped jobs are skipped so current pins are not changed.
+    func adminBackfillCoordinatesForAllJobs(
+        progress: ((AdminMaintenanceProgress) -> Void)? = nil,
+        completion: @escaping (Result<Int, Error>) -> Void
+    ) {
+        db.collection("jobs").getDocuments { snapshot, error in
+            if let error {
+                DispatchQueue.main.async { completion(.failure(error)) }
+                return
+            }
+
+            let candidates = (snapshot?.documents ?? []).filter { doc in
+                let data = doc.data()
+                let address = (data["address"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let hasLatitude = data["latitude"] is Double || data["latitude"] is NSNumber
+                let hasLongitude = data["longitude"] is Double || data["longitude"] is NSNumber
+                return !address.isEmpty && (!hasLatitude || !hasLongitude)
+            }
+
+            guard !candidates.isEmpty else {
+                DispatchQueue.main.async {
+                    progress?(AdminMaintenanceProgress(processed: 0, total: 0, message: "No map updates required."))
+                    completion(.success(0))
+                }
+                return
+            }
+
+            DispatchQueue.main.async {
+                progress?(AdminMaintenanceProgress(processed: 0, total: candidates.count, message: "Geocoding old jobs…"))
+            }
+
+            Task {
+                var updatedCount = 0
+                for (index, doc) in candidates.enumerated() {
+                    let data = doc.data()
+                    let address = (data["address"] as? String) ?? ""
+                    if let coordinate = await MapKitGeocoding.coordinate(for: address) {
+                        do {
+                            try await doc.reference.updateData([
+                                "latitude": coordinate.latitude,
+                                "longitude": coordinate.longitude
+                            ])
+                            updatedCount += 1
+                        } catch {
+                            await MainActor.run { completion(.failure(error)) }
+                            return
+                        }
+                    }
+
+                    await MainActor.run {
+                        progress?(AdminMaintenanceProgress(
+                            processed: index + 1,
+                            total: candidates.count,
+                            message: "Mapped \(updatedCount) of \(candidates.count) legacy jobs"
+                        ))
+                    }
+                }
+
+                await MainActor.run { completion(.success(updatedCount)) }
+            }
+        }
+    }
+
     // MARK: - Photo Upload
     
     func uploadImage(_ image: UIImage, for jobID: String, completion: @escaping (Result<String, Error>) -> Void) {

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -223,6 +223,7 @@ struct AdminPanelView: View {
     @State private var pendingToggle: PendingToggle?
     @State private var pendingDeleteUser: AppUser?
     @State private var showingBackfillConfirmation = false
+    @State private var showingMapBackfillConfirmation = false
     @State private var pendingUpdateAction: PendingUpdateAction?
     @State private var showingLogs = false
 
@@ -318,6 +319,22 @@ struct AdminPanelView: View {
             }
         } message: {
             Text("Merges legacy job creators and assignees into each job's participants array. Only run when you understand the impact.")
+        }
+
+        .confirmationDialog(
+            "Add old jobs to the map?",
+            isPresented: $showingMapBackfillConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Add Old Jobs to Map") {
+                showingMapBackfillConfirmation = false
+                viewModel.runMapCoordinateBackfill()
+            }
+            Button("Cancel", role: .cancel) {
+                showingMapBackfillConfirmation = false
+            }
+        } message: {
+            Text("Geocodes legacy jobs that do not already have saved coordinates so their pins appear on the route mapper. Existing mapped jobs are left unchanged.")
         }
         #if DEBUG
         .confirmationDialog(
@@ -625,6 +642,48 @@ struct AdminPanelView: View {
                     Label("Run Backfill", systemImage: "arrow.triangle.2.circlepath")
                 }
                 .disabled(viewModel.maintenanceStatus.isRunning)
+            }
+            .padding(.vertical, 4)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Add old jobs to route mapper")
+                    .font(.headline)
+                Text("Geocode legacy jobs with missing coordinates so each saved address can appear as a tappable map pin.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                if viewModel.mapBackfillStatus.isRunning, let progress = viewModel.mapBackfillStatus.progress {
+                    if let fraction = progress.fractionComplete {
+                        ProgressView(value: fraction) {
+                            Text(progress.message)
+                                .font(.subheadline)
+                        } currentValueLabel: {
+                            Text("\(progress.processed)/\(progress.total)")
+                                .font(.caption.monospacedDigit())
+                        }
+                    } else {
+                        ProgressView(progress.message)
+                    }
+                }
+
+                if let lastCount = viewModel.mapBackfillStatus.lastRunCount, !viewModel.mapBackfillStatus.isRunning {
+                    Text("Last run mapped \(lastCount) job\(lastCount == 1 ? "" : "s").")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let error = viewModel.mapBackfillStatus.lastErrorMessage {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+
+                Button {
+                    showingMapBackfillConfirmation = true
+                } label: {
+                    Label("Add Old Jobs to Map", systemImage: "mappin.and.ellipse")
+                }
+                .disabled(viewModel.mapBackfillStatus.isRunning)
             }
             .padding(.vertical, 4)
         }

--- a/Job Tracker/Resources/WebMaps/FiberMap.html
+++ b/Job Tracker/Resources/WebMaps/FiberMap.html
@@ -40,12 +40,14 @@
                 layers: {
                     poles: null,
                     splices: null,
-                    lines: null
+                    lines: null,
+                    jobs: null
                 },
                 cache: {
                     poles: new Map(),
                     splices: new Map(),
-                    lines: new Map()
+                    lines: new Map(),
+                    jobs: new Map()
                 },
                 polePositions: new Map(),
                 isReady: false,
@@ -78,6 +80,7 @@
                 state.layers.poles = L.layerGroup().addTo(map);
                 state.layers.splices = L.layerGroup().addTo(map);
                 state.layers.lines = L.layerGroup().addTo(map);
+                state.layers.jobs = L.layerGroup().addTo(map);
 
                 setSelection(false);
 
@@ -170,6 +173,29 @@
                 return marker;
             }
 
+
+            function createJobMarker(job) {
+                const status = (job.status || '').toLowerCase();
+                const color = status === 'pending' ? '#2563eb' : status.includes('done') || status.includes('complete') ? '#16a34a' : '#f97316';
+                const icon = L.divIcon({
+                    className: 'job-pin-icon',
+                    html: `<div style="position:relative;width:28px;height:28px;transform:translateY(-7px);"><i class="fa-solid fa-location-dot" style="font-size:28px;color:${color};filter:drop-shadow(0 2px 3px rgba(0,0,0,.35));-webkit-text-stroke:2px white;"></i></div>`,
+                    iconSize: [28, 28],
+                    iconAnchor: [14, 28],
+                    popupAnchor: [0, -26]
+                });
+                const marker = L.marker([job.lat, job.lng], { icon, bubblingMouseEvents: false });
+                marker.bindPopup(renderPopup(job, 'Job'));
+                marker.on('touchstart', stopDomEvent);
+                marker.on('pointerdown', stopDomEvent);
+                marker.on('click', function(event) {
+                    stopDomEvent(event);
+                    setSelection(true, event.latlng);
+                    marker.openPopup();
+                });
+                return marker;
+            }
+
             function createLine(line) {
                 const start = state.polePositions.get(line.startPoleId);
                 const end = state.polePositions.get(line.endPoleId);
@@ -207,7 +233,7 @@
                 Object.entries(item).forEach(([key, value]) => {
                     if (ignoredKeys.has(key) || key === 'id' || value === null || value === undefined || key === 'name') { return; }
                     const formattedKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
-                    if (key === 'imageUrl' && value) {
+                    if ((key === 'imageUrl' || key.endsWith('PhotoURL')) && value) {
                         html += `<img src="${value}" alt="${item.name || type}" class="rounded-md mt-2 max-h-40 w-full object-cover" onerror="this.style.display='none'">`;
                     } else if (value instanceof Array) {
                         html += `<strong>${formattedKey}:</strong> ${value.join(', ')}<br>`;
@@ -228,11 +254,13 @@
                 state.cache.poles.clear();
                 state.cache.splices.clear();
                 state.cache.lines.clear();
+                state.cache.jobs.clear();
                 state.polePositions.clear();
 
                 clearLayer(state.layers.poles);
                 clearLayer(state.layers.splices);
                 clearLayer(state.layers.lines);
+                clearLayer(state.layers.jobs);
 
                 snapshot.poles.forEach(pole => {
                     state.polePositions.set(pole.id, { lat: pole.lat, lng: pole.lng });
@@ -245,6 +273,12 @@
                     const marker = createSpliceMarker(splice);
                     state.cache.splices.set(splice.id, marker);
                     marker.addTo(state.layers.splices);
+                });
+
+                (snapshot.jobs || []).forEach(job => {
+                    const marker = createJobMarker(job);
+                    state.cache.jobs.set(job.id, marker);
+                    marker.addTo(state.layers.jobs);
                 });
 
                 snapshot.lines.forEach(line => {


### PR DESCRIPTION
### Motivation
- Provide a tappable map marker for every job that already has geocoded coordinates so users can view job details directly on the route mapper.  
- Make the address search UI unobtrusive by keeping the search bar at the top and expose a lightweight control to see how many jobs are mapped.  
- Ensure future job creates/updates automatically appear on the map and add an admin maintenance action to backfill coordinates for legacy jobs that lack them.  

### Description
- Stream job search entries into the map by adding a `jobs` publisher to `FiberMapViewModel`, filtering for valid coordinates, exposing `mappedJobCount`, and a `bindJobs(_:)` helper to subscribe to `JobsViewModel.$allSearchEntries`.  
- Wire `MapsView` to the jobs stream by adding an `@EnvironmentObject` `JobsViewModel`, calling `viewModel.bindJobs(jobsViewModel.$allSearchEntries.eraseToAnyPublisher())`, and ensuring the map starts the global search index with `jobsViewModel.startSearchIndexForAllJobs()`.  
- Extend the snapshot bridge in `LeafletWebMapView` to include `WebJob` entries and emit them to the WebMap, and update `Resources/WebMaps/FiberMap.html` to add a `jobs` layer, render status-colored job pins, and show rich popups (status, assignments, materials, footages, photos, notes, etc.).  
- Add an admin maintenance flow to geocode legacy jobs: new `adminBackfillCoordinatesForAllJobs` in `FirebaseService`, a `runMapCoordinateBackfill()` handler + `mapBackfillStatus` in `AdminPanelViewModel`, and UI in `MainTabView`/Admin to trigger “Add Old Jobs to Map” with progress and results reporting.  

### Testing
- Ran a lightweight Swift parse check with `swiftc -parse` on modified Swift sources (`AdminPanelViewModel.swift`, `LeafletWebMapView.swift`, `MapsView.swift`, `FirebaseService.swift`, `MainTabView.swift`) which produced no parse errors.  
- Ran the Javascript/firebase emulator tests with `npm test -- --runInBand`, and the test suite passed (`1 passed, 3 skipped`).  
- Attempted an Xcode build with `xcodebuild -project 'Job Tracker.xcodeproj' -scheme 'Job Tracker' -destination 'generic/platform=iOS Simulator'` but it could not be executed in this environment because `xcodebuild` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d301c6ec0832da9915c9f94977196)