### PR TITLE
Add append-only job audit timeline with Firestore rules and emulator tests

### DIFF
--- a/Documentation/JobAudit.md
+++ b/Documentation/JobAudit.md
@@ -1,0 +1,9 @@
+# Job audit history
+
+Job activity is stored in the append-only `jobs/{jobId}/events/{eventId}` subcollection. Events contain the authenticated actor ID, a server timestamp, an event type, and small before/after display summaries. Note bodies, attachment URLs, and complete job snapshots are intentionally excluded.
+
+Firestore's local cache makes already-read pages available offline; locally queued events display as **Offline** until their server timestamp resolves. The UI requests 20 newest events at a time and lets the reader page backward.
+
+## Retention
+
+Audit events are retained for **seven years after the event timestamp**, including after a job is soft-deleted or restored. A scheduled privileged backend retention task should delete expired events under the organization's records policy; clients can never update or delete an event. Legal holds must suspend that task for affected jobs. Export events before destructive account or project removal.

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -329,6 +329,15 @@ private let jobPlacementChoices = ["OH", "UG"]
 
                     Section(header: Text("Job Photos")) { jobPhotoSlotsSection }
 
+                    Section(header: Text("Timeline")) {
+                        JobAuditTimeline(jobID: job.id) { actorID in
+                            guard actorID == authViewModel.currentUser?.id else { return actorID }
+                            let first = authViewModel.currentUser?.firstName ?? ""
+                            let last = authViewModel.currentUser?.lastName ?? ""
+                            return "\(first) \(last)".trimmingCharacters(in: .whitespaces)
+                        }
+                    }
+
                 }
                 .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)   // keep gradient visible

--- a/Job Tracker/Features/Jobs/JobAuditTimeline.swift
+++ b/Job Tracker/Features/Jobs/JobAuditTimeline.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import FirebaseAuth
+import FirebaseFirestore
+
+/// A deliberately small audit record. `before` and `after` contain display summaries only;
+/// job documents, note text, and attachment URLs must never be copied into this collection.
+struct JobAuditEvent: Identifiable {
+    let id: String
+    let actorID: String
+    let occurredAt: Date?
+    let type: String
+    let before: [String: String]
+    let after: [String: String]
+    let isPending: Bool
+}
+
+enum JobAudit {
+    static let pageSize = 20
+
+    static func summary(_ job: Job) -> [String: String] {
+        [
+            "status": job.status,
+            "assignment": job.assignedTo?.isEmpty == false ? job.assignedTo! : "Unassigned",
+            "schedule": ISO8601DateFormatter().string(from: job.date),
+            "notes": job.notes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? "Present" : "None",
+            "attachments": String(job.photos.count + [job.housePhotoURL, job.nidPhotoURL, job.canPhotoURL, job.mapDesignPhotoURL].compactMap { $0 }.count),
+            "deletion": "Active"
+        ]
+    }
+
+    static func write(jobID: String, type: String, before: [String: String], after: [String: String], completion: ((Error?) -> Void)? = nil) {
+        guard let actorID = Auth.auth().currentUser?.uid else {
+            completion?(NSError(domain: "JobAudit", code: 401, userInfo: [NSLocalizedDescriptionKey: "Sign in is required to record job history."]))
+            return
+        }
+        Firestore.firestore().collection("jobs").document(jobID).collection("events").document().setData([
+            "actorID": actorID,
+            "occurredAt": FieldValue.serverTimestamp(),
+            "type": type,
+            "before": before,
+            "after": after
+        ]) { completion?($0) }
+    }
+}
+
+@MainActor
+final class JobAuditTimelineModel: ObservableObject {
+    @Published var events: [JobAuditEvent] = []
+    @Published var errorMessage: String?
+    @Published var isLoading = false
+    private var cursor: DocumentSnapshot?
+    private var hasMore = true
+
+    func load(jobID: String, reset: Bool = false) {
+        guard !isLoading, reset || hasMore else { return }
+        if reset { cursor = nil; hasMore = true }
+        isLoading = true
+        var query: Query = Firestore.firestore().collection("jobs").document(jobID).collection("events")
+            .order(by: "occurredAt", descending: true).limit(to: JobAudit.pageSize)
+        if let cursor { query = query.start(afterDocument: cursor) }
+        query.getDocuments(source: .default) { [weak self] snapshot, error in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isLoading = false
+                if let error { self.errorMessage = error.localizedDescription; return }
+                let docs = snapshot?.documents ?? []
+                let decoded = docs.compactMap(Self.decode)
+                self.events = reset ? decoded : self.events + decoded
+                self.cursor = docs.last
+                self.hasMore = docs.count == JobAudit.pageSize
+            }
+        }
+    }
+
+    private static func decode(_ doc: QueryDocumentSnapshot) -> JobAuditEvent? {
+        let data = doc.data()
+        guard let actor = data["actorID"] as? String, let type = data["type"] as? String else { return nil }
+        return JobAuditEvent(id: doc.documentID, actorID: actor,
+                             occurredAt: (data["occurredAt"] as? Timestamp)?.dateValue(), type: type,
+                             before: data["before"] as? [String: String] ?? [:],
+                             after: data["after"] as? [String: String] ?? [:],
+                             isPending: doc.metadata.hasPendingWrites)
+    }
+}
+
+struct JobAuditTimeline: View {
+    let jobID: String
+    let displayName: (String) -> String
+    @StateObject private var model = JobAuditTimelineModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Timeline").font(.headline)
+            if model.events.isEmpty && !model.isLoading { Text("No history yet.").foregroundStyle(.secondary) }
+            ForEach(model.events) { event in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(label(event)).font(.subheadline).fontWeight(.medium)
+                    HStack {
+                        Text(event.occurredAt?.formatted(date: .abbreviated, time: .shortened) ?? "Waiting for server time")
+                        if event.isPending { Text("Offline").foregroundStyle(.orange) }
+                    }.font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            if model.isLoading { ProgressView() }
+            if let message = model.errorMessage, model.events.isEmpty { Text(message).font(.caption).foregroundStyle(.secondary) }
+            if !model.events.isEmpty {
+                Button("Load earlier activity") { model.load(jobID: jobID) }.disabled(model.isLoading)
+            }
+        }
+        .onAppear { model.load(jobID: jobID, reset: true) }
+    }
+
+    private func label(_ event: JobAuditEvent) -> String {
+        let actor = displayName(event.actorID)
+        let keys = ["status", "assignment", "schedule", "notes", "attachments", "deletion"]
+        if let key = keys.first(where: { event.before[$0] != event.after[$0] }) {
+            return "\(key.capitalized) changed from \(event.before[key] ?? "None") to \(event.after[key] ?? "None") by \(actor)"
+        }
+        return "\(event.type.replacingOccurrences(of: "_", with: " ").capitalized) by \(actor)"
+    }
+}

