### PR TITLE
Replace feature tap gestures with accessible controls

### DIFF
--- a/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardJobSectionsView.swift
@@ -34,6 +34,7 @@ struct DashboardJobSectionsView: View {
                                 job: job,
                                 isHere: job.id == nearestJobID,
                                 statusOptions: statusOptions,
+                                onJobTap: { onJobTap(job) },
                                 onMapTap: { onMapTap(job) },
                                 onStatusChange: { newStatus in onStatusChange(job, newStatus) },
                                 onDelete: { onDelete(job) },
@@ -41,7 +42,6 @@ struct DashboardJobSectionsView: View {
                                 distanceString: distanceStrings[job.id]
                             )
                             .id("\(job.id)_\(job.status)")
-                            .onTapGesture { onJobTap(job) }
                         }
                     }
 
@@ -53,6 +53,7 @@ struct DashboardJobSectionsView: View {
                                 job: job,
                                 isHere: job.id == nearestJobID,
                                 statusOptions: statusOptions,
+                                onJobTap: { onJobTap(job) },
                                 onMapTap: { onMapTap(job) },
                                 onStatusChange: { newStatus in onStatusChange(job, newStatus) },
                                 onDelete: { onDelete(job) },
@@ -60,7 +61,6 @@ struct DashboardJobSectionsView: View {
                                 distanceString: distanceStrings[job.id]
                             )
                             .id("\(job.id)_\(job.status)")
-                            .onTapGesture { onJobTap(job) }
                         }
                     }
                 }
