### PR TITLE
Bump to 3.0.5 (build 76) and harden forced-update parsing/logic

### DIFF
--- a/Documentation/Features/AppUpdate.md
+++ b/Documentation/Features/AppUpdate.md
@@ -8,7 +8,7 @@ Create or update the document at `app_config/ios_version` with these fields:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `latestVersion` | String | Yes | Latest available marketing version, such as `2.2.0`. Any installed version lower than this is blocked. |
+| `latestVersion` | String | Yes | Latest available marketing version, such as `3.0.5`. Any installed version lower than this is blocked. |
 | `latestBuild` | String | No | Latest available build number. When the marketing version matches, lower installed builds are blocked. |
 | `minimumRequiredVersion` | String | No | Optional hard floor. Installed versions below this value are blocked even if `latestVersion` is omitted. |
 | `minimumRequiredBuild` | String | No | Optional hard floor for build numbers. |
@@ -22,6 +22,8 @@ Create or update the document at `app_config/ios_version` with these fields:
 2. `FirestoreAppUpdateRequirementProvider` listens to `app_config/ios_version` in real time.
 3. `AppVersionComparator` compares semantic version components numerically, so `1.10.0` correctly sorts after `1.2.9`.
 4. If the policy describes a newer version or build, `ForceUpdateView` is rendered over the app and cannot be dismissed. The only action is to open `updateURL`.
+
+For the 3.0.5 rollout, set both `latestVersion` and `minimumRequiredVersion` to `3.0.5` and set both `latestBuild` and `minimumRequiredBuild` to `76` so any 3.0.4 (75) client is blocked until it updates.
 
 ## Testing Notes
 