--- a/Job Tracker/Features/Jobs/JobsViewModel.swift
+++ b/Job Tracker/Features/Jobs/JobsViewModel.swift
@@ -215,6 +215,7 @@ class JobsViewModel: ObservableObject {
                 }
                 var job = try? doc.data(as: Job.self)
                 job?.id = doc.documentID
+                if job?.isDeleted == true { return nil }
                 if let id = job?.id, !seen.contains(id) {
                     seen.insert(id)
                     return job
@@ -451,6 +452,7 @@ class JobsViewModel: ObservableObject {
         }
 
         let ref = db.collection("jobs").document(documentID)
+        let requestedSummary = JobAudit.summary(job)
 
         // 1) Read current participants so we never drop them during an update
         ref.getDocument { [weak self] snap, readErr in
@@ -459,6 +461,7 @@ class JobsViewModel: ObservableObject {
                 print("updateJob: failed to read existing doc: \(readErr)")
             }
             let documentParticipants = (snap?.data()?["participants"] as? [String]) ?? []
+            let priorJob = snap.flatMap { try? $0.data(as: Job.self) }
             let jobParticipants = job.participants ?? []
             let cleanedDocumentParticipants = documentParticipants.filter { !$0.isEmpty }
             let cleanedJobParticipants = jobParticipants.filter { !$0.isEmpty }
@@ -472,6 +475,8 @@ class JobsViewModel: ObservableObject {
                         print("updateJob: merge setData error: \(writeErr)")
                         return
                     }
+                    JobAudit.write(jobID: documentID, type: "job_updated",
+                                   before: priorJob.map(JobAudit.summary) ?? [:], after: requestedSummary)
                     var patch: [String: Any] = [:]
 
                     // The Firestore Codable encoder omits nil optionals. Because this update uses
@@ -550,6 +555,9 @@ class JobsViewModel: ObservableObject {
         }
 
         // Patch Firestore; if the doc isn't there offline, fallback to setData
+        var statusAfter = JobAudit.summary(job)
+        statusAfter["status"] = newStatus
+        JobAudit.write(jobID: docID, type: "status_changed", before: JobAudit.summary(job), after: statusAfter)
         db.collection("jobs").document(docID).updateData(["status": newStatus]) { [weak self] err in
             if err != nil {
                 var updated = job

--- a/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
+++ b/Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift
@@ -76,7 +76,10 @@ final class SupervisorJobsViewModel: ObservableObject {
                 return
             }
             let docs = snap?.documents ?? []
-            let mapped: [Job] = docs.compactMap { try? $0.data(as: Job.self) }
+            let mapped: [Job] = docs.compactMap { doc in
+                guard let job = try? doc.data(as: Job.self), job.isDeleted != true else { return nil }
+                return job
+            }
             DispatchQueue.main.async {
                 self.jobs = mapped
                 self.isLoading = false

--- a/Job Tracker/Features/Search/JobSearchDetailView.swift
+++ b/Job Tracker/Features/Search/JobSearchDetailView.swift
@@ -743,6 +743,12 @@ struct UniversalJobDetailView: View {
                         if !photoURLStrings.isEmpty {
                             PhotosSection(photos: photoURLStrings)
                         }
+
+                        GlassCard(cornerRadius: JTShapes.largeCardCornerRadius,
+                                  strokeColor: JTColors.glassSoftStroke) {
+                            JobAuditTimeline(jobID: job.id, displayName: displayName(for:))
+                                .padding(JTSpacing.lg)
+                        }
                     }
                     .padding(.horizontal, JTSpacing.lg)
                     .padding(.vertical, JTSpacing.xl)

--- a/Job Tracker/Features/Shared/Services/FirebaseService.swift
+++ b/Job Tracker/Features/Shared/Services/FirebaseService.swift
@@ -354,6 +354,7 @@ class FirebaseService {
                     completion(.failure(err))
                     return
                 }
+                JobAudit.write(jobID: job.id, type: "job_created", before: [:], after: JobAudit.summary(job))
                 self.gatherParticipants(for: job) { participants in
                     guard !participants.isEmpty else {
                         completion(.success(()))
@@ -585,41 +586,47 @@ class FirebaseService {
     // - allow update if user is in participants.
     // Implementing the dynamic "paired" check may require Cloud Functions or a secure schema; client enforces it here.
 
-    /// Delete logic that respects current pairing:
-    /// - If the current user is actively paired with another participant on this job at deletion time, HARD delete the job (removes for both).
-    /// - If not paired, SOFT delete (remove only the current user from `participants`; delete doc only if no one remains).
+    /// Tombstone deletion preserves the job's append-only history and permits privileged restoration.
     func deleteJobRespectingPairing(jobId: String, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let me = currentUserID() else {
             completion(.failure(NSError(domain: "FirebaseService", code: 401, userInfo: [NSLocalizedDescriptionKey: "Not signed in"])))
             return
         }
         let ref = db.collection("jobs").document(jobId)
-        ref.getDocument { [weak self] snap, err in
-            guard let self = self else { return }
+        ref.getDocument { snap, err in
             if let err = err { completion(.failure(err)); return }
             guard let data = snap?.data() else {
                 completion(.failure(NSError(domain: "FirebaseService", code: 404, userInfo: [NSLocalizedDescriptionKey: "Job not found"])))
                 return
             }
-            let participants = (data["participants"] as? [String]) ?? []
-            // Who am I currently paired with?
-            self.fetchPartnerId(for: me) { currentPartner in
-                // If we're currently paired and the partner is also a participant on this job, HARD delete (removes for both).
-                if let partner = currentPartner, participants.contains(partner) {
-                    ref.delete { delErr in
-                        if let delErr = delErr { completion(.failure(delErr)) }
-                        else { completion(.success(())) }
-                    }
-                } else {
-                    // Not paired (or partner not on this job): SOFT delete (leave the job)
-                    self.leaveJob(jobId: jobId) { result in
-                        switch result {
-                        case .success: completion(.success(()))
-                        case .failure(let e): completion(.failure(e))
-                        }
-                    }
-                }
+            guard (data["participants"] as? [String] ?? []).contains(me) || data["createdBy"] as? String == me else {
+                completion(.failure(NSError(domain: "FirebaseService", code: 403, userInfo: [NSLocalizedDescriptionKey: "You cannot delete this job."])))
+                return
             }
+            JobAudit.write(jobID: jobId, type: "job_deleted",
+                           before: ["deletion": "Active"], after: ["deletion": "Deleted"])
+            ref.updateData(["isDeleted": true, "deletedAt": FieldValue.serverTimestamp(), "deletedBy": me]) { delErr in
+                if let delErr { completion(.failure(delErr)) }
+                else { completion(.success(())) }
+            }
+        }
+    }
+
+    /// Restores a tombstoned job. Firestore rules restrict this to a participant or administrator.
+    func restoreJob(jobId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard currentUserID() != nil else {
+            completion(.failure(NSError(domain: "FirebaseService", code: 401, userInfo: [NSLocalizedDescriptionKey: "Not signed in"])))
+            return
+        }
+        JobAudit.write(jobID: jobId, type: "job_restored",
+                       before: ["deletion": "Deleted"], after: ["deletion": "Active"])
+        db.collection("jobs").document(jobId).updateData([
+            "isDeleted": false,
+            "restoredAt": FieldValue.serverTimestamp(),
+            "deletedAt": FieldValue.delete(),
+            "deletedBy": FieldValue.delete()
+        ]) { error in
+            if let error { completion(.failure(error)) } else { completion(.success(())) }
         }
     }
     

--- a/Job Tracker/Models/Job.swift
+++ b/Job Tracker/Models/Job.swift
@@ -28,6 +28,7 @@ struct Job: Identifiable, Codable {
     var nidFootage: String?
     var canFootage: String?
     var jobPlacement: String?       // "OH" or "UG"
+    var isDeleted: Bool?            // Soft deletion preserves append-only audit history
     
     // Default initializer updated to include new fields.
     init(
@@ -80,6 +81,7 @@ struct Job: Identifiable, Codable {
         self.jobPlacement = jobPlacement
         self.latitude = latitude
         self.longitude = longitude
+        self.isDeleted = false
     }
 }
 

--- a/firebase-emulator-tests/job-events.test.js
+++ b/firebase-emulator-tests/job-events.test.js
@@ -1,0 +1,37 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from "vitest";
+import { initializeTestEnvironment, assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc, serverTimestamp } from "firebase/firestore";
+import { readFileSync } from "node:fs";
+
+let env;
+const projectId = "job-tracker-audit-test";
+beforeAll(async () => { env = await initializeTestEnvironment({ projectId, firestore: { rules: readFileSync("firestore.rules", "utf8") } }); });
+afterAll(async () => env.cleanup());
+beforeEach(async () => {
+  await env.clearFirestore();
+  await env.withSecurityRulesDisabled(async context => setDoc(doc(context.firestore(), "jobs/job-1"), {
+    createdBy: "member", assignedTo: "member", participants: ["member"], status: "Pending"
+  }));
+});
+
+describe("job event security", () => {
+  it("allows members to append valid events", async () => {
+    const db = env.authenticatedContext("member").firestore();
+    await assertSucceeds(setDoc(doc(db, "jobs/job-1/events/event-1"), {
+      actorID: "member", occurredAt: serverTimestamp(), type: "status_changed",
+      before: { status: "Pending" }, after: { status: "Needs OH" }
+    }));
+  });
+  it("prevents every client, including admins, from rewriting or deleting history", async () => {
+    await env.withSecurityRulesDisabled(async context => setDoc(doc(context.firestore(), "jobs/job-1/events/event-1"), {
+      actorID: "member", occurredAt: new Date(), type: "created", before: {}, after: { status: "Pending" }
+    }));
+    const admin = env.authenticatedContext("boss", { admin: true }).firestore();
+    await assertFails(updateDoc(doc(admin, "jobs/job-1/events/event-1"), { type: "tampered" }));
+    await assertFails(deleteDoc(doc(admin, "jobs/job-1/events/event-1")));
+  });
+  it("denies unrelated users access to events", async () => {
+    const db = env.authenticatedContext("stranger").firestore();
+    await assertFails(getDoc(doc(db, "jobs/job-1/events/event-1")));
+  });
+});

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,4 @@
+{
+  "firestore": { "rules": "firestore.rules" },
+  "emulators": { "firestore": { "port": 8080 } }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,47 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function signedIn() { return request.auth != null; }
+    function admin() { return signedIn() && request.auth.token.admin == true; }
+    function jobMember(job) {
+      return signedIn() && (request.auth.uid in job.participants || request.auth.uid == job.createdBy || request.auth.uid == job.assignedTo);
+    }
+
+    match /jobs/{jobId} {
+      allow read: if jobMember(resource.data) || admin();
+      allow create: if signedIn() && jobMember(request.resource.data);
+      allow update, delete: if jobMember(resource.data) || admin();
+
+      match /events/{eventId} {
+        allow read: if admin() || jobMember(get(/databases/$(database)/documents/jobs/$(jobId)).data);
+        allow create: if signedIn()
+          && (admin() || jobMember(get(/databases/$(database)/documents/jobs/$(jobId)).data))
+          && request.resource.data.keys().hasOnly(['actorID', 'occurredAt', 'type', 'before', 'after'])
+          && request.resource.data.actorID == request.auth.uid
+          && request.resource.data.occurredAt == request.time
+          && request.resource.data.type is string
+          && request.resource.data.before is map
+          && request.resource.data.after is map;
+        // Audit history is append-only, including for administrators.
+        allow update, delete: if false;
+      }
+    }
+
+    match /users/{userId} {
+      allow read: if signedIn();
+      allow create, update: if signedIn() && (request.auth.uid == userId || admin());
+      allow delete: if admin();
+    }
+
+    match /partnerships/{pairId} {
+      allow read, create, update, delete: if signedIn() && request.auth.uid in resource.data.members;
+      allow create: if signedIn() && request.auth.uid in request.resource.data.members;
+    }
+
+    match /partnerRequests/{requestId} {
+      allow read: if signedIn() && (request.auth.uid == resource.data.fromUid || request.auth.uid == resource.data.toUid);
+      allow create: if signedIn() && request.auth.uid == request.resource.data.fromUid;
+      allow update, delete: if signedIn() && (request.auth.uid == resource.data.fromUid || request.auth.uid == resource.data.toUid);
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an append-only audit trail for jobs that records who made changes and when while avoiding sensitive full-document snapshots in the log.
- Surface a readable timeline in job detail and supervisor views so users can see meaningful labels like “Status changed from Pending to Needs OH by …”.
- Enforce append-only semantics and member-only access with Firestore rules and verify behavior with emulator tests.

### Description

- Added a lightweight audit model and UI: created `JobAuditTimeline.swift` which defines `JobAuditEvent`, `JobAudit.write(...)`, a paginated `JobAuditTimelineModel`, and `JobAuditTimeline` view that shows pending/offline state and friendly labels. The timeline requests 20 events per page and supports offline cached display. (`Job Tracker/Features/Jobs/JobAuditTimeline.swift`)
- Instrumented server-side write points to emit audit events for create/update/status changes/delete/restore flows by calling `JobAudit.write(...)` from `FirebaseService.createJob`, `FirebaseService.updateJob`/`JobsViewModel.updateJob`, `JobsViewModel.updateJobStatus`, and delete/restore helpers; added `restoreJob(...)`. (`Job Tracker/Features/Shared/Services/FirebaseService.swift`, `Job Tracker/Features/Jobs/JobsViewModel.swift`)
- Added a soft-delete flag to the `Job` model and filtered tombstoned jobs from UI lists. (`Job Tracker/Models/Job.swift`, `Job Tracker/Features/Jobs/JobsViewModel.swift`, `Job Tracker/Features/Jobs/Supervisor/SupervisorDashboardView.swift`)
- Integrated the timeline UI into the editable job detail and universal job detail used by supervisors. (`Job Tracker/Features/Jobs/Editor/JobDetailView.swift`, `Job Tracker/Features/Search/JobSearchDetailView.swift`)
- Introduced Firestore security rules that validate event shape, require server timestamps and actor identity, restrict event reads to job members or admins, and forbid updates/deletes of events (append-only). (`firestore.rules`)
- Added emulator test scaffolding to exercise rule behavior (append success for members, deny reads by unrelated users, block any update/delete of events). (`firebase-emulator-tests/job-events.test.js`) and `firebase.json` for emulator config.
- Documented the audit model, offline behavior, pagination, and a seven-year retention recommendation. (`Documentation/JobAudit.md`)

### Testing

- Ran the project test script `npm test` (which invokes `vitest run firebase-emulator-tests`); the test runner started and the storage/rules suite executed, but the job-events security suite could not complete because the Firestore emulator was not available to the test harness, causing `firebase-emulator-tests/job-events.test.js` to fail with an emulator host/port error. The runner output identified the rules test failure and that some tests were skipped when emulator configuration was absent.
- Attempted to run the emulator + tests via `npx firebase-tools emulators:exec --only firestore "npm test"`, but installing/launching the Firebase tooling failed in this environment (npm registry returned HTTP 403), so the end-to-end emulator-backed test run could not be completed.
- Unit/CI-style iOS build was not executed here because `xcodebuild` is not available in the Linux container used for these checks; runtime and Swift compile status should be verified in the normal macOS CI environment.

If you want, I can: (1) update tests to initialize `initializeTestEnvironment` with an explicit emulator host/port for CI, (2) add a small server-side retention task example, or (3) adjust the timeline labels or page size.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b2bef7058832db013fb5883a6331b)