### PR TITLE
Harden job location and deep-link validation

### DIFF
--- a/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
+++ b/Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift
@@ -29,12 +29,11 @@ struct CarPlayJobDisplay: Identifiable, Hashable {
     }
 
     var coordinate: CLLocationCoordinate2D? {
-        guard let latitude = job.latitude, let longitude = job.longitude else { return nil }
-        return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        job.clLocation?.coordinate
     }
 
     static func formatDistance(_ meters: CLLocationDistance) -> String {
-        guard meters.isFinite else { return "" }
+        guard meters.isFinite, meters >= 0 else { return "" }
         let miles = meters / 1_609.344
         if miles >= 10 {
             return "\(Int(miles.rounded())) mi"

--- a/Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift
+++ b/Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift
@@ -45,9 +45,11 @@ enum DeepLinkRouter {
 
         let isJob = (host == "job") || (lastSegment == "job")
         if isJob,
-           let id = components.queryItems?.first(where: { $0.name.lowercased() == "id" })?.value,
-           !id.isEmpty {
-            return .job(id: id)
+           let rawID = components.queryItems?.first(where: { $0.name.lowercased() == "id" })?.value {
+            let id = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !id.isEmpty {
+                return .job(id: id)
+            }
         }
 
         let isImport = (host == "importjob") || (lastSegment == "importjob")
@@ -62,7 +64,8 @@ enum DeepLinkRouter {
         let token = components
             .queryItems?
             .first(where: { $0.name.lowercased() == "token" })?
-            .value
+            .value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard let token, !token.isEmpty else {
             #if DEBUG

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -116,6 +116,9 @@ extension Job {
     /// Convenience CLLocation for distance calculations (returns nil if coords missing)
     var clLocation: CLLocation? {
         guard let lat = latitude, let lon = longitude else { return nil }
+        guard lat.isFinite, lon.isFinite,
+              (-90.0...90.0).contains(lat),
+              (-180.0...180.0).contains(lon) else { return nil }
         return CLLocation(latitude: lat, longitude: lon)
     }
 }

--- a/Job TrackerTests/DeepLinkRouterTests.swift
+++ b/Job TrackerTests/DeepLinkRouterTests.swift
@@ -32,6 +32,22 @@ final class DeepLinkRouterTests: XCTestCase {
         XCTAssertEqual(DeepLinkRouter.handle(url), .job(id: "job-456"))
     }
 
+    func testTrimsRouteValues() throws {
+        let jobURL = try XCTUnwrap(URL(string: "jobtracker://job?id=%20job-456%20"))
+        let importURL = try XCTUnwrap(URL(string: "jobtracker://importJob?token=%20ABC123%20"))
+
+        XCTAssertEqual(DeepLinkRouter.handle(jobURL), .job(id: "job-456"))
+        XCTAssertEqual(DeepLinkRouter.handle(importURL), .importJob(token: "ABC123"))
+    }
+
+    func testRejectsBlankRouteValues() throws {
+        let jobURL = try XCTUnwrap(URL(string: "jobtracker://job?id=%20%20"))
+        let importURL = try XCTUnwrap(URL(string: "jobtracker://importJob?token=%0A%20"))
+
+        XCTAssertNil(DeepLinkRouter.handle(jobURL))
+        XCTAssertNil(DeepLinkRouter.handle(importURL))
+    }
+
     func testRejectsUnknownRoute() throws {
         let url = try XCTUnwrap(URL(string: "jobtracker://help?token=ABC123"))
         XCTAssertNil(DeepLinkRouter.handle(url))

--- a/Job TrackerTests/JobLocationTests.swift
+++ b/Job TrackerTests/JobLocationTests.swift
@@ -1,0 +1,37 @@
+import CoreLocation
+import XCTest
+@testable import Job_Tracker
+
+final class JobLocationTests: XCTestCase {
+    func testLocationUsesValidCoordinates() throws {
+        let job = makeJob(latitude: 36.1627, longitude: -86.7816)
+
+        let location = try XCTUnwrap(job.clLocation)
+        XCTAssertEqual(location.coordinate.latitude, 36.1627, accuracy: 0.000_001)
+        XCTAssertEqual(location.coordinate.longitude, -86.7816, accuracy: 0.000_001)
+    }
+
+    func testLocationRejectsMissingNonFiniteAndOutOfRangeCoordinates() {
+        XCTAssertNil(makeJob(latitude: nil, longitude: -86).clLocation)
+        XCTAssertNil(makeJob(latitude: 36, longitude: nil).clLocation)
+        XCTAssertNil(makeJob(latitude: .nan, longitude: -86).clLocation)
+        XCTAssertNil(makeJob(latitude: 36, longitude: .infinity).clLocation)
+        XCTAssertNil(makeJob(latitude: 90.000_001, longitude: 0).clLocation)
+        XCTAssertNil(makeJob(latitude: 0, longitude: -180.000_001).clLocation)
+    }
+
+    func testLocationAcceptsBoundaryCoordinates() {
+        XCTAssertNotNil(makeJob(latitude: -90, longitude: -180).clLocation)
+        XCTAssertNotNil(makeJob(latitude: 90, longitude: 180).clLocation)
+    }
+
+    private func makeJob(latitude: Double?, longitude: Double?) -> Job {
+        Job(
+            address: "123 Main Street",
+            date: Date(),
+            status: "Pending",
+            latitude: latitude,
+            longitude: longitude
+        )
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent malformed or out-of-range geographic coordinates from producing invalid `CLLocation` objects used by mapping, routing, and CarPlay features.
- Avoid showing misleading distance labels when distances are negative or non-finite and guard downstream consumers against invalid values.
- Make deep-link handling more robust by trimming and rejecting blank identifiers and import tokens to avoid no-op or error flows.

### Description

- Validate job coordinates in `Job.clLocation` to reject missing, non-finite, or out-of-range latitude/longitude values before constructing a `CLLocation` object (changes in `Job Tracker/Models/Job.swift`).
- Update CarPlay display code to reuse the validated job location (`job.clLocation?.coordinate`) and prevent formatting for negative or non-finite distances in `CarPlayJobDisplay.formatDistance` (changes in `Job Tracker/Features/CarPlay/CarPlayJobDispatchService.swift`).
- Harden deep-link parsing by trimming whitespace from `id` and `token` query parameters and rejecting values that are empty after trimming (changes in `Job Tracker/Features/Jobs/Sharing/DeepLinkRouter.swift`).
- Add regression tests: `JobLocationTests` to cover valid, missing, non-finite, out-of-range, and boundary coordinates and extend `DeepLinkRouterTests` with trimming and blank-value cases (new file `Job TrackerTests/JobLocationTests.swift` and updates to `Job TrackerTests/DeepLinkRouterTests.swift`).

### Testing

- Ran `npm test` (Firebase rules tests) which succeeded: 1 file passed, 1 test file (with 3 skipped tests) ran successfully.
- Performed JavaScript syntax checks (`node --check`) and shell syntax checks (`bash -n`) which reported no issues for the checked files.
- Ran `git diff --check` and other repository checks which reported no whitespace or diff errors after the commit.
- iOS `XCTest` execution via `xcodebuild` could not be run in this Linux environment because macOS/Xcode is unavailable, so the newly added Swift XCTest files could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b22937c68832d983c61f8fe3e5472)