### PR TITLE
Bump release to 3.0.6 (build 130), parameterize Info.plist, add CI archive preflight and docs

### DIFF
--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -65,3 +65,25 @@ Keep this setup as the default safety net when the project grows:
 - Move slow, flaky, device-only, or external-integration checks into an additional workflow/test plan instead of weakening this one.
 
 The guardrail script intentionally detects new XCTest targets in the project and fails the workflow if they are not listed in the safety-net test plan. That makes future test bundles opt-out by exception instead of accidentally invisible to Xcode Cloud.
+
+## Release version and build numbers
+
+The iOS app and its embedded watch app are the distributable targets in the current project. Keep their Debug and Release `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` settings identical. The unit-test and UI-test bundles do not ship and therefore do not carry release numbers. The `imessage cs` sources and plist are retained in the repository, but there is currently no iMessage extension target or extension product in the Xcode project; if one is restored, treat that embedded extension as a distributable target and give it the containing app's effective version and build.
+
+For every App Store release:
+
+1. Choose an App Store version train that is still open. **A closed App Store version train cannot receive another build**; increment `MARKETING_VERSION` and create/use the new version in App Store Connect instead.
+2. Set the iOS app and watch app `MARKETING_VERSION` to that public version (for example, `3.0.6`) in both build configurations.
+3. Find the greatest build already uploaded to App Store Connect, including expired or rejected builds, and set `CURRENT_PROJECT_VERSION` on both distributable targets to a strictly greater integer. Release `3.0.6` starts at build `130` because build `129` has already been uploaded.
+4. Do not add these settings to XCTest or UI-test targets. Keep `Job-Tracker-Info.plist` parameterized with `$(MARKETING_VERSION)` and `$(CURRENT_PROJECT_VERSION)` so the packaged bundle uses Xcode's effective settings.
+5. Run the preflight and then archive. For an extra local check on a Mac, supply App Store Connect's latest values as environment variables:
+
+   ```sh
+   CI_XCODE_CLOUD=TRUE \
+   CI_XCODEBUILD_ACTION=archive \
+   CI_LAST_UPLOADED_VERSION=3.0.6 \
+   CI_LAST_UPLOADED_BUILD=129 \
+   ci_scripts/ci_pre_xcodebuild.sh
+   ```
+
+For Xcode Cloud, define `CI_LAST_UPLOADED_VERSION` and `CI_LAST_UPLOADED_BUILD` as optional workflow environment variables and update them when the latest upload changes. Before an Archive action, the script asks Xcode for the app target's effective Release build settings, rejects empty/unexpanded or malformed bundle versions, rejects an older public version, and—when the archive stays on the last uploaded version train—requires a strictly increasing build. Omitting both inputs still performs resolution and format validation.

--- a/Job Tracker.xcodeproj/project.pbxproj
+++ b/Job Tracker.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
+				CURRENT_PROJECT_VERSION = 130;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Job Tracker Companion";
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.5;
+				MARKETING_VERSION = 3.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -456,7 +456,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
+				CURRENT_PROJECT_VERSION = 130;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Job Tracker Companion";
@@ -466,7 +466,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.5;
+				MARKETING_VERSION = 3.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -610,7 +610,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Job Tracker/Job Tracker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
+				CURRENT_PROJECT_VERSION = 130;
 				DEVELOPMENT_ASSET_PATHS = "\"Job Tracker/Preview Content\"";
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				ENABLE_PREVIEWS = YES;
@@ -632,7 +632,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.5;
+				MARKETING_VERSION = 3.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -654,7 +654,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Job Tracker/Job Tracker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
+				CURRENT_PROJECT_VERSION = 130;
 				DEVELOPMENT_ASSET_PATHS = "\"Job Tracker/Preview Content\"";
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				ENABLE_PREVIEWS = YES;
@@ -676,7 +676,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.5;
+				MARKETING_VERSION = 3.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -695,7 +695,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -704,7 +703,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -721,7 +719,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -730,7 +727,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -746,11 +742,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.ui-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -766,11 +760,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = Z2Z5T47373;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.quinton.Job-Tracker-CS25.ui-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Job-Tracker-Info.plist
+++ b/Job-Tracker-Info.plist
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.5</string>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -115,6 +115,75 @@ if updated != project:
 PYRESTORE
 }
 
