### PR TITLE
Improve Create Job workflow, address suggestions, duplicate handling, and photo support

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -42,6 +42,10 @@ private extension View {
     }
 }
 
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}
+
 // MARK: - Section Card
 @ViewBuilder
 private func SectionCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
@@ -310,6 +314,18 @@ struct CreateJobView: View {
     @State private var locationNumber = ""
     @State private var customStatusText = ""
     @State private var assignmentsText: String = ""
+    @State private var fiberType = ""
+    @State private var jobPlacement = ""
+    @State private var canFootage = ""
+    @State private var nidFootage = ""
+    @State private var housePhotoImage: UIImage?
+    @State private var nidPhotoImage: UIImage?
+    @State private var canPhotoImage: UIImage?
+    @State private var mapDesignPhotoImage: UIImage?
+    @State private var activePhotoSlot: JobPhotoSlot?
+    @State private var selectedPhotoSource: UIImagePickerController.SourceType = .photoLibrary
+    @State private var showPhotoSourceDialog = false
+    @State private var showImagePicker = false
     @FocusState private var isAssignmentsFocused: Bool
     @FocusState private var focusedAddressID: AddressDraft.ID?
     @StateObject private var addressSearch = AddressSearchCompleter()
@@ -318,8 +334,12 @@ struct CreateJobView: View {
     @State private var alertMessage: String?
     @State private var duplicatePrompt: DuplicateJobPrompt?
     @State private var duplicateCheckTasks: [AddressDraft.ID: Task<Void, Never>] = [:]
+    @State private var approvedSeparateAddresses = Set<String>()
+    @State private var isSaving = false
 
     let statusOptions = ["Pending","OH","UG","Nid","Can","Done","Talk to Rick","Custom"]
+    let fiberChoices = ["Flat", "Round", "Mainline"]
+    let placementChoices = ["OH", "UG"]
 
     // Address suggestion state removed
 
@@ -478,6 +498,31 @@ struct CreateJobView: View {
                             }
                         }
 
+                        SectionCard(title: "Fiber & Placement") {
+                            VStack(alignment: .leading, spacing: 14) {
+                                Picker("Fiber Type", selection: $fiberType) {
+                                    Text("Not selected").tag("")
+                                    ForEach(fiberChoices, id: \.self) { Text($0).tag($0) }
+                                }
+                                .pickerStyle(.segmented)
+
+                                Picker("Placement", selection: $jobPlacement) {
+                                    Text("Not selected").tag("")
+                                    ForEach(placementChoices, id: \.self) { Text($0).tag($0) }
+                                }
+                                .pickerStyle(.segmented)
+
+                                HStack(spacing: 12) {
+                                    TextField("CAN footage", text: $canFootage)
+                                        .keyboardType(.numberPad)
+                                        .textFieldStyle(.roundedBorder)
+                                    TextField("NID footage", text: $nidFootage)
+                                        .keyboardType(.numberPad)
+                                        .textFieldStyle(.roundedBorder)
+                                }
+                            }
+                        }
+
                         // Materials
                         SectionCard(title: "Materials Used") {
                             TextField("Enter materials info…", text: $materialsUsed)
@@ -508,6 +553,15 @@ struct CreateJobView: View {
                                 )
                         }
 
+                        SectionCard(title: "Job Photos") {
+                            VStack(spacing: 10) {
+                                createPhotoRow("House", image: housePhotoImage, slot: .house)
+                                createPhotoRow("NID", image: nidPhotoImage, slot: .nid)
+                                createPhotoRow("CAN", image: canPhotoImage, slot: .can)
+                                createPhotoRow("Map / Design", image: mapDesignPhotoImage, slot: .mapDesign)
+                            }
+                        }
+
                         // Save Button (prominent)
                         Button {
                             attemptSave()
@@ -522,6 +576,7 @@ struct CreateJobView: View {
                             .glassCard(cornerRadius: 14)
                         }
                         .buttonStyle(.plain)
+                        .disabled(isSaving)
                         .padding(.top, 4)
                     }
                     .padding(.horizontal, 16)
@@ -539,6 +594,7 @@ struct CreateJobView: View {
                     Button("Save") {
                         attemptSave()
                     }
+                    .disabled(isSaving)
                 }
             }
             .alert(alertTitle, isPresented: alertBinding, actions: {
@@ -561,6 +617,22 @@ struct CreateJobView: View {
                         duplicatePrompt = nil
                     }
                 )
+            }
+            .confirmationDialog("Add Photo", isPresented: $showPhotoSourceDialog, titleVisibility: .visible) {
+                if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                    Button("Take Photo") {
+                        selectedPhotoSource = .camera
+                        showImagePicker = true
+                    }
+                }
+                Button("Choose from Photos") {
+                    selectedPhotoSource = .photoLibrary
+                    showImagePicker = true
+                }
+                Button("Cancel", role: .cancel) { activePhotoSlot = nil }
+            }
+            .sheet(isPresented: $showImagePicker, onDismiss: { activePhotoSlot = nil }) {
+                ImagePicker(image: selectedPhotoBinding, sourceType: selectedPhotoSource)
             }
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
@@ -605,6 +677,7 @@ struct CreateJobView: View {
     // MARK: - Save
 
     private func attemptSave() {
+        guard !isSaving else { return }
         let addressDraftsToSave = addresses.compactMap { draft -> AddressDraft? in
             let trimmed = draft.text.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : AddressDraft(id: draft.id, text: trimmed, apartment: draft.trimmedApartment)
@@ -641,6 +714,7 @@ struct CreateJobView: View {
             return
         }
 
+        isSaving = true
         saveJobs(addressDraftsToSave: addressDraftsToSave)
     }
 
@@ -661,6 +735,10 @@ struct CreateJobView: View {
         let trimmedJobNumber = jobNumber.trimmingCharacters(in: .whitespacesAndNewlines)
         let jobNumberValue = trimmedJobNumber.isEmpty ? nil : trimmedJobNumber
         let materialsUsedValue = materialsUsed
+        let fiberValue = fiberType.trimmingCharacters(in: .whitespacesAndNewlines)
+        let combinedMaterials = [fiberValue.isEmpty ? nil : "Fiber: \(fiberValue)", materialsUsedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : materialsUsedValue]
+            .compactMap { $0 }
+            .joined(separator: ", ")
 
         Task {
             var preparedJobs: [PreparedJob] = []
@@ -680,7 +758,10 @@ struct CreateJobView: View {
                     portalID: portalIDValue,
                     locationNumber: locationNumberValue,
                     assignments: assignmentsValue,
-                    materialsUsed: materialsUsedValue,
+                    materialsUsed: combinedMaterials.isEmpty ? nil : combinedMaterials,
+                    nidFootage: nidFootage.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                    canFootage: canFootage.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                    jobPlacement: jobPlacement.isEmpty ? nil : jobPlacement,
                     latitude: coord?.latitude,
                     longitude: coord?.longitude
                 )))
@@ -694,13 +775,14 @@ struct CreateJobView: View {
 
     private func processPreparedJobs(_ jobs: [PreparedJob]) {
         guard let next = jobs.first else {
+            isSaving = false
             dismiss()
             return
         }
 
         let remaining = Array(jobs.dropFirst())
 
-        let matches = duplicateMatches(for: next.job)
+        let matches = approvedSeparateAddresses.contains(addressKey(next.job.address)) ? [] : duplicateMatches(for: next.job)
         if matches.isEmpty {
             createJobAndContinue(next, remainingJobs: remaining)
         } else {
@@ -717,13 +799,15 @@ struct CreateJobView: View {
 
     private func createJobAndContinue(_ preparedJob: PreparedJob, remainingJobs: [PreparedJob]) {
         duplicatePrompt = nil
-        jobsViewModel.createJob(preparedJob.job) { success in
+        jobsViewModel.createJobReturningID(preparedJob.job) { success, createdJobID in
             guard success else {
+                isSaving = false
                 alertMessage = "Could not create this job. Please try again."
                 return
             }
 
             removeCompletedAddress(id: preparedJob.addressID)
+            if let createdJobID { enqueueSelectedPhotos(for: createdJobID) }
 
             if remainingJobs.isEmpty {
                 onAddedToDashboard?(preparedJob.job)
@@ -739,9 +823,10 @@ struct CreateJobView: View {
         let dashboardDate = prompt.newJob?.job.date ?? date
         let dashboardCopy = dashboardCopyForCurrentUser(from: match.entry, scheduledDate: dashboardDate)
 
-        jobsViewModel.createJob(dashboardCopy) { success in
+        jobsViewModel.createJobReturningID(dashboardCopy) { success, createdJobID in
             handleDuplicateJoinResult(
                 success: success,
+                createdJobID: createdJobID,
                 dashboardJob: dashboardCopy,
                 prompt: prompt
             )
@@ -759,8 +844,9 @@ struct CreateJobView: View {
         return dashboardCopy
     }
 
-    private func handleDuplicateJoinResult(success: Bool, dashboardJob: Job, prompt: DuplicateJobPrompt) {
+    private func handleDuplicateJoinResult(success: Bool, createdJobID: String?, dashboardJob: Job, prompt: DuplicateJobPrompt) {
         if success {
+            if let createdJobID { enqueueSelectedPhotos(for: createdJobID) }
             if prompt.joinsAndContinuesSave {
                 if prompt.remainingJobs.isEmpty {
                     onAddedToDashboard?(dashboardJob)
@@ -774,11 +860,10 @@ struct CreateJobView: View {
                 if let addressID = prompt.addressID {
                     removeCompletedAddress(id: addressID)
                 }
-                if validAddressCount == 0 {
-                    dismiss()
-                }
+                ensureEmptyAddressRow()
             }
         } else {
+            isSaving = false
             alertMessage = "Could not add this duplicate job to your dashboard. Please try again or create a separate job."
         }
     }
@@ -787,6 +872,8 @@ struct CreateJobView: View {
         duplicatePrompt = nil
         if prompt.joinsAndContinuesSave, let newJob = prompt.newJob {
             createJobAndContinue(newJob, remainingJobs: prompt.remainingJobs)
+        } else {
+            approvedSeparateAddresses.insert(addressKey(prompt.address))
         }
     }
 
@@ -909,11 +996,79 @@ struct CreateJobView: View {
         )
     }
 
+    private var selectedPhotoBinding: Binding<UIImage?> {
+        Binding(
+            get: {
+                switch activePhotoSlot {
+                case .house: housePhotoImage
+                case .nid: nidPhotoImage
+                case .can: canPhotoImage
+                case .mapDesign: mapDesignPhotoImage
+                case nil: nil
+                }
+            },
+            set: { image in
+                switch activePhotoSlot {
+                case .house: housePhotoImage = image
+                case .nid: nidPhotoImage = image
+                case .can: canPhotoImage = image
+                case .mapDesign: mapDesignPhotoImage = image
+                case nil: break
+                }
+            }
+        )
+    }
+
+    private func createPhotoRow(_ title: String, image: UIImage?, slot: JobPhotoSlot) -> some View {
+        HStack(spacing: 12) {
+            Group {
+                if let image {
+                    Image(uiImage: image).resizable().scaledToFill()
+                } else {
+                    Image(systemName: "photo").foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 52, height: 52)
+            .clipped()
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
+
+            Text(title).font(.subheadline.weight(.semibold))
+            Spacer()
+            Button(image == nil ? "Add" : "Replace") {
+                activePhotoSlot = slot
+                showPhotoSourceDialog = true
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func enqueueSelectedPhotos(for jobID: String) {
+        let photos: [(slot: JobPhotoSlot, image: UIImage)] = [
+            housePhotoImage.map { (.house, $0) },
+            nidPhotoImage.map { (.nid, $0) },
+            canPhotoImage.map { (.can, $0) },
+            mapDesignPhotoImage.map { (.mapDesign, $0) }
+        ].compactMap { $0 }
+        guard !photos.isEmpty else { return }
+        JobPhotoUploadQueue.shared.enqueue(photos, for: jobID)
+    }
+
+    private func addressKey(_ address: String) -> String {
+        AddressDuplicateMatcher.normalizedAddressKey(address)
+    }
+
+    private func ensureEmptyAddressRow() {
+        if addresses.isEmpty {
+            addresses = [AddressDraft()]
+        }
+        isSaving = false
+    }
+
     @ViewBuilder
     private func addressField(for address: Binding<AddressDraft>) -> some View {
         let addressID = address.wrappedValue.id
 
-        ZStack(alignment: .topLeading) {
+        VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 8) {
             TextField("Enter address", text: Binding(
                 get: { address.wrappedValue.text },
@@ -1008,7 +1163,6 @@ struct CreateJobView: View {
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .stroke(Color.gray.opacity(0.2), lineWidth: 1)
                 )
-                .padding(.top, 58)
             }
         }
         .overlay(alignment: .topTrailing) {

--- a/Job Tracker/Features/Jobs/JobsViewModel.swift
+++ b/Job Tracker/Features/Jobs/JobsViewModel.swift
@@ -327,13 +327,19 @@ class JobsViewModel: ObservableObject {
     // MARK: - Create
 
     func createJob(_ job: Job, completion: @escaping (Bool) -> Void = { _ in }) {
+        createJobReturningID(job) { success, _ in completion(success) }
+    }
+
+    /// Creates a job and returns the actual local Firestore document ID. Callers that queue
+    /// follow-up work (such as photo uploads) must use this ID instead of the draft UUID.
+    func createJobReturningID(_ job: Job, completion: @escaping (Bool, String?) -> Void) {
         if ProcessInfo.processInfo.shouldSeedJobTrackerUITestData {
             var newJob = job
             newJob.id = "ui-test-created-\(jobs.count + 1)"
             jobs.append(newJob)
             rebuildSearchIndexEntries()
             notifyJobsChanged()
-            completion(true)
+            completion(true, newJob.id)
             return
         }
 
@@ -362,14 +368,14 @@ class JobsViewModel: ObservableObject {
         FirebaseService.shared.createJob(newJob) { result in
             switch result {
             case .success:
-                DispatchQueue.main.async { completion(true) }
+                DispatchQueue.main.async { completion(true, newJob.id) }
             case .failure(let error):
                 print("Error creating job via service: \(error)")
                 DispatchQueue.main.async {
                     self.pendingWriteIDs.remove(docRef.documentID)
                     self.hasPendingWrites = !self.pendingWriteIDs.isEmpty
                     self.postSyncStateChange()
-                    completion(false)
+                    completion(false, nil)
                 }
             }
             // Listener established by fetch methods will reconcile & clear pending when server ACKs

--- a/Job TrackerTests/AddressDuplicateMatcherTests.swift
+++ b/Job TrackerTests/AddressDuplicateMatcherTests.swift
@@ -31,4 +31,21 @@ final class AddressDuplicateMatcherTests: XCTestCase {
         XCTAssertFalse(comparison.isExact)
         XCTAssertTrue(comparison.isClose)
     }
+
+    func testNormalizedKeyTreatsApartmentSpellingsAsTheSameDraft() {
+        XCTAssertEqual(
+            AddressDuplicateMatcher.normalizedAddressKey("1207 Main Street, Apartment 4B"),
+            AddressDuplicateMatcher.normalizedAddressKey("1207 main st #4B")
+        )
+    }
+
+    func testDifferentApartmentNumbersAreNotExactDuplicates() {
+        let comparison = AddressDuplicateMatcher.compare(
+            "1207 Main Street Apt 4B",
+            "1207 Main Street Apt 5B"
+        )
+
+        XCTAssertFalse(comparison.isExact)
+        XCTAssertFalse(comparison.isClose)
+    }
 }


### PR DESCRIPTION
### Motivation
- Fix unreliable address suggestion tap targets caused by suggestion overlay layout so users reliably select the intended address. 
- Merge the important fields from the Job Detail into the Create Job flow so users can complete a job in one pass rather than creating then editing. 
- Prevent the Create Job view from closing when a user adds an existing job and avoid repeatedly prompting the user about the same duplicate address. 

### Description
- Expanded the Create job form (`CreateJobView.swift`) with fiber type, placement (OH/UG), CAN/NID footage fields, materials, notes, and four photo slots (House, NID, CAN, Map/Design) plus photo picker UI and camera/library flows. 
- Changed address suggestion rendering so suggestions participate in the form layout and provide full-width, reliable tap targets instead of an offset overlay. 
- Added duplicate-workflow improvements that (a) remember when the user chooses “Create My Own Separate Job” for a normalized address (`approvedSeparateAddresses`) and (b) keep the multi-address create session open, only removing the completed address and restoring an empty row when needed. 
- Added a `createJobReturningID` API in `JobsViewModel.swift` and switched Create Job callers to use it so photo uploads are queued against the real Firestore document ID rather than a draft UUID, and added `enqueueSelectedPhotos` helper to queue photos after creation. 
- Added guards to prevent double submissions during save/geocode (`isSaving`) and a small `String` helper `nilIfEmpty` plus several UI helpers (`selectedPhotoBinding`, `createPhotoRow`, `addressKey`, `ensureEmptyAddressRow`). 
- Added tests to improve duplicate-address normalization coverage for apartment/unit variants (`Job TrackerTests/AddressDuplicateMatcherTests.swift`). 

### Testing
- Ran `npm test` (Firebase rules tests) which completed successfully with the project suite showing 1 passed and 3 environment-dependent tests skipped. 
- Ran a Swift parse check using `swiftc -frontend -parse` on the changed Swift sources which completed successfully to validate syntax. 
- Ran `git diff --check` to verify there are no whitespace/patch issues and observed no problems; a full Xcode build and XCTest run could not be executed in this Linux container because Xcode is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b25db0d20832da8d6e62502f54341)