### PR TITLE
Add secure administrator company exports (Cloud Functions, rules, docs)

### DIFF
--- a/Documentation/AdminExports.md
+++ b/Documentation/AdminExports.md
@@ -1,0 +1,27 @@
+# Administrator company exports
+
+## Security and workflow
+
+Company exports are available only through the Cloud Functions API. `requestCompanyExport` and `createCompanyExportDownload` require the Firebase `admin: true` custom claim and an ID token whose `auth_time` is no more than five minutes old. The app must reauthenticate the administrator before each call. Supervisor or technician UI visibility is not authorization; the backend rejects them.
+
+Requesting an export creates an `adminExports` job and immediately returns its ID. A Firestore-triggered backend worker reads jobs, timesheets, yellow sheets, and users in bounded pages, inventories attachments, and streams a ZIP to private Cloud Storage. The phone only observes its small status document: `status`, `progress`, `expiresAt`, `checksum`, `recordCounts`, and a bounded `failure` object. It never assembles the archive.
+
+When the job is `ready`, call `createCompanyExportDownload` after reauthentication. It returns a random, single-use URL valid for five minutes. The HTTP endpoint atomically consumes that token, records a `downloaded` audit event with the actor UID, and streams the private object. Requests and downloads are append-only audit documents. Do not place export URLs in analytics, logs, email, or support tickets.
+
+## Archive format and import compatibility
+
+The ZIP and its root `manifest.json` use semantic `archiveVersion` **1.0**. Importers must reject unsupported major versions and may accept newer minor versions while ignoring unknown fields.
+
+* `data/jobs.{json,csv}`, `data/timesheets.{json,csv}`, and `data/yellowSheets.{json,csv}` contain operational records.
+* `data/users.{json,csv}` retains UID, name, crew position, and role flags so relationships can be reconstructed. Email, profile-picture URL, phone, tokens, and all unknown profile fields are deliberately omitted.
+* Each JSON file is an array. Each RFC 4180 CSV has `id,json` columns; `json` is the canonical complete record, avoiding lossy flattening of arrays and nested Firestore data.
+* `attachments/manifest.json` inventories path, byte size, content type, update time, and MD5 metadata. Attachment bytes are not included in v1.0; recovery tooling must restore them from the separately retained Storage backup.
+* `schemas/archive.schema.json` describes the root manifest and documents record encoding. Importers should validate the manifest, verify the SHA-256 checksum exposed on the export status, import users before relationship-bearing records, preserve IDs, and perform import in a staging project before production cutover.
+
+The format supports business-transfer and compliance review, but data minimization means it is not an identity-provider backup. Firebase Authentication accounts, passwords, custom claims, deleted records, and attachment bytes require their own controlled backup or transfer process.
+
+## Retention and operations
+
+Archives expire seven days after request. A scheduled function deletes expired Storage objects and marks status `expired`; download links expire after five minutes and after one successful use. Firestore status and audit metadata remain for the organization's audit-retention policy and should be covered by an explicit Firestore TTL or records policy if eventual deletion is required. The Storage bucket should also have a defense-in-depth lifecycle rule for the `admin-exports/` prefix.
+
+For disaster recovery, schedule and test independent Firestore, Authentication, and Storage backups: this on-demand export is a portable business archive, not the sole backup. Operators should monitor `failed` jobs, Cloud Function errors, and scheduled expiration, and compare every downloaded file's SHA-256 digest with the status document before custody transfer.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -5,6 +5,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 ## Feature Guides
 
 - [Admin](Features/Admin.md)
+- [Administrator Company Exports](AdminExports.md)
 - [Authentication](Features/Authentication.md)
 - [CarPlay Job Dispatch](Features/CarPlay.md)
 - [CarPlay Entitlement Request Packet](CarPlayEntitlementRequest.md)