+preflight_archive_version() {
+  # Ask Xcode for the app target's Release settings rather than trusting values
+  # parsed directly from project.pbxproj. This catches unresolved xcconfig/build
+  # setting substitutions before App Store Connect sees the archive.
+  command -v xcodebuild >/dev/null 2>&1 || {
+    printf '[xcode-cloud-safety-net] ERROR: xcodebuild is required for archive version preflight.\n' >&2
+    exit 1
+  }
+
+  log "Resolving the archive version from the Job Tracker Release configuration."
+  settings=$(xcodebuild -showBuildSettings \
+    -project "$PROJECT_PATH" \
+    -target "Job Tracker" \
+    -configuration Release \
+    -sdk iphoneos)
+  marketing_version=$(printf '%s\n' "$settings" | sed -n 's/^[[:space:]]*MARKETING_VERSION = //p' | tail -n 1)
+  project_version=$(printf '%s\n' "$settings" | sed -n 's/^[[:space:]]*CURRENT_PROJECT_VERSION = //p' | tail -n 1)
+
+  case "$marketing_version" in
+    ""|*'$('*|*'${'*)
+      printf '[xcode-cloud-safety-net] ERROR: CFBundleShortVersionString is empty or unresolved: %s\n' "$marketing_version" >&2
+      exit 1
+      ;;
+  esac
+  case "$project_version" in
+    ""|*'$('*|*'${'*)
+      printf '[xcode-cloud-safety-net] ERROR: CFBundleVersion is empty or unresolved: %s\n' "$project_version" >&2
+      exit 1
+      ;;
+  esac
+
+  ARCHIVE_MARKETING_VERSION=$marketing_version \
+  ARCHIVE_PROJECT_VERSION=$project_version \
+  python3 <<'PYVERSION'
+import os
+import re
+
+version = os.environ["ARCHIVE_MARKETING_VERSION"]
+build = os.environ["ARCHIVE_PROJECT_VERSION"]
+last_version = os.environ.get("CI_LAST_UPLOADED_VERSION", "").strip()
+last_build = os.environ.get("CI_LAST_UPLOADED_BUILD", "").strip()
+
+if not re.fullmatch(r"\d+(?:\.\d+){1,2}", version):
+    raise SystemExit(f"[xcode-cloud-safety-net] ERROR: Invalid resolved CFBundleShortVersionString: {version}")
+if not re.fullmatch(r"\d+", build):
+    raise SystemExit(f"[xcode-cloud-safety-net] ERROR: Invalid resolved CFBundleVersion: {build}")
+
+def version_tuple(value):
+    return tuple(int(component) for component in value.split("."))
+
+if last_version and not re.fullmatch(r"\d+(?:\.\d+){1,2}", last_version):
+    raise SystemExit(f"[xcode-cloud-safety-net] ERROR: CI_LAST_UPLOADED_VERSION is invalid: {last_version}")
+if last_build and not re.fullmatch(r"\d+", last_build):
+    raise SystemExit(f"[xcode-cloud-safety-net] ERROR: CI_LAST_UPLOADED_BUILD is invalid: {last_build}")
+if last_build and not last_version:
+    raise SystemExit("[xcode-cloud-safety-net] ERROR: CI_LAST_UPLOADED_BUILD requires CI_LAST_UPLOADED_VERSION.")
+if last_version:
+    comparison_width = max(len(version_tuple(version)), len(version_tuple(last_version)))
+    current_train = version_tuple(version) + (0,) * (comparison_width - len(version_tuple(version)))
+    uploaded_train = version_tuple(last_version) + (0,) * (comparison_width - len(version_tuple(last_version)))
+    if current_train < uploaded_train:
+        raise SystemExit(f"[xcode-cloud-safety-net] ERROR: Release {version} is older than uploaded version {last_version}.")
+    if current_train == uploaded_train and last_build and int(build) <= int(last_build):
+        raise SystemExit(f"[xcode-cloud-safety-net] ERROR: Build {build} must exceed uploaded build {last_build} for version {version}.")
+
+print(f"[xcode-cloud-safety-net] Archive version resolved to {version} ({build}).")
+PYVERSION
+}
+
 # Xcode Cloud runs ci_pre_xcodebuild.sh before every workflow action, including
 # Archive. Keep these safety-net checks out of Archive/Build actions so release
 # packaging is not blocked by a test-only guardrail.