--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Job Tracker Companion";
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -456,7 +456,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Job Tracker Companion";
@@ -466,7 +466,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -610,7 +610,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Job Tracker/Job Tracker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_ASSET_PATHS = "\"Job Tracker/Preview Content\"";
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				ENABLE_PREVIEWS = YES;
@@ -632,7 +632,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -654,7 +654,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Job Tracker/Job Tracker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_ASSET_PATHS = "\"Job Tracker/Preview Content\"";
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				ENABLE_PREVIEWS = YES;
@@ -676,7 +676,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -695,7 +695,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -704,7 +704,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -721,7 +721,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -730,7 +730,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -746,11 +746,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.ui-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -766,11 +766,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.ui-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Job Tracker/Features/Shared/AppUpdate/AppUpdateRequirement.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/AppUpdateRequirement.swift
@@ -48,6 +48,7 @@ enum AppVersionComparator {
 
         if let minimumRequiredBuild = requirement.minimumRequiredBuild,
            let currentBuild,
+           compare(currentVersion, requirement.minimumRequiredVersion ?? requirement.latestVersion) == .orderedSame,
            compareBuild(currentBuild, minimumRequiredBuild) == .orderedAscending {
             return .updateRequired(requirement)
         }
@@ -59,7 +60,7 @@ enum AppVersionComparator {
         if let latestBuild = requirement.latestBuild,
            let currentBuild,
            compareBuild(currentBuild, latestBuild) == .orderedAscending,
-           compare(currentVersion, requirement.latestVersion) != .orderedDescending {
+           compare(currentVersion, requirement.latestVersion) == .orderedSame {
             return .updateRequired(requirement)
         }
 

--- a/Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift
+++ b/Job Tracker/Features/Shared/AppUpdate/ForceUpdateViewModel.swift
@@ -39,13 +39,16 @@ struct AppUpdateRemoteConfigDocument: Equatable {
     }
 
     init(data: [String: Any]) {
+        let latestVersion = Self.trimmedString(data["latestVersion"])
+        let minimumRequiredVersion = Self.trimmedString(data["minimumRequiredVersion"])
+
         self.init(
-            latestVersion: data["latestVersion"] as? String ?? data["minimumRequiredVersion"] as? String ?? "0",
-            minimumRequiredVersion: data["minimumRequiredVersion"] as? String,
-            latestBuild: data["latestBuild"] as? String,
-            minimumRequiredBuild: data["minimumRequiredBuild"] as? String,
-            updateURLString: data["updateURL"] as? String,
-            releaseNotes: data["releaseNotes"] as? String,
+            latestVersion: latestVersion ?? minimumRequiredVersion ?? "0",
+            minimumRequiredVersion: minimumRequiredVersion,
+            latestBuild: Self.trimmedString(data["latestBuild"]),
+            minimumRequiredBuild: Self.trimmedString(data["minimumRequiredBuild"]),
+            updateURLString: Self.trimmedString(data["updateURL"]),
+            releaseNotes: Self.trimmedString(data["releaseNotes"]),
             forceUpdateEnabled: data["forceUpdateEnabled"] as? Bool ?? true
         )
     }
@@ -64,11 +67,16 @@ struct AppUpdateRemoteConfigDocument: Equatable {
 
     private var trustedUpdateURL: URL? {
         guard let updateURLString else { return nil }
-        let trimmed = updateURLString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let url = URL(string: trimmed), ["https", "itms-apps"].contains(url.scheme?.lowercased()) else {
+        guard let url = URL(string: updateURLString), ["https", "itms-apps"].contains(url.scheme?.lowercased()) else {
             return nil
         }
         return url
+    }
+
+    private static func trimmedString(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/Job TrackerTests/AppVersionComparatorTests.swift
+++ b/Job TrackerTests/AppVersionComparatorTests.swift
@@ -40,4 +40,36 @@ final class AppVersionComparatorTests: XCTestCase {
 
         XCTAssertEqual(decision, .updateRequired(requirement))
     }
+
+    func testVersion305PolicyRequiresOlderInstalledVersionToUpdate() {
+        let requirement = AppUpdateRequirement(
+            latestVersion: "3.0.5",
+            minimumRequiredVersion: "3.0.5",
+            latestBuild: "76",
+            minimumRequiredBuild: "76"
+        )
+        let decision = AppVersionComparator.decision(
+            currentVersion: "3.0.4",
+            currentBuild: "75",
+            requirement: requirement
+        )
+
+        XCTAssertEqual(decision, .updateRequired(requirement))
+    }
+
+    func testMinimumRequiredBuildOnlyAppliesToMatchingMinimumVersion() {
+        let requirement = AppUpdateRequirement(
+            latestVersion: "3.0.5",
+            minimumRequiredVersion: "3.0.5",
+            latestBuild: "76",
+            minimumRequiredBuild: "76"
+        )
+        let decision = AppVersionComparator.decision(
+            currentVersion: "3.0.6",
+            currentBuild: "1",
+            requirement: requirement
+        )
+
+        XCTAssertEqual(decision, .upToDate)
+    }
 }

--- a/Job TrackerTests/ForceUpdateViewModelTests.swift
+++ b/Job TrackerTests/ForceUpdateViewModelTests.swift
@@ -106,12 +106,12 @@ final class ForceUpdateViewModelTests: XCTestCase {
 
     func testRemoteConfigDocumentParsesTrustedFirestorePayloadAndRejectsUntrustedURLScheme() {
         let document = AppUpdateRemoteConfigDocument(data: [
-            "latestVersion": "2.4.0",
-            "minimumRequiredVersion": "2.3.0",
-            "latestBuild": "30",
-            "minimumRequiredBuild": "25",
-            "updateURL": "javascript:alert(1)",
-            "releaseNotes": "Required security update",
+            "latestVersion": " 2.4.0 ",
+            "minimumRequiredVersion": " 2.3.0 ",
+            "latestBuild": " 30 ",
+            "minimumRequiredBuild": " 25 ",
+            "updateURL": " javascript:alert(1) ",
+            "releaseNotes": " Required security update ",
             "forceUpdateEnabled": true
         ])
 
@@ -123,6 +123,22 @@ final class ForceUpdateViewModelTests: XCTestCase {
         XCTAssertNil(requirement.updateURL)
         XCTAssertEqual(requirement.releaseNotes, "Required security update")
         XCTAssertTrue(requirement.isEnabled)
+    }
+
+    func testRemoteConfigDocumentFallsBackToMinimumRequiredVersionWhenLatestVersionIsBlank() {
+        let document = AppUpdateRemoteConfigDocument(data: [
+            "latestVersion": " ",
+            "minimumRequiredVersion": "3.0.5",
+            "latestBuild": "76",
+            "minimumRequiredBuild": "76",
+            "forceUpdateEnabled": true
+        ])
+
+        let requirement = document.requirement
+        XCTAssertEqual(requirement.latestVersion, "3.0.5")
+        XCTAssertEqual(requirement.minimumRequiredVersion, "3.0.5")
+        XCTAssertEqual(requirement.latestBuild, "76")
+        XCTAssertEqual(requirement.minimumRequiredBuild, "76")
     }
 
     @MainActor

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.4</string>
+	<string>3.0.5</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
### Motivation
- Release the app as `3.0.5` / build `76` and ensure the remote forced-update policy reliably blocks older clients (e.g. `3.0.4` / 75) that must update. 
- Fix cases where Firestore values containing whitespace or blank fields could prevent the app from correctly deciding to force an update.

### Description
- Updated Xcode project and targets to `MARKETING_VERSION = 3.0.5` and `CURRENT_PROJECT_VERSION = 76` and set `CFBundleShortVersionString` in `Job-Tracker-Info.plist` to `3.0.5`.
- Hardened remote-config parsing in `AppUpdateRemoteConfigDocument` to trim whitespace, treat blank `latestVersion` by falling back to `minimumRequiredVersion`, and normalize `latestBuild`/`minimumRequiredBuild`/`updateURL`/`releaseNotes` values.
- Tightened `AppVersionComparator` logic so `minimumRequiredBuild` is enforced only for the matching minimum version and `latestBuild` checks only force updates when the marketing version matches; this prevents unrelated versions from being incorrectly blocked.
- Updated `ForceUpdateView` URL validation to only allow trusted schemes and added a helper `trimmedString(_:)` to centralize trimming behavior.
- Added unit tests covering the `3.0.5` rollout scenarios and whitespace/fallback parsing: `AppVersionComparatorTests` and `ForceUpdateViewModelTests` additions.
- Documented the Firestore rollout values for 3.0.5 in `Documentation/Features/AppUpdate.md` (recommended values: set `latestVersion` and `minimumRequiredVersion` to `3.0.5` and `latestBuild`/`minimumRequiredBuild` to `76`).

### Testing
- Ran repository checks including `git diff --check` which passed.
- Validated `Job-Tracker-Info.plist` using a small Python `plistlib` script which confirmed `CFBundleShortVersionString` is `3.0.5`.
- Verified there are no stale `3.0.4` / `75` markers via targeted `rg` checks which returned clean results.
- Added unit tests for comparator and remote-config parsing but could not execute `xcodebuild test` in this environment because `xcodebuild` is not available, so iOS unit tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4002b45e0c832d99183c38876b501c)