@@ -88,6 +88,7 @@ struct JobCard: View {
     let job: Job
     let isHere: Bool
     let statusOptions: [String]
+    let onJobTap: () -> Void
     let onMapTap: () -> Void
     let onStatusChange: (String) -> Void
     let onDelete: () -> Void
@@ -104,6 +105,7 @@ struct JobCard: View {
         job: Job,
         isHere: Bool,
         statusOptions: [String],
+        onJobTap: @escaping () -> Void,
         onMapTap: @escaping () -> Void,
         onStatusChange: @escaping (String) -> Void,
         onDelete: @escaping () -> Void,
@@ -113,6 +115,7 @@ struct JobCard: View {
         self.job = job
         self.isHere = isHere
         self.statusOptions = statusOptions
+        self.onJobTap = onJobTap
         self.onMapTap = onMapTap
         self.onStatusChange = onStatusChange
         self.onDelete = onDelete
@@ -123,8 +126,20 @@ struct JobCard: View {
     var body: some View {
         GlassCard(cornerRadius: JTShapes.cardCornerRadius) {
             VStack(alignment: .leading, spacing: JTSpacing.sm) {
-                header
-                details
+                Button(action: onJobTap) {
+                    VStack(alignment: .leading, spacing: JTSpacing.sm) {
+                        header
+                        details
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .frame(minHeight: 44)
+                .accessibilityLabel("Job at \(job.address)")
+                .accessibilityValue("\(job.displayStatus), \(DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))")
+                .accessibilityHint("Opens job details")
+                .accessibilityIdentifier("dashboard.job.\(job.id).details")
                 actions
             }
             .padding(JTSpacing.md)
@@ -154,9 +169,7 @@ struct JobCard: View {
         .sheet(item: $portalPage) { page in
             GibsonPortalView(url: page.url)
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(houseNumber(job.address)), \(DateFormatter.localizedString(from: job.date, dateStyle: .medium, timeStyle: .none))")
-        .accessibilityHint("Double tap for details. Swipe actions for share and delete.")
+        .accessibilityElement(children: .contain)
     }
 
     private var header: some View {
@@ -239,6 +252,11 @@ struct JobCard: View {
                     .clipShape(Capsule())
             }
             .buttonStyle(.plain)
+            .frame(minWidth: 44, minHeight: 44)
+            .accessibilityLabel("Change status")
+            .accessibilityValue(job.displayStatus)
+            .accessibilityHint("Shows available job statuses")
+            .accessibilityIdentifier("dashboard.job.\(job.id).status")
             .confirmationDialog("Change Status", isPresented: $showStatusDialog, titleVisibility: .visible) {
                 ForEach(statusOptions, id: \.self) { option in
                     if option == "Custom" {
@@ -289,6 +307,10 @@ struct JobCard: View {
                         .jtGlassBackground(shape: Capsule(), strokeColor: JTColors.glassSoftStroke)
                 }
                 .accessibilityLabel("Open Gibson portal")
+                .accessibilityValue(job.address)
+                .accessibilityHint("Opens this job in the Gibson portal")
+                .accessibilityIdentifier("dashboard.job.\(job.id).portal")
+                .frame(minHeight: 44)
             }
 
             Button(action: onMapTap) {
@@ -299,6 +321,10 @@ struct JobCard: View {
                     .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
             }
             .accessibilityLabel("Directions")
+            .accessibilityValue(job.address)
+            .accessibilityHint("Opens this job in Maps")
+            .accessibilityIdentifier("dashboard.job.\(job.id).map")
+            .frame(minWidth: 44, minHeight: 44)
 
             Button(action: onShare) {
                 Image(systemName: "square.and.arrow.up")
@@ -307,6 +333,11 @@ struct JobCard: View {
                     .padding(JTSpacing.xs)
                     .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
             }
+            .accessibilityLabel("Share job")
+            .accessibilityValue(job.address)
+            .accessibilityHint("Opens sharing options for this job")
+            .accessibilityIdentifier("dashboard.job.\(job.id).share")
+            .frame(minWidth: 44, minHeight: 44)
 
             Button {
                 showDeleteConfirm = true
@@ -320,6 +351,11 @@ struct JobCard: View {
                     .padding(JTSpacing.xs)
                     .jtGlassBackground(shape: Circle(), strokeColor: JTColors.glassSoftStroke)
             }
+            .accessibilityLabel("Delete job")
+            .accessibilityValue(job.address)
+            .accessibilityHint("Asks for confirmation before deleting this job")
+            .accessibilityIdentifier("dashboard.job.\(job.id).delete")
+            .frame(minWidth: 44, minHeight: 44)
         }
     }
 

--- a/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
+++ b/Job Tracker/Features/Dashboard/Components/DashboardSyncBanner.swift
@@ -65,8 +65,7 @@ struct DashboardSyncBanner: View {
         }
         .frame(height: 44)
         .padding(.horizontal, JTSpacing.lg)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(title). Tap for details.")
+        .accessibilityHidden(true)
     }
 }
 

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -136,15 +136,21 @@ struct DashboardView: View {
             .overlay(alignment: .top) {
                 VStack(spacing: JTSpacing.sm) {
                     if viewModel.showSyncBanner, viewModel.syncTotal > 0, viewModel.syncDone <= viewModel.syncTotal {
-                        DashboardSyncBanner(
-                            done: viewModel.syncDone,
-                            total: viewModel.syncTotal,
-                            inFlight: viewModel.syncInFlight,
-                            failed: viewModel.syncFailed,
-                            waitingForNetwork: viewModel.syncWaitingForNetwork,
-                            phase: viewModel.wavePhase
-                        )
-                        .onTapGesture { viewModel.presentSyncDetails() }
+                        Button(action: viewModel.presentSyncDetails) {
+                            DashboardSyncBanner(
+                                done: viewModel.syncDone,
+                                total: viewModel.syncTotal,
+                                inFlight: viewModel.syncInFlight,
+                                failed: viewModel.syncFailed,
+                                waitingForNetwork: viewModel.syncWaitingForNetwork,
+                                phase: viewModel.wavePhase
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Sync status")
+                        .accessibilityValue("\(viewModel.syncDone) of \(viewModel.syncTotal) changes uploaded")
+                        .accessibilityHint("Opens sync details")
+                        .accessibilityIdentifier("dashboard.syncDetails")
                         .transition(.move(edge: .top).combined(with: .opacity))
                     }
 

--- a/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
+++ b/Job Tracker/Features/Jobs/Editor/JobDetailView.swift
@@ -668,7 +668,52 @@ extension JobDetailView {
 
     private func jobPhotoSlotRow(title: String, urlString: String?, image: UIImage?, slot: JobPhotoSlot) -> some View {
         HStack(spacing: 12) {
+            let fullScreenURL = image == nil ? urlString.flatMap { URL(string: $0) } : nil
+            let isAvailable = image != nil || urlString?.isEmpty == false
+
             Group {
+                if let fullScreenURL {
+                    Button {
+                        fullScreenImageURL = fullScreenURL
+                    } label: {
+                        photoThumbnail(urlString: urlString, image: image)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(title), available")
+                    .accessibilityValue("Ready")
+                    .accessibilityHint("Opens the full-screen photo")
+                    .accessibilityIdentifier("jobDetail.photo.\(slot.rawValue)")
+                } else {
+                    photoThumbnail(urlString: urlString, image: image)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("\(title), \(isAvailable ? "available" : "not added")")
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(isAvailable ? "Ready" : "Not added")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(isAvailable ? "Replace" : "Add") {
+                activePhotoSlot = slot
+                showPhotoSourceDialog = true
+            }
+            .font(.subheadline)
+            .buttonStyle(.borderless)
+            .frame(minWidth: 44, minHeight: 44)
+            .accessibilityHint("Choose a photo source for \(title)")
+            .accessibilityIdentifier("jobDetail.photo.\(slot.rawValue).edit")
+        }
+    }
+
+    private func photoThumbnail(urlString: String?, image: UIImage?) -> some View {
+        Group {
                 if let image {
                     Image(uiImage: image)
                         .resizable()
@@ -701,29 +746,6 @@ extension JobDetailView {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
             )
-            .onTapGesture {
-                if image == nil, let urlString, let url = URL(string: urlString) {
-                    fullScreenImageURL = url
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                Text(image != nil || urlString?.isEmpty == false ? "Ready" : "Not added")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            Button(image != nil || urlString?.isEmpty == false ? "Replace" : "Add") {
-                activePhotoSlot = slot
-                showPhotoSourceDialog = true
-            }
-            .font(.subheadline)
-            .buttonStyle(.borderless)
-        }
     }
 
 
@@ -755,6 +777,9 @@ extension JobDetailView {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Other job photo, available")
+        .accessibilityValue("Ready")
+        .accessibilityHint("Opens the full-screen photo")
     }
 
     // OH Materials Section

--- a/Job Tracker/Features/Jobs/ExtraWorkView.swift
+++ b/Job Tracker/Features/Jobs/ExtraWorkView.swift
@@ -34,18 +34,25 @@ struct ExtraWorkView: View {
                                     .foregroundColor(.gray)
                             } else {
                                 ForEach(matchingJobs) { job in
-                                    VStack(alignment: .leading) {
-                                        Text(job.address)
-                                            .font(.headline)
-                                            .foregroundColor(.white)
-                                        Text("Created by: \(creatorFullName(for: job))")
-                                            .font(.subheadline)
-                                            .foregroundColor(.gray)
-                                    }
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
+                                    Button {
                                         selectedJob = job
+                                    } label: {
+                                        VStack(alignment: .leading) {
+                                            Text(job.address)
+                                                .font(.headline)
+                                                .foregroundColor(.white)
+                                            Text("Created by: \(creatorFullName(for: job))")
+                                                .font(.subheadline)
+                                                .foregroundColor(.gray)
+                                        }
+                                        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                                        .contentShape(Rectangle())
                                     }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Extra work at \(job.address)")
+                                    .accessibilityValue("Created by \(creatorFullName(for: job))")
+                                    .accessibilityHint("Opens job details")
+                                    .accessibilityIdentifier("extraWork.job.\(job.id)")
                                 }
                             }
                         }

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -482,10 +482,17 @@ struct AdminPanelView: View {
                 }
 
                 if let error = updateViewModel.errorReason {
-                    Text(error)
-                        .font(.footnote)
-                        .foregroundStyle(.red)
-                        .onTapGesture { updateViewModel.resetError() }
+                    Button(action: updateViewModel.resetError) {
+                        Text(error)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Dismiss update error")
+                    .accessibilityValue(error)
+                    .accessibilityHint("Clears this error message")
+                    .accessibilityIdentifier("settings.update.dismissError")
                 }
 
                 VStack(spacing: 8) {

--- a/Job Tracker/Features/SpliceAssist/SpliceAssistView.swift
+++ b/Job Tracker/Features/SpliceAssist/SpliceAssistView.swift
@@ -19,9 +19,16 @@ struct SpliceAssistView: View {
                 stepThreeCard
 
                 if let message = viewModel.message {
-                    messageCard(message)
+                    Button(action: viewModel.clearMessage) {
+                        messageCard(message)
+                    }
+                        .buttonStyle(.plain)
+                        .frame(minHeight: 44)
+                        .accessibilityLabel("Dismiss message")
+                        .accessibilityValue(message)
+                        .accessibilityHint("Clears this message")
+                        .accessibilityIdentifier("spliceAssist.dismissMessage")
                         .transition(.opacity.combined(with: .move(edge: .top)))
-                        .onTapGesture { viewModel.clearMessage() }
                 }
 
                 if viewModel.isProcessing || viewModel.result != nil {

--- a/Job TrackerUITests/DashboardJobFlowUITests.swift
+++ b/Job TrackerUITests/DashboardJobFlowUITests.swift
@@ -17,10 +17,30 @@ final class DashboardJobFlowUITests: XCTestCase {
     func testJobDetailSupportsEditSaveAndDeleteControls() {
         let app = JobTrackerUITestSupport.launch()
 
-        waitForElement(app.staticTexts["100 Safety Net Lane"])
-        app.staticTexts["100 Safety Net Lane"].tap()
+        let detailsButton = app.buttons["dashboard.job.ui-test-job-1.details"]
+        waitForElement(detailsButton)
+        detailsButton.tap()
         waitForElement(app.navigationBars["Job Detail"])
         XCTAssertTrue(app.buttons["Save"].exists)
         XCTAssertTrue(app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Delete")).firstMatch.exists)
+    }
+
+    func testDashboardCardActionsAreIndependentlyActionable() {
+        let app = JobTrackerUITestSupport.launch()
+
+        let statusButton = app.buttons["dashboard.job.ui-test-job-1.status"]
+        let deleteButton = app.buttons["dashboard.job.ui-test-job-1.delete"]
+        waitForElement(statusButton)
+        waitForElement(deleteButton)
+
+        statusButton.tap()
+        waitForElement(app.buttons["Pending"])
+        XCTAssertFalse(app.navigationBars["Job Detail"].exists)
+        app.buttons["Pending"].tap()
+
+        deleteButton.tap()
+        waitForElement(app.alerts["Delete this job?"])
+        XCTAssertFalse(app.navigationBars["Job Detail"].exists)
+        app.alerts.buttons["Cancel"].tap()
     }
 }


### PR DESCRIPTION
### Motivation

- Improve accessibility and semantics by replacing view-level `onTapGesture` handlers with semantic `Button` controls where appropriate to ensure keyboard, VoiceOver, and pointer interactions work as expected. 
- Preserve the original visual appearance while providing explicit accessibility labels, values, hints, identifiers, and a minimum activation area.

### Description

- Replace card-level tapping on dashboard job cards with a `.buttonStyle(.plain)` parent `Button` that preserves the look and opens job details, and keep nested map, status, portal, share, and delete controls as independent buttons with their own accessibility labels, values, hints, identifiers, and 44x44 minimum frames. (Dashboard Job components updated.)
- Wrap the sync banner in a `.buttonStyle(.plain)` `Button` exposing sync progress via an accessibility value and add a stable `accessibilityIdentifier`; mark the visual banner itself as accessibility-hidden so the button is the single semantic control. (Dashboard banner/view updated.)
- Make photo thumbnails in the job editor conditional `Button`s when a full-screen URL is available and provide an accessible name reflecting the photo category and availability, while keeping the separate Replace/Add control actionable with an identifier. (Job detail photo rows updated.)
- Audit and convert remaining feature-level taps to semantic controls where appropriate: Extra Work list rows, Splice Assist message dismissal, and update-error dismissal are now buttons with accessibility metadata and minimum sizes. (ExtraWorkView, SpliceAssistView, MainTabView updated.)
- Add accessibility identifiers and a UI test (`DashboardJobFlowUITests`) that activates dashboard card details, status, and delete controls via identifiers and verifies nested actions are independently actionable without coordinate-based taps.

### Testing

- Ran `swiftc -frontend -parse` against the modified Swift sources and the updated UI test file to validate parsing of the changes (succeeded).
- Ran `git diff --check` to ensure no trailing whitespace or patch problems (succeeded).
- Confirmed no remaining feature-level `onTapGesture` usages under `Job Tracker/Features` using `rg` (succeeded).
- Full Xcode UI test execution could not be run in this Linux environment because Xcode is unavailable, so end-to-end UI test runs are pending in CI or a macOS environment (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b66ce8f70832d9e1274257d7a1000)