@@ -122,6 +191,12 @@ if [ "${CI_XCODE_CLOUD:-}" = "TRUE" ]; then
   normalize_xcode_cloud_bundle_identifiers
   case "${CI_XCODEBUILD_ACTION:-}" in
     build-for-testing|test|test-without-building)
+      ;;
+    archive)
+      restore_xcode_cloud_archive_graph
+      preflight_archive_version
+      log "Archive version preflight passed; skipping test-only safety-net checks."
+      exit 0
       ;;
     *)
       restore_xcode_cloud_archive_graph
@@ -154,6 +229,7 @@ project = Path("Job Tracker.xcodeproj/project.pbxproj").read_text()
 scheme = Path("Job Tracker.xcodeproj/xcshareddata/xcschemes/Job Tracker.xcscheme").read_text()
 plan_path = Path("Job Tracker Safety Net.xctestplan")
 plan = json.loads(plan_path.read_text())
+app_plist = Path("Job-Tracker-Info.plist").read_text()
 
 # Shared schemes live under Job Tracker.xcodeproj/xcshareddata/xcschemes.
 # Xcode resolves TestPlanReference container paths from the .xcodeproj bundle,
@@ -165,6 +241,37 @@ errors = []
 def check(condition, message):
     if not condition:
         errors.append(message)
+
+check("<string>$(MARKETING_VERSION)</string>" in app_plist,
+      "The app Info.plist must derive CFBundleShortVersionString from MARKETING_VERSION.")
+check("<string>$(CURRENT_PROJECT_VERSION)</string>" in app_plist,
+      "The app Info.plist must derive CFBundleVersion from CURRENT_PROJECT_VERSION.")
+
+# Only products shipped in the archive own release numbers. The watch app must
+# match its containing iOS app; XCTest bundles intentionally inherit no public
+# release train/build-number policy of their own.
+release_settings = []
+for config_id in ("CD1C8C832E5BBB150001CE7E", "CD1C8C842E5BBB150001CE7E",
+                  "CDDA112C2D579EC2007BADFF", "CDDA112D2D579EC2007BADFF"):
+    config_match = re.search(rf'{config_id} /\* (?:Debug|Release) \*/ = \{{.*?buildSettings = \{{(?P<body>.*?)\n\s+\}};', project, re.S)
+    check(config_match is not None, f"Missing distributable build configuration {config_id}.")
+    if config_match:
+        marketing_match = re.search(r"MARKETING_VERSION = ([^;]+);", config_match.group("body"))
+        build_match = re.search(r"CURRENT_PROJECT_VERSION = ([^;]+);", config_match.group("body"))
+        check(marketing_match is not None and build_match is not None,
+              "Every distributable configuration must define marketing and build versions.")
+        if marketing_match and build_match:
+            release_settings.append((marketing_match.group(1), build_match.group(1)))
+check(len(set(release_settings)) == 1,
+      "iOS and watch app Debug/Release configurations must use the same release version and build.")
+for config_id in ("CD7E57000000000000000109", "CD7E5700000000000000010A",
+                  "CD9A00000000000000000009", "CD9A0000000000000000000A"):
+    config_match = re.search(rf'{config_id} /\* (?:Debug|Release) \*/ = \{{.*?buildSettings = \{{(?P<body>.*?)\n\s+\}};', project, re.S)
+    check(config_match is not None, f"Missing test build configuration {config_id}.")
+    if config_match:
+        check("MARKETING_VERSION" not in config_match.group("body") and
+              "CURRENT_PROJECT_VERSION" not in config_match.group("body"),
+              "Unit-test and UI-test bundles must not participate in release numbering.")
 
 check(f'reference = "{expected_plan_reference}"' in scheme,
       "Shared Job Tracker scheme must use the safety-net test plan via a path relative to the .xcodeproj container.")


