### PR TITLE
Rename Yellow Sheet terminology to Materials

### DIFF
--- a/Documentation/AdminExports.md
+++ b/Documentation/AdminExports.md
@@ -4,7 +4,7 @@
 
 Company exports are available only through the Cloud Functions API. `requestCompanyExport` and `createCompanyExportDownload` require the Firebase `admin: true` custom claim and an ID token whose `auth_time` is no more than five minutes old. The app must reauthenticate the administrator before each call. Supervisor or technician UI visibility is not authorization; the backend rejects them.
 
-Requesting an export creates an `adminExports` job and immediately returns its ID. A Firestore-triggered backend worker reads jobs, timesheets, yellow sheets, and users in bounded pages, inventories attachments, and streams a ZIP to private Cloud Storage. The phone only observes its small status document: `status`, `progress`, `expiresAt`, `checksum`, `recordCounts`, and a bounded `failure` object. It never assembles the archive.
+Requesting an export creates an `adminExports` job and immediately returns its ID. A Firestore-triggered backend worker reads jobs, timesheets, materials, and users in bounded pages, inventories attachments, and streams a ZIP to private Cloud Storage. The phone only observes its small status document: `status`, `progress`, `expiresAt`, `checksum`, `recordCounts`, and a bounded `failure` object. It never assembles the archive.
 
 When the job is `ready`, call `createCompanyExportDownload` after reauthentication. It returns a random, single-use URL valid for five minutes. The HTTP endpoint atomically consumes that token, records a `downloaded` audit event with the actor UID, and streams the private object. Requests and downloads are append-only audit documents. Do not place export URLs in analytics, logs, email, or support tickets.
 
@@ -12,7 +12,7 @@ When the job is `ready`, call `createCompanyExportDownload` after reauthenticati
 
 The ZIP and its root `manifest.json` use semantic `archiveVersion` **1.0**. Importers must reject unsupported major versions and may accept newer minor versions while ignoring unknown fields.
 
-* `data/jobs.{json,csv}`, `data/timesheets.{json,csv}`, and `data/yellowSheets.{json,csv}` contain operational records.
+* `data/jobs.{json,csv}`, `data/timesheets.{json,csv}`, and `data/yellowSheets.{json,csv}` contain operational records. The `yellowSheets` export path is retained as a legacy compatibility name for materials data.
 * `data/users.{json,csv}` retains UID, name, crew position, and role flags so relationships can be reconstructed. Email, profile-picture URL, phone, tokens, and all unknown profile fields are deliberately omitted.
 * Each JSON file is an array. Each RFC 4180 CSV has `id,json` columns; `json` is the canonical complete record, avoiding lossy flattening of arrays and nested Firestore data.
 * `attachments/manifest.json` inventories path, byte size, content type, update time, and MD5 metadata. Attachment bytes are not included in v1.0; recovery tooling must restore them from the separately retained Storage backup.

--- a/Documentation/Features/YellowSheet.md
+++ b/Documentation/Features/YellowSheet.md
@@ -1,10 +1,10 @@
-# Yellow Sheet
+# Materials
 
-Yellow sheets capture daily compliance checklists and signatures that complement the timesheet workflow. This module reuses many of the timesheet patterns while tailoring the experience to the yellow sheet document format.
+Materials records capture daily compliance checklists and signatures that complement the timesheet workflow. This module reuses many of the timesheet patterns while tailoring the experience to the materials document format.
 
 ## Responsibilities
 
-- Fetch and display yellow sheet records for the signed-in technician using `UserYellowSheetsViewModel`.
+- Fetch and display materials records for the signed-in technician using `UserYellowSheetsViewModel`.
 - Provide form-driven entry for daily safety checks, job notes, and material usage via `YellowSheetView`.
 - Allow supervisors to review previous submissions through `PastYellowSheetsView`.
 - Generate PDFs using `YellowSheetPDFGenerator`, including editable overlays for signatures and corrections.
@@ -15,7 +15,7 @@ Yellow sheets capture daily compliance checklists and signatures that complement
 | Type | Role |
 | --- | --- |
 | `YellowSheet` | Firestore model storing metadata, completion status, and generated PDF URLs. |
-| `UserYellowSheetsViewModel` | Coordinates Firestore listeners and exposes the current user's yellow sheets. |
+| `UserYellowSheetsViewModel` | Coordinates Firestore listeners and exposes the current user's materials. |
 | `YellowSheetView` | Main editing surface for the active day. Integrates photo attachments and checklists. |
 | `YellowSheetDetailView` | Expanded view for reviewing submissions, downloading PDFs, or resending to supervisors. |
 | `YellowSheetPDFGenerator` | Renders SwiftUI content into PDFs. Shares PDF utilities with the timesheet module. |
@@ -30,6 +30,6 @@ Yellow sheets capture daily compliance checklists and signatures that complement
 
 ## Integration Notes
 
-- Yellow sheets often link to specific jobs. Keep job metadata handy so forms can pre-populate addresses or partner info.
+- Materials often link to specific jobs. Keep job metadata handy so forms can pre-populate addresses or partner info.
 - Ensure Storage rules allow technicians to upload PDF exports while preventing cross-user access.
 - When altering the PDF layout, update both the generator and any tests that verify PDF metadata or file generation.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -18,7 +18,7 @@ This folder collects long-form guides for each feature area in Job Tracker. The 
 - [Shared](Features/Shared.md)
 - [Splice Assist](Features/SpliceAssist.md)
 - [Timesheets](Features/Timesheets.md)
-- [Yellow Sheet](Features/YellowSheet.md)
+- [Materials](Features/YellowSheet.md)
 
 ## Companion Experiences
 