--- a/firebase-emulator-tests/admin-exports.test.js
+++ b/firebase-emulator-tests/admin-exports.test.js
@@ -1,0 +1,23 @@
+import { beforeAll, afterAll, beforeEach, describe, it } from "vitest";
+import { initializeTestEnvironment, assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { readFileSync } from "node:fs";
+
+let env;
+beforeAll(async () => { env = await initializeTestEnvironment({ projectId: "job-tracker-export-test", firestore: { rules: readFileSync("firestore.rules", "utf8") } }); });
+afterAll(async () => env.cleanup());
+beforeEach(async () => {
+  await env.clearFirestore();
+  await env.withSecurityRulesDisabled(async context => setDoc(doc(context.firestore(), "adminExports/export-1"), { requestedBy: "admin-1", status: "running" }));
+});
+
+describe("administrator export status security", () => {
+  it("lets only the requesting administrator read status", async () => {
+    await assertSucceeds(getDoc(doc(env.authenticatedContext("admin-1", { admin: true }).firestore(), "adminExports/export-1")));
+    await assertFails(getDoc(doc(env.authenticatedContext("admin-2", { admin: true }).firestore(), "adminExports/export-1")));
+    await assertFails(getDoc(doc(env.authenticatedContext("technician-1").firestore(), "adminExports/export-1")));
+  });
+  it("prevents clients, including administrators, from creating export jobs directly", async () => {
+    await assertFails(setDoc(doc(env.authenticatedContext("admin-1", { admin: true }).firestore(), "adminExports/client-created"), { requestedBy: "admin-1", status: "ready" }));
+  });
+});

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,5 @@
 {
   "firestore": { "rules": "firestore.rules" },
+  "functions": { "source": "functions" },
   "emulators": { "firestore": { "port": 8080 } }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,6 +33,16 @@ service cloud.firestore {
       allow delete: if admin();
     }
 
+    match /adminExports/{exportId} {
+      allow read: if admin() && resource.data.requestedBy == request.auth.uid;
+      allow create, update, delete: if false;
+      match /audit/{auditId} {
+        allow read: if admin() && get(/databases/$(database)/documents/adminExports/$(exportId)).data.requestedBy == request.auth.uid;
+        allow write: if false;
+      }
+      match /downloadTokens/{tokenId} { allow read, write: if false; }
+    }
+
     match /partnerships/{pairId} {
       allow read, create, update, delete: if signedIn() && request.auth.uid in resource.data.members;
       allow create: if signedIn() && request.auth.uid in request.resource.data.members;

--- a/functions/export-helpers.js
+++ b/functions/export-helpers.js
@@ -1,0 +1,10 @@
+"use strict";
+const crypto = require("crypto");
+const ARCHIVE_VERSION = "1.0";
+const COLLECTIONS = ["jobs", "timesheets", "yellowSheets", "users"];
+const USER_FIELDS = new Set(["id", "firstName", "lastName", "position", "isAdmin", "isSupervisor"]);
+function minimizeUser(id, data) { const result = { id }; for (const field of USER_FIELDS) if (field !== "id" && data[field] !== undefined) result[field] = data[field]; return result; }
+function csvCell(value) { const text = value == null ? "" : String(value); return `"${text.replaceAll('"', '""')}"`; }
+function csvRecord(id, data) { return `${csvCell(id)},${csvCell(JSON.stringify(data))}\n`; }
+function sha256(value) { return crypto.createHash("sha256").update(value).digest("hex"); }
+module.exports = { ARCHIVE_VERSION, COLLECTIONS, USER_FIELDS, minimizeUser, csvCell, csvRecord, sha256 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,117 @@
+"use strict";
+const admin = require("firebase-admin");
+const archiver = require("archiver");
+const crypto = require("crypto");
+const { PassThrough, Readable } = require("stream");
+const { onCall, onRequest, HttpsError } = require("firebase-functions/v2/https");
+const { onDocumentCreated } = require("firebase-functions/v2/firestore");
+const { onSchedule } = require("firebase-functions/v2/scheduler");
+const { logger } = require("firebase-functions");
+const { ARCHIVE_VERSION, COLLECTIONS, minimizeUser, csvRecord } = require("./export-helpers");
+admin.initializeApp();
+const db = admin.firestore();
+const bucket = admin.storage().bucket();
+const REGION = "us-central1", STEP_UP_SECONDS = 300, DOWNLOAD_SECONDS = 300, RETENTION_MS = 7 * 86400000;
+
+function requireAdmin(auth) {
+  if (!auth || auth.token.admin !== true) throw new HttpsError("permission-denied", "Company exports are restricted to administrators.");
+  if (Date.now() / 1000 - Number(auth.token.auth_time || 0) > STEP_UP_SECONDS) throw new HttpsError("failed-precondition", "Recent sign-in required. Sign in again and retry within five minutes.");
+}
+
+async function* records(collection, format, counter) {
+  let cursor, first = true;
+  if (format === "json") yield "["; else yield "id,json\n";
+  do {
+    let query = db.collection(collection).orderBy(admin.firestore.FieldPath.documentId()).limit(500);
+    if (cursor) query = query.startAfter(cursor);
+    const page = await query.get();
+    for (const doc of page.docs) {
+      const record = collection === "users" ? minimizeUser(doc.id, doc.data()) : { id: doc.id, ...doc.data() };
+      if (format === "json") { yield `${first ? "" : ","}\n${JSON.stringify(record)}`; first = false; counter.value++; }
+      else { const { id, ...data } = record; yield csvRecord(id, data); }
+    }
+    cursor = page.docs.at(-1);
+    if (page.size < 500) cursor = undefined;
+  } while (cursor);
+  if (format === "json") yield "\n]\n";
+}
+
+async function appendGenerated(zip, generator, name) {
+  const stream = Readable.from(generator);
+  const done = new Promise((resolve, reject) => stream.on("end", resolve).on("error", reject));
+  zip.append(stream, { name });
+  await done;
+}
+
+exports.requestCompanyExport = onCall({ region: REGION }, async request => {
+  requireAdmin(request.auth);
+  const ref = db.collection("adminExports").doc();
+  const now = admin.firestore.Timestamp.now();
+  await ref.set({ archiveVersion: ARCHIVE_VERSION, status: "queued", progress: { completed: 0, total: COLLECTIONS.length + 1, phase: "Queued" }, recordCounts: {}, requestedBy: request.auth.uid, requestedAt: now, expiresAt: admin.firestore.Timestamp.fromMillis(now.toMillis() + RETENTION_MS) });
+  await ref.collection("audit").add({ event: "requested", actorUid: request.auth.uid, at: now });
+  return { exportId: ref.id };
+});
+
+exports.buildCompanyExport = onDocumentCreated({ document: "adminExports/{exportId}", region: REGION, timeoutSeconds: 540, memory: "1GiB" }, async event => {
+  const ref = event.data.ref;
+  if (event.data.data().status !== "queued") return;
+  const path = `admin-exports/${ref.id}/job-tracker-export-v${ARCHIVE_VERSION}.zip`;
+  const output = bucket.file(path).createWriteStream({ resumable: false, contentType: "application/zip", metadata: { cacheControl: "private, no-store" } });
+  const hash = crypto.createHash("sha256"), tee = new PassThrough(), zip = archiver("zip", { zlib: { level: 6 } });
+  tee.on("data", chunk => hash.update(chunk)); tee.pipe(output); zip.pipe(tee);
+  const counts = {};
+  try {
+    await ref.update({ status: "running", startedAt: admin.firestore.FieldValue.serverTimestamp(), "progress.phase": "Reading records" });
+    for (let i = 0; i < COLLECTIONS.length; i++) {
+      const collection = COLLECTIONS[i], counter = { value: 0 };
+      await appendGenerated(zip, records(collection, "json", counter), `data/${collection}.json`);
+      await appendGenerated(zip, records(collection, "csv", counter), `data/${collection}.csv`);
+      counts[collection] = counter.value;
+      await ref.update({ recordCounts: counts, progress: { completed: i + 1, total: COLLECTIONS.length + 1, phase: `Archived ${collection}` } });
+    }
+    const [files] = await bucket.getFiles({ prefix: "attachments/" });
+    const attachments = files.map(file => ({ path: file.name, size: Number(file.metadata.size || 0), contentType: file.metadata.contentType || null, md5Hash: file.metadata.md5Hash || null, updated: file.metadata.updated || null }));
+    counts.attachments = attachments.length;
+    zip.append(JSON.stringify(attachments, null, 2), { name: "attachments/manifest.json" });
+    zip.append(JSON.stringify(require("./schemas/archive.schema.json"), null, 2), { name: "schemas/archive.schema.json" });
+    zip.append(JSON.stringify({ archiveVersion: ARCHIVE_VERSION, createdAt: new Date().toISOString(), recordCounts: counts, personalDataPolicy: "Email, profile-picture URL, phone, tokens, and unknown user fields are omitted." }, null, 2), { name: "manifest.json" });
+    await zip.finalize();
+    await new Promise((resolve, reject) => output.on("finish", resolve).on("error", reject));
+    await ref.update({ status: "ready", checksum: { algorithm: "SHA-256", value: hash.digest("hex") }, storagePath: path, recordCounts: counts, progress: { completed: COLLECTIONS.length + 1, total: COLLECTIONS.length + 1, phase: "Ready" }, completedAt: admin.firestore.FieldValue.serverTimestamp() });
+  } catch (error) {
+    logger.error("Company export failed", { exportId: ref.id, error }); zip.abort();
+    await bucket.file(path).delete({ ignoreNotFound: true }).catch(() => {});
+    await ref.update({ status: "failed", failure: { code: "archive_generation_failed", message: String(error.message || error).slice(0, 500) }, failedAt: admin.firestore.FieldValue.serverTimestamp() });
+  }
+});
+
+exports.createCompanyExportDownload = onCall({ region: REGION }, async request => {
+  requireAdmin(request.auth);
+  const exportId = String(request.data?.exportId || ""), ref = db.collection("adminExports").doc(exportId), snapshot = await ref.get(), data = snapshot.data();
+  if (!data || data.requestedBy !== request.auth.uid) throw new HttpsError("permission-denied", "This export belongs to a different administrator.");
+  if (data.status !== "ready" || data.expiresAt.toMillis() <= Date.now()) throw new HttpsError("failed-precondition", "The export is not ready or has expired.");
+  const token = crypto.randomBytes(32).toString("hex");
+  await ref.collection("downloadTokens").doc(token).set({ actorUid: request.auth.uid, expiresAt: admin.firestore.Timestamp.fromMillis(Date.now() + DOWNLOAD_SECONDS), used: false });
+  return { url: `https://${REGION}-${process.env.GCLOUD_PROJECT}.cloudfunctions.net/downloadCompanyExport?exportId=${encodeURIComponent(exportId)}&token=${token}`, expiresInSeconds: DOWNLOAD_SECONDS };
+});
+
+exports.downloadCompanyExport = onRequest({ region: REGION }, async (req, res) => {
+  const exportRef = db.collection("adminExports").doc(String(req.query.exportId || ""));
+  const tokenRef = exportRef.collection("downloadTokens").doc(String(req.query.token || ""));
+  let exportData;
+  try {
+    await db.runTransaction(async tx => {
+      const [exportSnap, tokenSnap] = await Promise.all([tx.get(exportRef), tx.get(tokenRef)]); exportData = exportSnap.data(); const token = tokenSnap.data();
+      if (!exportData || exportData.status !== "ready" || exportData.expiresAt.toMillis() <= Date.now() || !token || token.used || token.expiresAt.toMillis() <= Date.now()) throw new Error("invalid");
+      tx.update(tokenRef, { used: true, usedAt: admin.firestore.FieldValue.serverTimestamp() });
+      tx.set(exportRef.collection("audit").doc(), { event: "downloaded", actorUid: token.actorUid, at: admin.firestore.FieldValue.serverTimestamp(), userAgent: String(req.get("user-agent") || "").slice(0, 200) });
+    });
+  } catch (_) { res.status(401).send("Invalid or expired download link."); return; }
+  res.set({ "Content-Type": "application/zip", "Content-Disposition": `attachment; filename="job-tracker-export-v${ARCHIVE_VERSION}.zip"`, "Cache-Control": "private, no-store" });
+  bucket.file(exportData.storagePath).createReadStream().on("error", () => res.destroy()).pipe(res);
+});
+
+exports.deleteExpiredCompanyExports = onSchedule({ schedule: "every 24 hours", region: REGION }, async () => {
+  const expired = await db.collection("adminExports").where("expiresAt", "<=", admin.firestore.Timestamp.now()).limit(100).get();
+  await Promise.all(expired.docs.map(async doc => { const data = doc.data(); if (data.storagePath) await bucket.file(data.storagePath).delete({ ignoreNotFound: true }); await doc.ref.update({ status: "expired", storagePath: admin.firestore.FieldValue.delete(), expiredAt: admin.firestore.FieldValue.serverTimestamp() }); }));
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,1 @@
+{"name":"job-tracker-functions","private":true,"engines":{"node":"20"},"main":"index.js","scripts":{"test":"node --test test/*.test.js"},"dependencies":{"archiver":"^7.0.1","firebase-admin":"^13.4.0","firebase-functions":"^6.4.0"}}

--- a/functions/schemas/archive.schema.json
+++ b/functions/schemas/archive.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jobtracker.example/schemas/export/1.0/archive.schema.json",
+  "title": "Job Tracker export archive 1.0",
+  "type": "object",
+  "required": ["archiveVersion", "createdAt", "recordCounts", "personalDataPolicy"],
+  "properties": {
+    "archiveVersion": { "const": "1.0" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "recordCounts": { "type": "object", "additionalProperties": { "type": "integer", "minimum": 0 } },
+    "personalDataPolicy": { "type": "string" }
+  },
+  "$comment": "data/*.json contains record arrays. RFC 4180 CSV files use id,json columns. attachments/manifest.json inventories but does not embed attachment bytes."
+}

--- a/functions/test/export-helpers.test.js
+++ b/functions/test/export-helpers.test.js
@@ -1,0 +1,13 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { minimizeUser, csvRecord } = require("../export-helpers");
+test("user export omits contact and avatar data", () => {
+  assert.deepEqual(minimizeUser("u1", { firstName: "Ada", lastName: "L", email: "private@example.com", profilePictureURL: "https://private", position: "OH", isAdmin: false, isSupervisor: true, phone: "555" }), { id: "u1", firstName: "Ada", lastName: "L", position: "OH", isAdmin: false, isSupervisor: true });
+});
+test("CSV safely quotes identifiers and JSON", () => {
+  const row = csvRecord('a,"b', { note: 'x,"y' });
+  assert.ok(row.startsWith('"a,""b","{'));
+  assert.ok(row.endsWith('}"\n'));
+  assert.equal(row.split("\n").length, 2);
+});


### PR DESCRIPTION
### Motivation

- Provide an administrator-only, backend-driven export workflow that produces a versioned ZIP archive containing jobs, timesheets, yellow sheets, minimized user records, attachment manifests, and CSV/JSON schemas without assembling the archive on mobile devices.
- Ensure exports require step-up authentication and the `admin` custom claim so technicians and stale sessions cannot request company-wide data.
- Support auditability, safe short-lived downloads, progress reporting, retention, and import compatibility for business transfer/compliance/disaster recovery.

### Description

- Added a Cloud Functions implementation that queues exports (`requestCompanyExport`), builds archives in a background worker (`buildCompanyExport`) that pages collections and streams a ZIP to Cloud Storage, and issues single-use download links (`createCompanyExportDownload`/`downloadCompanyExport`).
- Minimized exported user data via `functions/export-helpers.js` so exported users include operational identifiers and role flags only, and produced both JSON and RFC 4180 CSV (`data/*.json` + `data/*.csv`) and an `attachments/manifest.json` without embedding attachment bytes; included a versioned `schemas/archive.schema.json` and `manifest.json` with SHA-256 checksum and record counts.
- Enforced security and audit rules in `firestore.rules` so only the requesting administrator may read an `adminExports/{exportId}` status and audit docs, download tokens are not client-accessible, and clients cannot create or mutate export jobs.
- Added docs `Documentation/AdminExports.md` describing the workflow, archive format, import compatibility, data minimization, and retention policy (seven-day expiry and scheduled deletion), and added a small emulator test `firebase-emulator-tests/admin-exports.test.js` to validate rules semantics.
- Updated `firebase.json` to include the `functions` entry and added Node function scaffolding and unit tests under `functions/` (`index.js`, `export-helpers.js`, `package.json`, `schemas/archive.schema.json`, `test/export-helpers.test.js`).

### Testing

- Ran unit tests for the helper module with `node --test test/*.test.js` inside `functions/` and `npm test` in `functions/` and both succeeded (helper tests passed).
- Verified static checks with `node --check functions/index.js` and no syntax errors were reported.
- Ran repository test harness `npm test` (which executes `vitest`), and some rule test suites were skipped; the new `admin-exports` emulator test was added but failed when run outside of a started Firestore emulator because the emulator host/port was not available in this environment.
- `npm install` inside `functions/` could not be completed here due to environment registry/access restrictions, so dependency installation was blocked in this run; function unit tests were executed without installing from the registry and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b48871e48832da1923c189db14f8a)