### PR DESCRIPTION
### Motivation

- Prepare the iOS app and embedded watch app for the next public release by advancing the public version and build beyond uploads already present in App Store Connect. 
- Ensure the packaged bundle uses Xcode-resolved values instead of hard-coded plist strings so archives always carry the effective `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION`.
- Prevent accidental release-number drift by keeping distributable targets aligned and excluding test bundles from release numbering.
- Add a CI preflight to detect unresolved or non-increasing archive versions before upload and document the release procedure for Xcode Cloud workflows.

### Description

- Updated `Job Tracker.xcodeproj/project.pbxproj` to replace `MARKETING_VERSION = 3.0.5` with `MARKETING_VERSION = 3.0.6` and to set `CURRENT_PROJECT_VERSION` from `76` to `130` for the iOS app and companion watch app Debug/Release configurations. 
- Replaced the hard-coded `CFBundleShortVersionString` in `Job-Tracker-Info.plist` with `$(MARKETING_VERSION)` and added `CFBundleVersion` as `$(CURRENT_PROJECT_VERSION)` so Xcode fills the final values at archive time.
- Added `preflight_archive_version` to `ci_scripts/ci_pre_xcodebuild.sh` which resolves the archive effective `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` via `xcodebuild -showBuildSettings`, rejects empty/unexpanded/malformed values, and optionally compares them to `CI_LAST_UPLOADED_VERSION`/`CI_LAST_UPLOADED_BUILD` to enforce a strictly increasing release when staying on the same version train. 
- Integrated the archive preflight into the script's Xcode Cloud path so Archive actions run the preflight and Test actions retain the existing safety-net checks that temporarily omit the embedded watch app for test destinations. 
- Audited build configurations in the preflight script to require distributable targets (iOS app and watch app) to share the same release settings and to assert that unit-test and UI-test bundles do not participate in release numbering. 
- Documented the release-number procedure and the rule that a closed App Store version train cannot receive another build in `Documentation/XcodeCloudTesting.md`.

### Testing

- Ran `sh -n ci_scripts/ci_pre_xcodebuild.sh` to validate shell syntax and it passed. 
- Executed `ci_scripts/ci_pre_xcodebuild.sh` in the repository environment and the script reported the safety-net checks valid (note: `xcodebuild` is not available in the Linux runner so the local scheme-resolution step is skipped by design). 
- Simulated `xcodebuild` output via a temporary shim and ran the archive preflight scenario with `CI_XCODE_CLOUD=TRUE CI_XCODEBUILD_ACTION=archive CI_LAST_UPLOADED_VERSION=3.0.6 CI_LAST_UPLOADED_BUILD=129` which passed and reported the resolved archive version; the same test with a non-increasing `CI_LAST_UPLOADED_BUILD` was correctly rejected. 
- Validated plist parsing with `python3` `plistlib` for `Job-Tracker-Info.plist` and `imessage cs/Info.plist` and ran a Python-based audit that confirmed the project now contains four `MARKETING_VERSION = 3.0.6;` and four `CURRENT_PROJECT_VERSION = 130;` occurrences and that the old values are absent. 
- Ran `git diff --check` as part of CI checks and found no whitespace/errors in the produced diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b2b0d0818832db593250f031b103e)