--- a/Documentation/TestingSafetyNet.md
+++ b/Documentation/TestingSafetyNet.md
@@ -12,7 +12,7 @@ The `Job TrackerTests` bundle should keep fast, deterministic XCTest coverage ar
 - **Job intake, sharing, and search**: Deep-link, shared-payload, parser, and search-matcher tests cover import/export payloads and matching heuristics that affect daily job routing.
 - **Dashboard and recent crew jobs**: View-model tests cover summaries and detail sheets that crew members use to understand current work.
 - **Help and tutorial flows**: Tutorial stage tests protect onboarding guidance from accidental regressions.
-- **Seeded UI flows**: `Job TrackerUITests` launches with `JT_UI_TESTING=1` and deterministic seed data to cover authentication validation, dashboard job flow, create/detail/delete controls, search, timesheets, yellow sheets, settings, and admin-only navigation without writing to production Firebase.
+- **Seeded UI flows**: `Job TrackerUITests` launches with `JT_UI_TESTING=1` and deterministic seed data to cover authentication validation, dashboard job flow, create/detail/delete controls, search, timesheets, materials, settings, and admin-only navigation without writing to production Firebase.
 - **Integration smoke tests**: `ServiceIntegrationSmokeTests` covers PDF generation, job-photo slot mapping, arrival-alert inactive state, and watch sync payload filtering; `AppIntentEntryPointTests` protects App Intent discoverability and fallback messaging.
 - **Firebase rules emulator tests**: `firebase-emulator-tests/firestore-storage.rules.test.js` is wired through `npm run test:firebase-rules` and intentionally skips until both `firestore.rules` and `storage.rules` are present.
 
@@ -22,7 +22,7 @@ Add or update tests in the same pull request when a change affects any of these 
 
 1. Decoding or encoding app models that come from Firebase, links, files, or JSON payloads.
 2. Crew-position, job-status, search, or matching normalization logic.
-3. View models with business decisions, especially admin, update, dashboard, job list, timesheet, yellow sheet, and sharing workflows.
+3. View models with business decisions, especially admin, update, dashboard, job list, timesheet, materials, and sharing workflows.
 4. App update requirements, version comparisons, package downloads, package retention, or safe-apply conditions.
 5. Deep links, shared job payloads, imported job sheets, or parsing of externally supplied data.
 6. Bug fixes where a regression test can reproduce the failing case.

--- a/Job Tracker/Features/Help/HelpCenterView.swift
+++ b/Job Tracker/Features/Help/HelpCenterView.swift
@@ -40,9 +40,9 @@ struct HelpCenterView: View {
                 bullets: [
                     "**Step 1:** From the **Dashboard**, tap **Create Job** (plus button) to capture the job #, address, crew, and schedule.",
                     "**Step 2:** Save, then tap the new job card to adjust assignments, notes, materials, and attach progress photos as work continues.",
-                    "**Step 3:** Move the status to **In Progress** when you roll out and **Done** when complete—anything not Pending flows automatically into Timesheets and the Yellow Sheet.",
-                    "**Step 4:** Open **Timesheets** to enter daily Gibson/CS hours; switch to **Yellow Sheet** to verify the week’s grouped jobs before submitting.",
-                    "**Step 5:** Use **Share** or **Print** from a job, Timesheet, or Yellow Sheet to deliver a PDF recap to supervisors."
+                    "**Step 3:** Move the status to **In Progress** when you roll out and **Done** when complete—anything not Pending flows automatically into Timesheets and Materials.",
+                    "**Step 4:** Open **Timesheets** to enter daily Gibson/CS hours; switch to **Materials** to verify the week’s grouped jobs before submitting.",
+                    "**Step 5:** Use **Share** or **Print** from a job, Timesheet, or Materials to deliver a PDF recap to supervisors."
                 ],
                 action: { showingCreateJob = true }
             ),
@@ -80,7 +80,7 @@ struct HelpCenterView: View {
                     "**Step 1:** Open a job from the **Dashboard** or **Job Search** and review the colored status pill at the top.",
                     "**Step 2:** Tap the status to choose **Pending**, **In Progress**, **Done**, or a custom need such as Needs Underground.",
                     "**Step 3:** The updated status saves immediately and appears for your partner and supervisors.",
-                    "**Step 4:** Any status other than Pending automatically includes the job in the current week’s **Timesheet** and **Yellow Sheet**.",
+                    "**Step 4:** Any status other than Pending automatically includes the job in the current week’s **Timesheet** and **Materials**.",
                     "**Step 5:** Switch back to Pending only when a job should drop off payroll tracking for the week."
                 ],
                 action: { navigation.navigate(to: .dashboard) }
