### PR TITLE
Extract Materials field into MaterialsInputField to avoid Swift compiler timeout

### DIFF
--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -46,6 +46,30 @@ private extension String {
     var nilIfEmpty: String? { isEmpty ? nil : self }
 }
 
+// Keep these form controls in their own view types so the compiler does not
+// need to infer every modifier in CreateJobView's large view hierarchy at once.
+private struct MaterialsInputField: View {
+    @Binding var text: String
+
+    var body: some View {
+        TextField("Enter materials info…", text: $text)
+            .textInputAutocapitalization(.sentences)
+            .padding(12)
+            .background(fieldBackground)
+            .overlay(fieldBorder)
+    }
+
+    private var fieldBackground: some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(Color(.systemBackground).opacity(0.9))
+    }
+
+    private var fieldBorder: some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .stroke(Color.gray.opacity(0.15), lineWidth: 1)
+    }
+}
+
 // MARK: - Section Card
 @ViewBuilder
 private func SectionCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
@@ -525,17 +549,7 @@ struct CreateJobView: View {
 
                         // Materials
                         SectionCard(title: "Materials Used") {
-                            TextField("Enter materials info…", text: $materialsUsed)
-                                .textInputAutocapitalization(.sentences)
-                                .padding(12)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .fill(Color(.systemBackground).opacity(0.9))
-                                )
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .stroke(Color.gray.opacity(0.15), lineWidth: 1)
-                                )
+                            MaterialsInputField(text: $materialsUsed)
                         }
 
                         // Notes


### PR DESCRIPTION
### Motivation
- `CreateJobView` contains a very large SwiftUI view expression and the compiler was timing out while type-checking chained modifiers on the inline materials `TextField`.
- Breaking the field out into a small, separately inferred view reduces expression complexity and prevents the "The compiler is unable to type-check this expression in reasonable time" error.

### Description
- Added a new `MaterialsInputField: View` that binds to `materialsUsed` and factors the field background and border into separate computed view properties to simplify type inference.
- Replaced the inline `TextField` in the "Materials Used" `SectionCard` with `MaterialsInputField(text: $materialsUsed)` in `Job Tracker/Features/Jobs/Editor/CreateJobView.swift`.
- This is a refactor-only change that preserves styling and behavior while lowering compiler type-check complexity.

### Testing
- Ran `git diff --check` with no reported issues.
- Inspected changes via `git status --porcelain=v1` and `git show --stat --oneline HEAD` to confirm the modified file and diff.
- Attempted `xcodebuild -version` but Xcode is not available in this environment so a full iOS build/test could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b65995828832d9d54606346d3d973)