### PR TITLE
Replace 'Talk to Rick' status with 'Talk to Supervisor' and normalize legacy values

### DIFF
--- a/Job Tracker Companion Watch App/WatchBridge.swift
+++ b/Job Tracker Companion Watch App/WatchBridge.swift
@@ -126,7 +126,10 @@ final class WatchBridge: NSObject, ObservableObject, WCSessionDelegate {
                   let address = raw["address"] as? String else { return nil }
             let date = parseDate(from: raw)
             let jobNumber = raw["jobNumber"] as? String
-            let status = raw["status"] as? String
+            let rawStatus = raw["status"] as? String
+            let status = rawStatus?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "talk to rick"
+                ? "Talk to Supervisor"
+                : rawStatus
             return WatchJob(id: id, address: address, date: date, jobNumber: jobNumber, status: status)
         }
 

--- a/Job Tracker Companion Watch App/WatchJobDetailView.swift
+++ b/Job Tracker Companion Watch App/WatchJobDetailView.swift
@@ -26,7 +26,7 @@ struct WatchJobDetailView: View {
         "Needs Nid",
         "Needs Can",
         "Done",
-        "Talk to Rick",
+        "Talk to Supervisor",
         "Custom"
     ]
 
@@ -75,7 +75,10 @@ struct WatchJobDetailView: View {
         }
         .navigationTitle("Details")
         .onAppear {
-            let s = job.status ?? "Pending"
+            let rawStatus = job.status ?? "Pending"
+            let s = rawStatus.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "talk to rick"
+                ? "Talk to Supervisor"
+                : rawStatus
             if statuses.contains(s) {
                 status = s
                 customStatus = ""

--- a/Job Tracker/Features/Dashboard/DashboardViewModel.swift
+++ b/Job Tracker/Features/Dashboard/DashboardViewModel.swift
@@ -87,7 +87,7 @@ final class DashboardViewModel: ObservableObject {
         "Needs Nid",
         "Needs Can",
         "Done",
-        "Talk to Rick",
+        "Talk to Supervisor",
         "Custom"
     ]
 

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -337,7 +337,7 @@ struct CreateJobView: View {
     @State private var approvedSeparateAddresses = Set<String>()
     @State private var isSaving = false
 
-    let statusOptions = ["Pending","OH","UG","Nid","Can","Done","Talk to Rick","Custom"]
+    let statusOptions = ["Pending","OH","UG","Nid","Can","Done","Talk to Supervisor","Custom"]
     let fiberChoices = ["Flat", "Round", "Mainline"]
     let placementChoices = ["OH", "UG"]
 

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -86,7 +86,7 @@ struct JobDetailView: View {
         "Needs Nid",
         "Needs Can",
         "Done",
-        "Talk to Rick",   // fixed option
+        "Talk to Supervisor",   // fixed option
         "Custom"          // allows manual entry
     ]
     let ohMaterials = ["None", "Weatherhead", "Rams Head"]

--- a/Job Tracker/Models/CrewPosition.swift
+++ b/Job Tracker/Models/CrewPosition.swift
@@ -38,6 +38,7 @@ enum CrewPosition: String, CaseIterable, Identifiable, Hashable {
 
     static func normalizedStatusForSaving(_ rawStatus: String) -> String {
         let trimmed = rawStatus.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isTalkToSupervisor(trimmed) { return "Talk to Supervisor" }
         if isOH(trimmed) { return oh.rawValue }
         if isNeedsOH(trimmed) { return "Needs OH" }
         return trimmed
@@ -45,6 +46,7 @@ enum CrewPosition: String, CaseIterable, Identifiable, Hashable {
 
     static func statusDisplayName(from rawStatus: String) -> String {
         let trimmed = rawStatus.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isTalkToSupervisor(trimmed) { return "Talk to Supervisor" }
         if isOH(trimmed) { return oh.rawValue }
         if isNeedsOH(trimmed) { return "Needs OH" }
         return trimmed
@@ -58,6 +60,11 @@ enum CrewPosition: String, CaseIterable, Identifiable, Hashable {
     private static func isNeedsOH(_ rawStatus: String) -> Bool {
         let token = normalizedToken(rawStatus)
         return token == "needsoh" || token == "needsaerial" || token == "needsariel" || token == "needsarial" || token == "needsoverhead"
+    }
+
+    private static func isTalkToSupervisor(_ rawStatus: String) -> Bool {
+        let token = normalizedToken(rawStatus)
+        return token == "talktorick" || token == "talktosupervisor"
     }
 
     private static let ohAliases: Set<String> = ["oh", "overhead", "aerial", "ariel", "arial"]

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -59,7 +59,9 @@ struct Job: Identifiable, Codable {
         self.id = id
         self.address = address
         self.date = date
-        self.status = status
+        // Statuses are persisted as their user-facing label. Normalize legacy labels at the
+        // model boundary so every writer and reader converges on the same current value.
+        self.status = CrewPosition.normalizedStatusForSaving(status)
         self.assignedTo = assignedTo
         self.createdBy = createdBy
         self.notes = notes
@@ -80,6 +82,38 @@ struct Job: Identifiable, Codable {
         self.jobPlacement = jobPlacement
         self.latitude = latitude
         self.longitude = longitude
+    }
+}
+
+extension Job {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try values.decode(String.self, forKey: .id),
+            address: try values.decode(String.self, forKey: .address),
+            date: try values.decode(Date.self, forKey: .date),
+            status: try values.decode(String.self, forKey: .status),
+            assignedTo: try values.decodeIfPresent(String.self, forKey: .assignedTo),
+            createdBy: try values.decodeIfPresent(String.self, forKey: .createdBy),
+            notes: try values.decodeIfPresent(String.self, forKey: .notes) ?? "",
+            jobNumber: try values.decodeIfPresent(String.self, forKey: .jobNumber),
+            portalID: try values.decodeIfPresent(String.self, forKey: .portalID),
+            locationNumber: try values.decodeIfPresent(String.self, forKey: .locationNumber),
+            assignments: try values.decodeIfPresent(String.self, forKey: .assignments),
+            materialsUsed: try values.decodeIfPresent(String.self, forKey: .materialsUsed),
+            photos: try values.decodeIfPresent([String].self, forKey: .photos) ?? [],
+            housePhotoURL: try values.decodeIfPresent(String.self, forKey: .housePhotoURL),
+            nidPhotoURL: try values.decodeIfPresent(String.self, forKey: .nidPhotoURL),
+            canPhotoURL: try values.decodeIfPresent(String.self, forKey: .canPhotoURL),
+            mapDesignPhotoURL: try values.decodeIfPresent(String.self, forKey: .mapDesignPhotoURL),
+            participants: try values.decodeIfPresent([String].self, forKey: .participants),
+            hours: try values.decodeIfPresent(Double.self, forKey: .hours) ?? 0,
+            nidFootage: try values.decodeIfPresent(String.self, forKey: .nidFootage),
+            canFootage: try values.decodeIfPresent(String.self, forKey: .canFootage),
+            jobPlacement: try values.decodeIfPresent(String.self, forKey: .jobPlacement),
+            latitude: try values.decodeIfPresent(Double.self, forKey: .latitude),
+            longitude: try values.decodeIfPresent(Double.self, forKey: .longitude)
+        )
     }
 }
 

--- a/Job Tracker/intent/CreateJobIntent.swift
+++ b/Job Tracker/intent/CreateJobIntent.swift
@@ -35,7 +35,7 @@ struct CreateJobIntent: AppIntent {
     
     // The perform method is called when Siri or Shortcuts executes this intent.
     func perform() async throws -> some ProvidesDialog {
-        let allowed = ["Pending","Needs OH","Needs Underground","Needs Nid","Needs Can","Done","Talk to Rick"]
+        let allowed = ["Pending","Needs OH","Needs Underground","Needs Nid","Needs Can","Done","Talk to Supervisor"]
         let chosen = status.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalized = CrewPosition.normalizedStatusForSaving(allowed.first { $0.lowercased() == chosen.lowercased() } ?? chosen)
         

--- a/Job Tracker/intent/UpdateJobStatusIntent.swift
+++ b/Job Tracker/intent/UpdateJobStatusIntent.swift
@@ -18,7 +18,7 @@ enum JobStatusIntentEnum: String, AppEnum {
     case needsNid = "Needs Nid"
     case needsCan = "Needs Can"
     case done = "Done"
-    case talkToRick = "Talk to Rick"
+    case talkToSupervisor = "Talk to Supervisor"
     case custom = "Custom"
 
     static var typeDisplayRepresentation: TypeDisplayRepresentation = "Job Status"
@@ -30,7 +30,7 @@ enum JobStatusIntentEnum: String, AppEnum {
         .needsNid: "Needs Nid",
         .needsCan: "Needs Can",
         .done: "Done",
-        .talkToRick: "Talk to Rick",
+        .talkToSupervisor: "Talk to Supervisor",
         .custom: "Custom"
     ]
 }

--- a/Job TrackerTests/CrewPositionTests.swift
+++ b/Job TrackerTests/CrewPositionTests.swift
@@ -29,4 +29,36 @@ final class CrewPositionTests: XCTestCase {
         XCTAssertEqual(CrewPosition.statusDisplayName(from: " needs overhead "), "Needs OH")
         XCTAssertEqual(CrewPosition.normalizedStatusForSaving("Complete"), "Complete")
     }
+
+    func testLegacySupervisorStatusUsesCurrentDisplayText() {
+        XCTAssertEqual(CrewPosition.statusDisplayName(from: " Talk to Rick "), "Talk to Supervisor")
+        XCTAssertEqual(CrewPosition.statusDisplayName(from: "Talk to Supervisor"), "Talk to Supervisor")
+    }
+
+    func testLegacySupervisorStatusDecodesAsCurrentValue() throws {
+        let legacyJob = Job(address: "1 Main St", date: Date(timeIntervalSinceReferenceDate: 1), status: "Pending")
+        let encoded = try JSONEncoder().encode(legacyJob)
+        var document = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        document["status"] = "Talk to Rick"
+
+        let decoded = try JSONDecoder().decode(Job.self, from: JSONSerialization.data(withJSONObject: document))
+
+        XCTAssertEqual(decoded.status, "Talk to Supervisor")
+    }
+
+    func testNewSupervisorStatusIsSavedAsDisplayLabel() throws {
+        let job = Job(address: "1 Main St", date: Date(), status: " talk to supervisor ")
+        let document = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(job)) as? [String: Any])
+
+        XCTAssertEqual(job.status, "Talk to Supervisor")
+        XCTAssertEqual(document["status"] as? String, "Talk to Supervisor")
+    }
+
+    @available(iOS 26.0, *)
+    func testAppIntentSupervisorStatusRawAndDisplayValues() {
+        XCTAssertEqual(JobStatusIntentEnum.talkToSupervisor.rawValue, "Talk to Supervisor")
+        let representation = JobStatusIntentEnum.caseDisplayRepresentations[.talkToSupervisor]
+        XCTAssertEqual(representation.map { String(localized: $0.title) }, "Talk to Supervisor")
+        XCTAssertNil(JobStatusIntentEnum(rawValue: "Talk to Rick"))
+    }
 }

--- a/website/app/parity-data-search.js
+++ b/website/app/parity-data-search.js
@@ -1,6 +1,6 @@
 // Web-only parity layer kept separate from parity-enhancements.js to avoid merge conflicts
 // with the shared baseline file while preserving iOS data/search/sharing behavior.
-const nativeStatusOptions = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
+const nativeStatusOptions = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Supervisor", "Custom"];
 statuses.splice(0, statuses.length, ...nativeStatusOptions);
 
 appState.searchJobs = appState.searchJobs || [];
@@ -144,7 +144,7 @@ loadAppData = async function enhancedLoadAppData() {
     paginatedListDocs("partnerRequests"),
   ]);
   appState.users = users;
-  appState.jobs = jobs.filter((job) => canSeeJob(job));
+  appState.jobs = jobs.filter((job) => canSeeJob(job)).map((job) => ({ ...job, status: normalizeCrewStatus(job.status) }));
   appState.searchJobs = mergeSearchEntries(jobs, searchIndex);
   appState.timesheets = Object.fromEntries(timesheets.filter((sheet) => sheet.userId === currentUser.id).map((sheet) => [sheet.weekStart, normalizeTimesheet(sheet)]));
   appState.yellowSheets = Object.fromEntries(yellowSheets.filter((sheet) => sheet.userId === currentUser.id).map((sheet) => [sheet.date || sheet.weekStart, normalizeYellowSheet(sheet)]));
@@ -198,7 +198,7 @@ isOpen = function enhancedIsOpen(job) {
 statusClass = function enhancedStatusClass(status) {
   const normalized = String(status || "").toLowerCase();
   if (normalized === "done") return "done";
-  if (normalized.startsWith("needs") || normalized === "talk to rick" || normalized === "custom") return "warning";
+  if (normalized.startsWith("needs") || ["talk to supervisor", "talk to rick"].includes(normalized) || normalized === "custom") return "warning";
   if (normalized === "pending") return "pending";
   return "";
 };

--- a/website/app/parity-enhancements.js
+++ b/website/app/parity-enhancements.js
@@ -1,4 +1,4 @@
-const nativeStatusOptions = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
+const nativeStatusOptions = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Supervisor", "Custom"];
 statuses.splice(0, statuses.length, ...nativeStatusOptions);
 
 const parityBase = {

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -4,7 +4,7 @@ const tokenBase = "https://securetoken.googleapis.com/v1/token";
 const firestoreBase = config.projectId ? `https://firestore.googleapis.com/v1/projects/${config.projectId}/databases/(default)/documents` : "";
 const sessionKey = "job-tracker-web-firebase-session";
 const appDataCachePrefix = "job-tracker-web-app-data";
-const statuses = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Rick", "Custom"];
+const statuses = ["Pending", "Needs OH", "Needs Underground", "Needs Nid", "Needs Can", "Done", "Talk to Supervisor", "Custom"];
 const weekDays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
 const shortDays = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 const shareTokenAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789";
@@ -269,7 +269,7 @@ async function loadAppData() {
     listDocs("partnerRequests"),
   ]);
   appState.users = users;
-  appState.jobs = jobs.filter((job) => canSeeJob(job));
+  appState.jobs = jobs.filter((job) => canSeeJob(job)).map((job) => ({ ...job, status: normalizeCrewStatus(job.status) }));
   appState.timesheets = Object.fromEntries(timesheets.filter((sheet) => sheet.userId === currentUser.id).map((sheet) => [sheet.weekStart, normalizeTimesheet(sheet)]));
   appState.yellowSheets = Object.fromEntries(yellowSheets.filter((sheet) => sheet.userId === currentUser.id).map((sheet) => [sheet.date || sheet.weekStart, normalizeYellowSheet(sheet)]));
   appState.partnerRequests = partnerRequests.filter((request) => request.fromUid === currentUser.id || request.toUid === currentUser.id);
@@ -287,6 +287,7 @@ function normalizeCrewStatus(status) {
   const key = value.toLowerCase().replace(/[^a-z0-9]/g, "");
   if (["oh", "overhead", "aerial", "ariel", "arial"].includes(key)) return "OH";
   if (["needsoh", "needsoverhead", "needsaerial", "needsariel", "needsarial"].includes(key)) return "Needs OH";
+  if (["talktorick", "talktosupervisor"].includes(key)) return "Talk to Supervisor";
   return value;
 }
 
@@ -432,7 +433,7 @@ function isOpen(job) { return String(job.status || "Pending").toLowerCase() === 
 function statusClass(status) {
   const normalized = String(status || "").toLowerCase();
   if (normalized === "done") return "done";
-  if (normalized.startsWith("needs") || normalized === "talk to rick" || normalized === "custom") return "warning";
+  if (normalized.startsWith("needs") || ["talk to supervisor", "talk to rick"].includes(normalized) || normalized === "custom") return "warning";
   if (normalized === "pending") return "pending";
   return "";
 }


### PR DESCRIPTION
### Motivation

- Move the user-facing status label from the person-specific `Talk to Rick` to a supervisor-neutral `Talk to Supervisor` across iOS, watchOS, App Intents, and the web while preserving compatibility with historical documents.
- Ensure reads of legacy stored values (`Talk to Rick`) surface the new display text and choose a consistent policy for new writes (store the human-readable display label).

### Description

- Replaced UI and enum references so the new display label is `Talk to Supervisor` in the job editors, dashboard, watch UI, App Intents, and web status options (e.g. `CreateJobView.swift`, `JobDetailView.swift`, `DashboardViewModel.swift`, watch app files, `CreateJobIntent.swift`, `UpdateJobStatusIntent.swift`, and web JS files). 
- Added normalization at the model boundary so `Job` initializers and decoding call `CrewPosition.normalizedStatusForSaving(...)`, and extended `CrewPosition` with `isTalkToSupervisor(...)` to map both `talktorick` and `talktosupervisor` tokens to the current display label.
- Updated web parity layer to normalize incoming job statuses and to treat both the normalized `talk to supervisor` and legacy `talk to rick` as warning-class statuses in `statusClass`.
- Preserved literal examples and fallback roster in `SupervisorJobImportView.swift` unchanged because they represent business data rather than app status values.
- Added unit tests in `Job TrackerTests/CrewPositionTests.swift` covering legacy decoding (legacy stored `Talk to Rick` decodes to `Talk to Supervisor`), new-status saving/display normalization, and App Intent raw/display values.

### Testing

- Ran JavaScript syntax checks: `node --check website/app/script.js`, `node --check website/app/parity-enhancements.js`, and `node --check website/app/parity-data-search.js` and they passed.
- Ran `git diff --check` to ensure no whitespace/merge issues and it passed.
- Added Swift unit tests in `Job TrackerTests/CrewPositionTests.swift` to cover legacy decoding, saving, and App Intent values, but the iOS unit suite was not executed because Xcode is unavailable in this Linux environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b2b19c2dc832d9a5067e809b42365)