@@ -138,14 +138,14 @@ struct HelpCenterView: View {
                 action: { navigation.navigate(to: .profile) }
             ),
             HelpTopic(
-                title: "Yellow Sheet",
+                title: "Materials",
                 icon: "doc.text",
                 summary: "Confirm non-pending jobs for the week before submitting payroll.",
                 bullets: [
-                    "**Step 1:** Go to **Yellow Sheet** and select the week with the picker or calendar sheet.",
+                    "**Step 1:** Go to **Materials** and select the week with the picker or calendar sheet.",
                     "**Step 2:** Review grouped sections by Job #—every non-Pending job from you or your partner is included.",
                     "**Step 3:** Expand a job card to double-check notes, assignments, and materials for the inspector.",
-                    "**Step 4:** Tap **Save Yellow Sheet** to capture the weekly summary and sync it to the archive.",
+                    "**Step 4:** Tap **Save Materials** to capture the weekly summary and sync it to the archive.",
                     "**Step 5:** Use the share button on individual jobs (from Dashboard) if additional documentation is requested."
                 ],
                 action: { navigation.navigate(to: .yellowSheet) }
@@ -183,7 +183,7 @@ struct HelpCenterView: View {
                 bullets: [
                     "**Step 1:** Open **Find a Partner** to see your current pairing status at the top of the list.",
                     "**Step 2:** Browse coworkers—tap **Request** to send a pairing invite or approve/decline incoming requests.",
-                    "**Step 3:** Once connected, your jobs, Timesheets, and Yellow Sheets stay aligned across both accounts.",
+                    "**Step 3:** Once connected, your jobs, Timesheets, and Materials stay aligned across both accounts.",
                     "**Step 4:** Use the outgoing and incoming sections to monitor pending requests or resend if needed.",
                     "**Step 5:** Tap **Unpair** whenever you need to switch partners; the change syncs immediately."
                 ],

--- a/Job Tracker/Features/Settings/ProfileView.swift
+++ b/Job Tracker/Features/Settings/ProfileView.swift
@@ -168,7 +168,7 @@ private extension ProfileView {
                 )
 
                 historyCard(
-                    title: "Yellow Sheets",
+                    title: "Materials",
                     icon: "folder.fill.badge.person.crop",
                     accent: JTColors.info,
                     primaryValue: yellowSheetCountText,
@@ -250,7 +250,7 @@ private extension ProfileView {
 
     var yellowSheetDetailText: String? {
         guard let latest = sortedYellowSheets.first else {
-            return yellowSheetHistory.yellowSheets.isEmpty ? "Capture a yellow sheet to see it appear here." : nil
+            return yellowSheetHistory.yellowSheets.isEmpty ? "Capture a materials record to see it appear here." : nil
         }
 
         let date = ProfileView.weekFormatter.string(from: latest.weekStart)
@@ -285,7 +285,7 @@ private extension ProfileView {
             }
 
             QuickActionLink(
-                title: "Past Yellow Sheets",
+                title: "Past Materials",
                 subtitle: "Keep tabs on weekly job groupings.",
                 icon: "folder.badge.person.crop",
                 accent: JTColors.info,
@@ -353,7 +353,7 @@ private extension ProfileView {
                     .font(JTTypography.headline)
                     .foregroundStyle(JTColors.textPrimary)
 
-                Text("Sign in from the main screen to see your profile, timesheets, and yellow sheets in one place.")
+                Text("Sign in from the main screen to see your profile, timesheets, and materials in one place.")
                     .font(JTTypography.caption)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(JTColors.textSecondary)

--- a/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
+++ b/Job Tracker/Features/Shared/Shell/AppNavigationViewModel.swift
@@ -26,7 +26,7 @@ final class AppNavigationViewModel: ObservableObject {
             switch self {
             case .dashboard:   return "Dashboard"
             case .timesheets:  return "Timesheets"
-            case .yellowSheet: return "Yellow Sheet"
+            case .yellowSheet: return "Materials"
             case .maps:        return "Route Mapper"
             case .recentCrewJobs: return "Recent Crew Jobs"
             case .mapDesigns: return "Map Designs"

--- a/Job Tracker/Features/YellowSheet/PDF/PDFEditorView.swift
+++ b/Job Tracker/Features/YellowSheet/PDF/PDFEditorView.swift
@@ -44,7 +44,7 @@ struct PDFEditorView: View {
             return
         }
         // Write the modified PDF to a temporary file.
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("EditedYellowSheet-\(UUID().uuidString).pdf")
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("EditedMaterials-\(UUID().uuidString).pdf")
         if doc.write(to: tempURL) {
             // Upload the edited PDF.
             uploadEditedPDF(from: tempURL)

--- a/Job Tracker/Features/YellowSheet/PastYellowSheetsView.swift
+++ b/Job Tracker/Features/YellowSheet/PastYellowSheetsView.swift
@@ -22,7 +22,7 @@ struct PastYellowSheetsView: View {
                 .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
             }
-            .navigationTitle("Past Yellow Sheets")
+            .navigationTitle("Past Materials")
             .navigationBarTitleDisplayMode(.inline)
             .jtNavigationBarStyle()
             .onAppear {

--- a/Job Tracker/Features/YellowSheet/UserYellowSheetsViewModel.swift
+++ b/Job Tracker/Features/YellowSheet/UserYellowSheetsViewModel.swift
@@ -28,7 +28,7 @@ class UserYellowSheetsViewModel: ObservableObject {
                 .whereField("userId", isEqualTo: ownerId)
                 .addSnapshotListener { [weak self] snapshot, error in
                     if let error = error {
-                        print("Error fetching yellow sheets: \(error)")
+                        print("Error fetching materials: \(error)")
                         return
                     }
 
@@ -53,14 +53,14 @@ class UserYellowSheetsViewModel: ObservableObject {
             let docRef = db.collection("yellowSheets").document(docID)
             try docRef.setData(from: sheet) { error in
                 if let error = error {
-                    print("Error saving yellow sheet: \(error)")
+                    print("Error saving materials: \(error)")
                     completion(false)
                 } else {
                     completion(true)
                 }
             }
         } catch {
-            print("Error encoding yellow sheet: \(error)")
+            print("Error encoding materials: \(error)")
             completion(false)
         }
     }
@@ -68,7 +68,7 @@ class UserYellowSheetsViewModel: ObservableObject {
     func deleteYellowSheet(documentID: String, completion: @escaping (Bool) -> Void = { _ in }) {
         db.collection("yellowSheets").document(documentID).delete { error in
             if let error = error {
-                print("Error deleting yellow sheet: \(error)")
+                print("Error deleting materials: \(error)")
                 completion(false)
             } else {
                 completion(true)

--- a/Job Tracker/Features/YellowSheet/YellowSheetDetailView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetDetailView.swift
@@ -12,7 +12,7 @@ struct YellowSheetDetailView: View {
                 VStack(alignment: .leading, spacing: JTSpacing.lg) {
                     GlassCard(cornerRadius: JTShapes.largeCardCornerRadius, strokeColor: JTColors.glassSoftStroke) {
                         VStack(alignment: .leading, spacing: JTSpacing.md) {
-                            Text("Yellow Sheet Detail")
+                            Text("Materials Detail")
                                 .font(JTTypography.title3)
                                 .foregroundStyle(JTColors.textPrimary)
 
@@ -46,7 +46,7 @@ struct YellowSheetDetailView: View {
                 .padding(JTSpacing.lg)
             }
         }
-        .navigationTitle("Yellow Sheet Detail")
+        .navigationTitle("Materials Detail")
         .navigationBarTitleDisplayMode(.inline)
         .jtNavigationBarStyle()
     }

--- a/Job Tracker/Features/YellowSheet/YellowSheetPDFGenerator.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetPDFGenerator.swift
@@ -29,7 +29,7 @@ class YellowSheetPDFGenerator {
             let margin: CGFloat = 20
             
             // 1) Draw the header.
-            let headerText = "Yellow Sheet for Week Starting: \(formattedDate(weekStart))"
+            let headerText = "Materials for Week Starting: \(formattedDate(weekStart))"
             drawText(headerText, at: CGPoint(x: margin, y: currentY), fontSize: 16, isBold: true)
             currentY += 30
             
@@ -81,7 +81,7 @@ class YellowSheetPDFGenerator {
             }
         }
         
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("YellowSheet-\(UUID().uuidString).pdf")
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("Materials-\(UUID().uuidString).pdf")
         do {
             try data.write(to: tempURL)
             return tempURL

--- a/Job Tracker/Features/YellowSheet/YellowSheetView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetView.swift
@@ -42,7 +42,7 @@ struct YellowSheetView: View {
                                         Image(systemName: "tray")
                                             .font(.system(size: 34))
                                             .foregroundStyle(JTColors.textMuted)
-                                        Text("No yellow sheet jobs")
+                                        Text("No materials jobs")
                                             .font(JTTypography.headline)
                                             .foregroundStyle(JTColors.textPrimary)
                                         Text("Completed jobs for this week will show here once they are available.")
@@ -78,7 +78,7 @@ struct YellowSheetView: View {
                         .padding(.bottom, JTSpacing.xl)
                     }
 
-                    JTPrimaryButton("Save Yellow Sheet", systemImage: "tray.and.arrow.down") {
+                    JTPrimaryButton("Save Materials", systemImage: "tray.and.arrow.down") {
                         saveCurrentYellowSheet()
                     }
                     .padding(.horizontal, JTSpacing.lg)
@@ -115,7 +115,7 @@ struct YellowSheetView: View {
                 }
             }
             .alert(isPresented: $showSaveAlert) {
-                Alert(title: Text("Yellow Sheet"), message: Text(saveAlertMessage), dismissButton: .default(Text("OK")))
+                Alert(title: Text("Materials"), message: Text(saveAlertMessage), dismissButton: .default(Text("OK")))
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
@@ -251,7 +251,7 @@ struct YellowSheetView: View {
                 sheet.pdfURL = downloadURL
                 yellowSheetsVM.saveYellowSheet(sheet) { success in
                     DispatchQueue.main.async {
-                        saveAlertMessage = success ? "Yellow Sheet saved successfully!" : "Failed to save Yellow Sheet."
+                        saveAlertMessage = success ? "Materials saved successfully!" : "Failed to save materials."
                         showSaveAlert = true
                     }
                 }

--- a/Job TrackerUITests/SearchTimesheetYellowSheetSettingsUITests.swift
+++ b/Job TrackerUITests/SearchTimesheetYellowSheetSettingsUITests.swift
@@ -19,7 +19,7 @@ final class SearchTimesheetYellowSheetSettingsUITests: XCTestCase {
         app.tabBars.buttons["Timesheets"].tap()
         waitForElement(app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "Timesheet")).firstMatch)
 
-        app.tabBars.buttons["Yellow Sheet"].tap()
+        app.tabBars.buttons["Materials"].tap()
         waitForElement(app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "Yellow")).firstMatch)
     }
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Future update checklist:
 - Update PDF generator tests and templates when changing document layout.
 - Keep job suggestions connected to `TimesheetJobsViewModel` and `JobsViewModel`.
 
-### Yellow Sheets
+### Materials
 
-Yellow sheets support daily compliance/safety paperwork, material usage, supervisor review, historical records, PDF generation, and in-app PDF viewing/annotation. Records may link to specific jobs so forms can prefill addresses and partner details.
+Materials support daily compliance/safety paperwork, material usage, supervisor review, historical records, PDF generation, and in-app PDF viewing/annotation. Records may link to specific jobs so forms can prefill addresses and partner details.
 
 Future update checklist:
 
@@ -300,7 +300,7 @@ Future update checklist:
 | `jobs` | Job assignments and searchable job records | Dashboard, Jobs, Search, Timesheets, CarPlay |
 | `sharedJobs` | Tokenized job share/import payloads | Deep links, iMessage, cross-device sharing |
 | `timesheets` | Weekly timesheet documents | Timesheets, PDF export/history |
-| `yellowSheets` | Daily yellow sheet documents | Yellow Sheet workflows, PDF export/history |
+| `yellowSheets` (legacy collection name) | Daily materials documents | Materials workflows, PDF export/history |
 | `partnerRequests` | Pending/accepted/declined partner requests | Find Partner, Team |
 | `partnerships` | Active partner pairings | Team, Messaging, Shared job context |
 | `conversations/{id}/messages` | Chat messages | Partner chat |
@@ -310,7 +310,7 @@ Future update checklist:
 
 ### Storage Usage
 
-Firebase Storage is used for job photos and generated PDFs. `JobPhotoUploadQueue` handles deferred photo uploads and updates job document photo URL fields after upload succeeds. Timesheet and yellow sheet PDF generators produce shareable documents and should remain aligned with Storage rules.
+Firebase Storage is used for job photos and generated PDFs. `JobPhotoUploadQueue` handles deferred photo uploads and updates job document photo URL fields after upload succeeds. Timesheet and materials PDF generators produce shareable documents and should remain aligned with Storage rules.
 
 ### Security Expectations
 
@@ -413,7 +413,7 @@ npm run test:firebase-rules
 - Shared job service behavior.
 - Fiber map view model behavior.
 
-`Job TrackerUITests/` covers user flows such as authentication, dashboard job flow, admin navigation, search, timesheets, yellow sheets, and settings.
+`Job TrackerUITests/` covers user flows such as authentication, dashboard job flow, admin navigation, search, timesheets, materials, and settings.
 
 ### Test Launch Arguments
 
@@ -542,7 +542,7 @@ Update all applicable locations:
 ### PDF export fails
 
 - Confirm Storage rules allow writes for the signed-in user.
-- Confirm linked jobs/timesheets/yellow sheets have required metadata.
+- Confirm linked jobs/timesheets/materials have required metadata.
 - Re-run tests around PDF generator behavior after layout changes.
 
 ### CarPlay does not appear
@@ -566,7 +566,7 @@ Update all applicable locations:
 - [Shared](Documentation/Features/Shared.md)
 - [Splice Assist](Documentation/Features/SpliceAssist.md)
 - [Timesheets](Documentation/Features/Timesheets.md)
-- [Yellow Sheet](Documentation/Features/YellowSheet.md)
+- [Materials](Documentation/Features/YellowSheet.md)
 - [Design System](Job%20Tracker/DesignSystem/DesignSystem.md)
 - [Testing Safety Net](Documentation/TestingSafetyNet.md)
 - [Xcode Cloud Testing](Documentation/XcodeCloudTesting.md)

--- a/website/README.md
+++ b/website/README.md
@@ -4,9 +4,9 @@ This folder contains a standalone, dependency-free browser version of the Job Tr
 
 ## Files
 
-- `index.html` – semantic tabbed structure for Dashboard, Timesheets, Yellow Sheet, Job Search, and More.
+- `index.html` – semantic tabbed structure for Dashboard, Timesheets, Materials, Job Search, and More.
 - `styles.css` – dark glassmorphism design system with a fixed bottom tab bar that mirrors the iOS navigation model.
-- `script.js` – localStorage-backed demo interactivity for jobs, weekly timesheets, yellow sheets, search, and tab routing.
+- `script.js` – localStorage-backed demo interactivity for jobs, weekly timesheets, materials, search, and tab routing.
 
 ## Run locally
 
@@ -20,7 +20,7 @@ Then open <http://localhost:8000> in a browser.
 
 ## Parity notes
 
-- The primary navigation matches the iOS app: Dashboard, Timesheets, Yellow Sheet, Job Search, and More.
+- The primary navigation matches the iOS app: Dashboard, Timesheets, Materials, Job Search, and More.
 - Dashboard content is limited to the selected day's job workflow.
-- Timesheet and Yellow Sheet content are separated into their own tabs.
+- Timesheet and Materials content are separated into their own tabs.
 - Additional native sections such as Profile, Settings, Find a Partner, Recent Crew Jobs, Route Mapper, Splice Assist, and Help Center are grouped under More instead of appearing on the Dashboard.

--- a/website/app/PARITY_IMPLEMENTATION_NOTES.md
+++ b/website/app/PARITY_IMPLEMENTATION_NOTES.md
@@ -6,7 +6,7 @@ These notes intentionally live outside `PARITY_PLAN.md` so the current PR can me
 
 1. Added a first-class Job Detail dialog for dashboard/search results with edit, route, share, and remove actions.
 2. Added shared-job import preview/claiming from pasted tokens or `jobtracker://importJob?token=...` links.
-3. Added Profile shortcuts to past timesheets and yellow sheets.
+3. Added Profile shortcuts to past timesheets and materials.
 4. Kept the original parity plan stable to avoid merge conflicts with the already-merged baseline documentation.
 
 ## Still remaining

--- a/website/app/PARITY_PLAN.md
+++ b/website/app/PARITY_PLAN.md
@@ -1,6 +1,6 @@
 # Job Tracker Web App Parity Plan
 
-This audit compares the Firebase-backed web app in `website/app/` against the native iOS flow that matters for the web release: dashboard, job creation/detail/search, timesheets, yellow sheets, sharing, More/Profile/Settings/Find a Partner, and login.
+This audit compares the Firebase-backed web app in `website/app/` against the native iOS flow that matters for the web release: dashboard, job creation/detail/search, timesheets, materials, sharing, More/Profile/Settings/Find a Partner, and login.
 
 ## What was checked
 
@@ -24,11 +24,11 @@ This audit compares the Firebase-backed web app in `website/app/` against the na
 
 - Replace the current desktop-first hero treatment with a closer SwiftUI glass-card layout: centered auth header, segmented controls, card spacing, and button sizing that mirrors the native `JTPrimaryButton` and `JTTextField` components.
 - Add icon affordances to web inputs where the app uses SF Symbols: envelope, lock, person, map pin, clock, and document symbols.
-- Normalize terminology and capitalization so the web uses the same labels as the app: `Sign In`, `Create Account`, `Yellow Sheet`, `Find a Partner`, and native status labels.
+- Normalize terminology and capitalization so the web uses the same labels as the app: `Sign In`, `Create Account`, `Materials`, `Find a Partner`, and native status labels.
 
 ### 2. Dashboard parity
 
-- Keep the current Monday-Friday picker, selected-day rollups, next-job card, timesheet hours, yellow sheet state, and partner card.
+- Keep the current Monday-Friday picker, selected-day rollups, next-job card, timesheet hours, materials state, and partner card.
 - Add a dedicated job detail drawer or route from dashboard cards so users can inspect/edit one job without relying only on inline status changes.
 - Add route/map affordances for addresses after map-provider integration is selected.
 
@@ -38,11 +38,11 @@ This audit compares the Firebase-backed web app in `website/app/` against the na
 - Expand sharing with an import-preview route for pasted/deep-linked tokens so the browser can consume the same `SharedJobPayload` flow it can now publish.
 - Expand search results so each result can open the same detail drawer and show matching fields.
 
-### 4. Timesheets and yellow sheets
+### 4. Timesheets and materials
 
-- Keep the current web editors for weekly timesheets and daily yellow sheets.
+- Keep the current web editors for weekly timesheets and daily materials.
 - Replace text exports with browser PDF generation or a shared server-side PDF service that matches the native PDF output.
-- Add profile shortcuts to past timesheets and past yellow sheets, matching the native Profile screen.
+- Add profile shortcuts to past timesheets and past materials, matching the native Profile screen.
 
 ### 5. More tab scope
 
@@ -54,7 +54,7 @@ This audit compares the Firebase-backed web app in `website/app/` against the na
 
 - Login, signup, reset, sign-out, and persisted-session refresh.
 - Create/update/remove jobs as technician and supervisor/admin roles.
-- Save/reopen timesheets and yellow sheets across refreshes.
+- Save/reopen timesheets and materials across refreshes.
 - Search by job number, address, type, status, date, notes, assignment, and materials.
 - Send/accept/decline partner requests between two test users.
 - Verify the UI at phone, tablet, and desktop widths.

--- a/website/app/README.md
+++ b/website/app/README.md
@@ -7,7 +7,7 @@ This folder contains the Firebase-backed browser version of Job Tracker. It is i
 - **Authentication** – Firebase email/password login, signup, password reset email, persisted session refresh, and sign-out.
 - **Dashboard** – Monday-Friday selector, daily job rollups, completion progress, Firebase sync status, next-job hint, daily summary copy/download, quick job creation, status updates, and job removal.
 - **Timesheets** – weekly timesheet editor with supervisor/partner fields, Gibson/Cable South/Other hour totals, Firestore-backed history, and text export.
-- **Yellow Sheets** – daily compliance checklist with job reference, materials, notes, technician signature, Firestore-backed history, and text export.
+- **Materials** – daily compliance checklist with job reference, materials, notes, technician signature, Firestore-backed history, and text export.
 - **Job Search** – global searchable job index across job number, address, status, type/assignment, date, notes, and materials with inline status updates.
 - **More** – functional Profile, Settings, and Find a Partner sections with Firestore-backed profile/settings and native-compatible partner request records.
 
@@ -34,6 +34,6 @@ The web app reads and writes these existing app collections:
 ## Deployment notes
 
 1. Keep `config.js` aligned with the Firebase project used by the native app.
-2. Ensure Firestore rules allow authenticated users to read/write their own `users`, visible `jobs`, personal timesheets/yellow sheets, and incoming/outgoing partner requests.
+2. Ensure Firestore rules allow authenticated users to read/write their own `users`, visible `jobs`, personal timesheets/materials, and incoming/outgoing partner requests.
 3. Replace text exports with the native PDF generation pipeline or a shared server-side PDF service if browser-generated PDFs are required.
 4. Connect routing distances and address suggestions to production map providers when web mapping is added.

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="A browser version of Job Tracker for dashboards, jobs, timesheets, yellow sheets, search, profile, settings, and partner finding."
+      content="A browser version of Job Tracker for dashboards, jobs, timesheets, materials, search, profile, settings, and partner finding."
     />
     <title>Job Tracker Web</title>
     <link rel="stylesheet" href="styles.css" />
@@ -108,7 +108,7 @@
           <section class="section-grid four" aria-label="Dashboard rollups">
             <article class="feature-card"><span class="icon">📍</span><h2 id="nextJobAddress">No next job</h2><p id="nextJobHint">Add jobs to get routing hints.</p></article>
             <article class="feature-card"><span class="icon">⏱️</span><h2 id="dashboardHours">0 hrs</h2><p>Timesheet hours logged for the selected day.</p></article>
-            <article class="feature-card"><span class="icon">🟨</span><h2 id="yellowStatus">Not started</h2><p>Yellow sheet compliance status for the selected day.</p></article>
+            <article class="feature-card"><span class="icon">🟨</span><h2 id="yellowStatus">Not started</h2><p>Materials compliance status for the selected day.</p></article>
             <article class="feature-card"><span class="icon">👥</span><h2 id="partnerStatus">No partner</h2><p>Current partner request or active crew pairing.</p></article>
           </section>
 
@@ -155,7 +155,7 @@
         </section>
 
         <section class="view" id="yellowSheetsView" data-view="yellowSheets" hidden>
-          <div class="page-heading"><p class="eyebrow">Yellow Sheets</p><h1>Daily compliance sheet</h1><p>Capture safety checks, material usage, job notes, and technician signature for the selected date.</p></div>
+          <div class="page-heading"><p class="eyebrow">Materials</p><h1>Daily compliance sheet</h1><p>Capture safety checks, material usage, job notes, and technician signature for the selected date.</p></div>
           <section class="workspace-card yellow-form">
             <div class="form-grid three">
               <label>Date<input id="yellowDateInput" type="date" /></label>
@@ -172,9 +172,9 @@
               <label>Material usage<textarea id="yellowMaterialsInput" rows="4" placeholder="Drops, connectors, enclosures, NIDs"></textarea></label>
               <label>Daily notes<textarea id="yellowNotesInput" rows="4" placeholder="Safety notes, blockers, extra work"></textarea></label>
             </div>
-            <div class="hero-actions"><button class="button primary" id="saveYellowSheetButton" type="button">Save yellow sheet</button><button class="button secondary" id="exportYellowSheetButton" type="button">Export</button></div>
+            <div class="hero-actions"><button class="button primary" id="saveYellowSheetButton" type="button">Save materials</button><button class="button secondary" id="exportYellowSheetButton" type="button">Export</button></div>
           </section>
-          <section class="workspace-card"><p class="eyebrow">History</p><h2>Past yellow sheets</h2><div class="compact-list" id="pastYellowSheetsList"></div></section>
+          <section class="workspace-card"><p class="eyebrow">History</p><h2>Past materials</h2><div class="compact-list" id="pastYellowSheetsList"></div></section>
         </section>
 
         <section class="view" id="searchView" data-view="search" hidden>
@@ -267,9 +267,9 @@
           <span class="tab-symbol" aria-hidden="true">◷</span>
           <span class="tab-label">Timesheets</span>
         </button>
-        <button class="tab-button" type="button" data-route="yellowSheets" aria-label="Yellow Sheet" data-symbol="doc.text">
+        <button class="tab-button" type="button" data-route="yellowSheets" aria-label="Materials" data-symbol="doc.text">
           <span class="tab-symbol" aria-hidden="true">▤</span>
-          <span class="tab-label">Yellow Sheet</span>
+          <span class="tab-label">Materials</span>
         </button>
         <button class="tab-button" type="button" data-route="search" aria-label="Job Search" data-symbol="magnifyingglass">
           <span class="tab-symbol" aria-hidden="true">⌕</span>

--- a/website/app/parity-enhancements.js
+++ b/website/app/parity-enhancements.js
@@ -323,7 +323,7 @@ function renderProfileShortcuts() {
   container.innerHTML = "";
   [
     { label: "Past Timesheets", count: timesheets.length, detail: latestTimesheet ? `Latest week of ${dateLabel(latestTimesheet.weekStart)}` : "No saved weeks yet", route: "timesheets" },
-    { label: "Past Yellow Sheets", count: yellowSheets.length, detail: latestYellow ? `Latest ${dateLabel(latestYellow.date)}` : "No saved sheets yet", route: "yellowSheets" },
+    { label: "Past Materials", count: yellowSheets.length, detail: latestYellow ? `Latest ${dateLabel(latestYellow.date)}` : "No saved sheets yet", route: "yellowSheets" },
   ].forEach((shortcut) => {
     const button = document.createElement("button");
     const label = document.createElement("span");

--- a/website/app/script.js
+++ b/website/app/script.js
@@ -786,14 +786,14 @@ async function handleSaveYellowSheet() {
   await setDoc("yellowSheets", sheet.id, sheet);
   await loadAppData();
   renderAll();
-  showToast("Yellow sheet saved to Firebase.");
+  showToast("Materials saved to Firebase.");
 }
 
 function renderPastYellowSheets() {
   const sheets = Object.values(appState.yellowSheets).filter((sheet) => sheet.savedAt);
   const list = $("#pastYellowSheetsList");
   list.innerHTML = "";
-  if (sheets.length === 0) { list.innerHTML = `<p class="empty-state">Saved yellow sheets will appear here.</p>`; return; }
+  if (sheets.length === 0) { list.innerHTML = `<p class="empty-state">Saved materials will appear here.</p>`; return; }
   sheets.sort((a, b) => b.date.localeCompare(a.date)).forEach((sheet) => { const checks = Object.values(sheet.checks || {}).filter(Boolean).length; const item = document.createElement("article"); item.className = "compact-item"; item.innerHTML = `<div><h3>${dateLabel(sheet.date)}</h3><span>${checks}/4 checks complete • Signature: ${sheet.signature || "Missing"}</span></div>`; list.append(item); });
 }
 
@@ -801,7 +801,7 @@ function downloadText(filename, text) { const blob = new Blob([text], { type: "t
 async function copyText(text, fallbackName) { try { await navigator.clipboard.writeText(text); showToast("Summary copied to clipboard."); } catch { downloadText(fallbackName, text); showToast("Clipboard unavailable, downloaded a text summary instead."); } }
 function dailySummaryText() { const lines = [`Job Tracker Daily Summary`, `Date: ${dateLabel(selectedDate)}`, `Technician: ${currentUser.firstName} ${currentUser.lastName}`, ""]; selectedJobs().forEach((job) => lines.push(`${job.jobNumber || "No job #"} • ${job.status} • ${job.address} • ${job.notes || "No note"}`)); if (selectedJobs().length === 0) lines.push("No jobs scheduled."); return lines.join("\n"); }
 function timesheetText() { const sheet = captureTimesheet(); return [`Job Tracker Timesheet`, `Week: ${sheet.weekStart}`, `Technician: ${sheet.name1}`, `Supervisor: ${sheet.supervisor || "Not set"}`, `Partner: ${sheet.name2 || "None"}`, "", ...sheet.days.map((day) => `${day.name}: ${sumDay(day).toFixed(2)} hrs - ${day.notes || "No notes"}`), `Total: ${sheet.totalHours} hrs`].join("\n"); }
-function yellowSheetText() { const sheet = captureYellowSheet(); const checks = Object.entries(sheet.checks).map(([key, value]) => `${key}: ${value ? "yes" : "no"}`).join("\n"); return [`Job Tracker Yellow Sheet`, `Date: ${sheet.date}`, `Technician: ${currentUser.firstName} ${currentUser.lastName}`, `Signature: ${sheet.signature || "Missing"}`, "", checks, "", `Materials: ${sheet.materials || "None"}`, `Notes: ${sheet.notes || "None"}`].join("\n"); }
+function yellowSheetText() { const sheet = captureYellowSheet(); const checks = Object.entries(sheet.checks).map(([key, value]) => `${key}: ${value ? "yes" : "no"}`).join("\n"); return [`Job Tracker Materials`, `Date: ${sheet.date}`, `Technician: ${currentUser.firstName} ${currentUser.lastName}`, `Signature: ${sheet.signature || "Missing"}`, "", checks, "", `Materials: ${sheet.materials || "None"}`, `Notes: ${sheet.notes || "None"}`].join("\n"); }
 
 function displayUserName(user) {
   if (!user) return "";
@@ -1181,7 +1181,7 @@ function bindEvents() {
   $("#exportTimesheetButton").addEventListener("click", () => downloadText(`timesheet-${$("#timesheetWeekInput").value}.txt`, timesheetText()));
   $("#yellowDateInput").addEventListener("change", renderYellowSheet);
   $("#saveYellowSheetButton").addEventListener("click", () => handleSaveYellowSheet().catch((error) => showToast(error.message)));
-  $("#exportYellowSheetButton").addEventListener("click", () => downloadText(`yellow-sheet-${$("#yellowDateInput").value}.txt`, yellowSheetText()));
+  $("#exportYellowSheetButton").addEventListener("click", () => downloadText(`materials-${$("#yellowDateInput").value}.txt`, yellowSheetText()));
   $("#jobSearchInput").addEventListener("input", renderSearch);
   $$('[data-more-tab]').forEach((button) => button.addEventListener("click", () => setMoreTab(button.dataset.moreTab)));
   $("#saveProfileButton").addEventListener("click", () => saveProfile().catch((error) => showToast(error.message)));

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="A browser version of the Job Tracker iOS app with Dashboard, Timesheets, Yellow Sheet, Job Search, and More tabs."
+      content="A browser version of the Job Tracker iOS app with Dashboard, Timesheets, Materials, Job Search, and More tabs."
     />
     <title>Job Tracker Web</title>
     <link rel="stylesheet" href="styles.css" />
@@ -121,18 +121,18 @@
 
         <section class="tab-view" id="yellowSheetView" data-tab="yellowSheet" aria-labelledby="yellowSheetTitle" hidden>
           <header class="page-heading">
-            <p class="eyebrow">Yellow Sheet</p>
-            <h1 id="yellowSheetTitle">Weekly yellow sheet</h1>
-            <p class="lede">Save the week-starting date and total job count for the same yellow sheet record the iOS app stores.</p>
+            <p class="eyebrow">Materials</p>
+            <h1 id="yellowSheetTitle">Weekly materials</h1>
+            <p class="lede">Save the week-starting date and total job count for the same materials record the iOS app stores.</p>
           </header>
 
           <section class="workspace-card">
             <div class="section-heading">
               <div>
                 <p class="eyebrow">Current week</p>
-                <h2>Yellow Sheet summary</h2>
+                <h2>Materials summary</h2>
               </div>
-              <button class="button primary" id="saveYellowSheetButton" type="button">Save Yellow Sheet</button>
+              <button class="button primary" id="saveYellowSheetButton" type="button">Save Materials</button>
             </div>
             <div class="yellow-summary">
               <article>
@@ -149,7 +149,7 @@
 
           <section class="workspace-card">
             <p class="eyebrow">History</p>
-            <h2>Past Yellow Sheets</h2>
+            <h2>Past Materials</h2>
             <div class="compact-list" id="pastYellowSheetsList"></div>
           </section>
         </section>
@@ -207,7 +207,7 @@
       <nav class="bottom-tabs" aria-label="Primary tabs">
         <button class="tab-button active" type="button" data-tab-target="dashboard" aria-label="Dashboard" aria-current="page"><span>▦</span><small>Dashboard</small></button>
         <button class="tab-button" type="button" data-tab-target="timesheets" aria-label="Timesheets"><span>◷</span><small>Timesheets</small></button>
-        <button class="tab-button" type="button" data-tab-target="yellowSheet" aria-label="Yellow Sheet"><span>▤</span><small>Yellow Sheet</small></button>
+        <button class="tab-button" type="button" data-tab-target="yellowSheet" aria-label="Materials"><span>▤</span><small>Materials</small></button>
         <button class="tab-button" type="button" data-tab-target="jobSearch" aria-label="Job Search"><span>⌕</span><small>Job Search</small></button>
         <button class="tab-button" type="button" data-tab-target="more" aria-label="More"><span>•••</span><small>More</small></button>
       </nav>

--- a/website/script.js
+++ b/website/script.js
@@ -314,7 +314,7 @@ function renderPastYellowSheets() {
   list.innerHTML = "";
 
   if (appState.yellowSheets.length === 0) {
-    list.innerHTML = `<p class="empty-state">No saved yellow sheets yet.</p>`;
+    list.innerHTML = `<p class="empty-state">No saved materials yet.</p>`;
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Align user-facing terminology across iOS and web so the former “Yellow Sheet(s)” surface is presented as “Materials”.
- Keep persistence and export compatibility with the existing `yellowSheets` collection/path while clarifying the UI and documentation labels. 

### Description
- Replaced user-facing strings and UI labels from “Yellow Sheet(s)” to “Materials” in iOS Swift files, including navigation titles, empty states, buttons, alerts, history cards, and detail screens (e.g. `AppNavigationViewModel.swift`, `YellowSheetView.swift`, `YellowSheetDetailView.swift`, `ProfileView.swift`, `PastYellowSheetsView.swift`).
- Updated PDF generator and editor filenames and headers to use `Materials` (e.g. `YellowSheetPDFGenerator.swift` now writes `Materials-<uuid>.pdf` and `PDFEditorView.swift` writes `EditedMaterials-<uuid>.pdf`).
- Updated web UI and scripts to match the new terminology and export filenames, including `website/index.html`, `website/app/index.html`, `website/script.js`, and `website/app/script.js`, and changed text export names to `materials-<date>.txt`.
- Adjusted documentation and admin/export notes to reference `Materials` while explicitly retaining `yellowSheets` as the legacy collection/export path for backward compatibility (`Documentation/*`, `README.md`).

### Testing
- Ran JavaScript syntax checks with `node --check` for `website/script.js`, `website/app/script.js`, and `website/app/parity-enhancements.js`, which completed without errors.
- Ran Cloud Functions unit tests with `npm test` under `functions` and observed 2 tests passed (`# pass 2`).
- Executed the Python fiber map test directly (`python3 tests/fiber_map_resources.test.py`) and the Node smoke test (`node tests/fiber_map_resource_smoke.js`), both of which passed.
- Performed repository checks: `git diff --check` returned clean and a case-insensitive search for remaining user-facing “yellow sheet(s)” occurrences found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b66aad8f0832dbf51f78b4dca865b)