### PR TITLE
Add iPad adaptive-layout UI tests and stable accessibility identifiers

### DIFF
--- a/Documentation/TestingSafetyNet.md
+++ b/Documentation/TestingSafetyNet.md
@@ -13,6 +13,7 @@ The `Job TrackerTests` bundle should keep fast, deterministic XCTest coverage ar
 - **Dashboard and recent crew jobs**: View-model tests cover summaries and detail sheets that crew members use to understand current work.
 - **Help and tutorial flows**: Tutorial stage tests protect onboarding guidance from accidental regressions.
 - **Seeded UI flows**: `Job TrackerUITests` launches with `JT_UI_TESTING=1` and deterministic seed data to cover authentication validation, dashboard job flow, create/detail/delete controls, search, timesheets, yellow sheets, settings, and admin-only navigation without writing to production Firebase.
+- **iPad adaptive UI flows**: `IPadAdaptiveLayoutUITests` runs from the same UI-test target on the documented iPad simulator and covers portrait/landscape continuity, readable empty states, reachable actions, form and keyboard behavior, dismissible presentations, maps, settings, and supervisor navigation. Stage Manager and Split View geometry remain part of the manual checklist in `XcodeCloudTesting.md`.
 - **Integration smoke tests**: `ServiceIntegrationSmokeTests` covers PDF generation, job-photo slot mapping, arrival-alert inactive state, and watch sync payload filtering; `AppIntentEntryPointTests` protects App Intent discoverability and fallback messaging.
 - **Firebase rules emulator tests**: `firebase-emulator-tests/firestore-storage.rules.test.js` is wired through `npm run test:firebase-rules` and intentionally skips until both `firestore.rules` and `storage.rules` are present.
 

--- a/Documentation/XcodeCloudTesting.md
+++ b/Documentation/XcodeCloudTesting.md
@@ -23,6 +23,29 @@ xcodebuild test \
   -destination 'platform=iOS Simulator,name=iPhone 15'
 ```
 
+Run the adaptive-layout suite on a current iPad simulator as a second QA destination (and configure the Xcode Cloud Test action with the same destination):
+
+```sh
+xcodebuild test \
+  -project "Job Tracker.xcodeproj" \
+  -scheme "Job Tracker" \
+  -testPlan "Job Tracker Safety Net" \
+  -destination 'platform=iOS Simulator,name=iPad Pro 11-inch (M4)' \
+  -only-testing:'Job TrackerUITests/IPadAdaptiveLayoutUITests'
+```
+
+The test plan includes the complete `Job TrackerUITests` target, so the file-system-synchronized `IPadAdaptiveLayoutUITests` suite is discovered without a per-file project entry. The suite skips on an iPhone runner, keeping the complete safety-net plan usable there, but it only supplies adaptive-layout coverage when the workflow also has the documented iPad destination.
+
+### Manual iPad multitasking QA
+
+XCTest can rotate the simulator but cannot reliably choose Stage Manager or Split View window geometry. Before a release, repeat these checks manually with seeded or non-production data in both light and dark appearance:
+
+1. In **Split View**, test approximately one-third, one-half, and two-thirds widths. Visit Dashboard, Search and a selected result, Timesheet, Yellow Sheet, Create/Edit Job, Route Mapper, Settings, and Supervisor Dashboard. Confirm the selected sidebar/tab and pushed detail remain selected while changing widths.
+2. With **Stage Manager**, resize from the smallest supported window to a wide window in portrait and landscape. Confirm empty-state copy wraps without clipping and primary Create, Save, Done, and map-control actions remain visible or reachable by scrolling.
+3. While a text field is focused, resize the window, dismiss the keyboard using its semantic Done/Search action, and verify the edited value and scroll position remain intact.
+4. Present the week calendar, a job detail, and Create Job. Resize or rotate, then dismiss each sheet or popover using its labeled Close/Done control; verify focus returns to the previously selected sidebar/detail item.
+5. On Route Mapper, verify the controls drawer, search overlay, and locate button do not overlap at each size. Do not use visual map coordinates as pass/fail criteria.
+
 You can also run the configuration guardrail locally:
 
 ```sh

--- a/Job Tracker Safety Net.xctestplan
+++ b/Job Tracker Safety Net.xctestplan
@@ -2,7 +2,7 @@
   "configurations": [
     {
       "id": "1C2DD7E4-8DA2-44E6-9751-1F5C6E28B9E0",
-      "name": "Safety Net"
+      "name": "Safety Net (including iPad Adaptive Layout)"
     }
   ],
   "defaultOptions": {

--- a/Job Tracker/Features/Dashboard/DashboardView.swift
+++ b/Job Tracker/Features/Dashboard/DashboardView.swift
@@ -105,6 +105,7 @@ struct DashboardView: View {
                     JTPrimaryButton("Create Job", systemImage: "plus") {
                         viewModel.presentCreateJob()
                     }
+                    .accessibilityIdentifier("Dashboard.CreateJob")
                     .padding(.horizontal)
                     .padding(.top, JTSpacing.sm)
 
@@ -167,6 +168,7 @@ struct DashboardView: View {
                 .padding(.top, JTSpacing.md)
             }
             .toolbar(navigationBarVisibility, for: .navigationBar)
+            .accessibilityIdentifier("Dashboard.Root")
             .jtNavigationBarStyle()
             .safeAreaInset(edge: .top) {
                 Color.clear.frame(height: shellChromeHeight)

--- a/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
+++ b/Job Tracker/Features/Dashboard/SupervisorHomeDashboardView.swift
@@ -40,6 +40,7 @@ struct SupervisorHomeDashboardView: View {
             .onChange(of: selectedDate) { _, newDate in viewModel.start(for: newDate) }
             .onDisappear { viewModel.stop() }
         }
+        .accessibilityIdentifier("SupervisorDashboard.Root")
     }
 
     private var header: some View {
@@ -113,6 +114,7 @@ struct SupervisorHomeDashboardView: View {
                 .buttonStyle(.plain)
             }
         }
+        .accessibilityIdentifier("SupervisorDashboard.Positions")
     }
 
     private func users(for position: CrewPosition) -> [AppUser] {

--- a/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
+++ b/Job Tracker/Features/Jobs/Editor/CreateJobView.swift
@@ -598,6 +598,7 @@ struct CreateJobView: View {
                 }
             }
             .navigationTitle("Create Job")
+            .accessibilityIdentifier("CreateJob.Root")
             .navigationBarTitleDisplayMode(.inline)
             .jtNavigationBarStyle()
             .toolbar {
@@ -608,6 +609,7 @@ struct CreateJobView: View {
                     Button("Save") {
                         attemptSave()
                     }
+                    .accessibilityIdentifier("CreateJob.Save")
                     .disabled(isSaving)
                 }
             }

--- a/Job Tracker/Features/Search/JobSearchView.swift
+++ b/Job Tracker/Features/Search/JobSearchView.swift
@@ -52,6 +52,7 @@ struct JobSearchView: View {
             }
         }
         .jtNavigationBarStyle()
+        .accessibilityIdentifier("Search.Root")
         .safeAreaInset(edge: .top) {
             Color.clear.frame(height: shellChromeHeight)
         }
@@ -84,6 +85,7 @@ struct JobSearchView: View {
 
     private var searchField: some View {
         JTTextField("Address, job #, status, or teammate", text: $viewModel.query, icon: "magnifyingglass")
+            .accessibilityIdentifier("Search.Query")
             .textInputAutocapitalization(.never)
             .disableAutocorrection(true)
             .submitLabel(.search)
@@ -264,6 +266,7 @@ private struct EmptyResultsView: View {
             .padding(.vertical, JTSpacing.xl)
             .padding(.horizontal, JTSpacing.xl)
         }
+        .accessibilityIdentifier("Search.EmptyState")
     }
 }
 

--- a/Job Tracker/Features/Settings/SettingsView.swift
+++ b/Job Tracker/Features/Settings/SettingsView.swift
@@ -287,6 +287,7 @@ struct SettingsView: View {
                 .padding(.bottom, 8)
             }
         }
+        .accessibilityIdentifier("Settings.Root")
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showThemeEditor) {

--- a/Job Tracker/Features/Shared/Mapping/MapsView.swift
+++ b/Job Tracker/Features/Shared/Mapping/MapsView.swift
@@ -916,6 +916,7 @@ struct MapsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
+        .accessibilityIdentifier("Maps.Root")
         .animation(.spring(response: 0.35, dampingFraction: 0.85), value: showControls)
         .onAppear {
             viewModel.bindLocationService(locationService)

--- a/Job Tracker/Features/Shared/Shell/MainTabView.swift
+++ b/Job Tracker/Features/Shared/Shell/MainTabView.swift
@@ -60,6 +60,7 @@ private struct PrimaryTabContainer: View {
             }
         }
         .tabViewStyle(.sidebarAdaptable)
+        .accessibilityIdentifier("IPadShell.Root")
         .jtNavigationBarStyle()
     }
 }

--- a/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
+++ b/Job Tracker/Features/Timesheets/WeeklyTimesheetView.swift
@@ -359,6 +359,7 @@ struct WeeklyTimesheetView: View {
             }
             .jtNavigationBarStyle()
         }
+        .accessibilityIdentifier("Timesheet.Root")
     }
 }
 
@@ -372,6 +373,7 @@ extension WeeklyTimesheetView {
                     .font(JTTypography.captionEmphasized)
                     .foregroundStyle(JTColors.textSecondary)
                 TextField("Supervisor", text: $supervisor)
+                    .accessibilityIdentifier("Timesheet.Supervisor")
                     .padding(.vertical, JTSpacing.sm)
                     .padding(.horizontal, JTSpacing.md)
                     .jtGlassBackground(cornerRadius: JTShapes.fieldCornerRadius, strokeColor: JTColors.glassSoftStroke)

--- a/Job Tracker/Features/YellowSheet/YellowSheetView.swift
+++ b/Job Tracker/Features/YellowSheet/YellowSheetView.swift
@@ -81,12 +81,14 @@ struct YellowSheetView: View {
                     JTPrimaryButton("Save Yellow Sheet", systemImage: "tray.and.arrow.down") {
                         saveCurrentYellowSheet()
                     }
+                    .accessibilityIdentifier("YellowSheet.Save")
                     .padding(.horizontal, JTSpacing.lg)
                     .padding(.bottom, JTSpacing.md)
                 }
                 .padding(.top, topContentPadding)
             }
             .navigationTitle("     ")
+            .accessibilityIdentifier("YellowSheet.Root")
             .jtNavigationBarStyle()
             .onAppear {
                 if ProcessInfo.processInfo.isJobTrackerUITesting {

--- a/Job TrackerUITests/IPadAdaptiveLayoutUITests.swift
+++ b/Job TrackerUITests/IPadAdaptiveLayoutUITests.swift
@@ -1,0 +1,146 @@
+import XCTest
+import UIKit
+
+/// Adaptive-layout smoke coverage intended for an iPad simulator destination.
+/// Window sizes controlled by Stage Manager and Split View remain manual QA checks
+/// because XCTest cannot deterministically resize an iPad application window.
+final class IPadAdaptiveLayoutUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .pad, "Run this adaptive suite with the documented iPad destination")
+        XCUIDevice.shared.orientation = .portrait
+    }
+
+    override func tearDownWithError() throws {
+        XCUIDevice.shared.orientation = .portrait
+    }
+
+    func testDashboardCreateAndEditRemainReachableAcrossRotation() {
+        let app = JobTrackerUITestSupport.launch()
+        waitForElement(app.descendants(matching: .any)["IPadShell.Root"])
+        waitForElement(app.descendants(matching: .any)["Dashboard.Root"])
+        let create = app.buttons["Dashboard.CreateJob"]
+        waitForElement(create)
+        XCTAssertTrue(create.isHittable)
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        waitForElement(app.staticTexts["100 Safety Net Lane"])
+        XCTAssertTrue(create.isHittable, "The dashboard selection and primary action should survive rotation")
+
+        create.tap()
+        waitForElement(app.descendants(matching: .any)["CreateJob.Root"])
+        XCTAssertTrue(app.buttons["CreateJob.Save"].exists)
+        app.swipeUp()
+        XCTAssertTrue(app.buttons["CreateJob.Save"].exists, "The form toolbar must remain reachable after scrolling")
+        app.buttons["Close"].tap()
+        XCTAssertFalse(app.descendants(matching: .any)["CreateJob.Root"].exists)
+
+        app.staticTexts["100 Safety Net Lane"].tap()
+        waitForElement(app.navigationBars["Job Detail"])
+        app.swipeUp()
+        XCTAssertTrue(app.buttons["Save"].exists)
+        XCUIDevice.shared.orientation = .portrait
+        waitForElement(app.navigationBars["Job Detail"])
+    }
+
+    func testSearchKeyboardEmptyStateAndDetailSelectionSurviveRotation() {
+        let app = JobTrackerUITestSupport.launch()
+        app.buttons["Search"].tap()
+        waitForElement(app.descendants(matching: .any)["Search.Root"])
+        let query = app.textFields["Search.Query"]
+        waitForElement(query)
+        query.tap()
+        query.typeText("NoSuchAdaptiveJob")
+        waitForElement(app.descendants(matching: .any)["Search.EmptyState"])
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "Try fewer keywords")).firstMatch.exists)
+        app.keyboards.buttons["Search"].tap()
+        XCTAssertTrue(app.keyboards.element.waitForNonExistence(timeout: 2), "The search keyboard should dismiss through its semantic submit action")
+
+        query.tap()
+        query.clearAndEnterText("Safety Net")
+        app.keyboards.buttons["Search"].tap()
+        let result = app.staticTexts["100 Safety Net Lane"]
+        waitForElement(result)
+        result.tap()
+        waitForElement(app.navigationBars["Job Details"])
+        XCUIDevice.shared.orientation = .landscapeRight
+        waitForElement(app.staticTexts["100 Safety Net Lane"])
+        XCTAssertTrue(app.navigationBars["Job Details"].exists, "The selected search detail should remain presented")
+    }
+
+    func testWeeklyTimesheetFormAndCalendarSheetAdapt() {
+        let app = JobTrackerUITestSupport.launch()
+        app.buttons["Timesheets"].tap()
+        waitForElement(app.descendants(matching: .any)["Timesheet.Root"])
+        let supervisor = app.textFields["Timesheet.Supervisor"]
+        waitForElement(supervisor)
+        supervisor.tap()
+        supervisor.typeText("Adaptive Supervisor")
+        app.keyboards.buttons[XCUIKeyboardKey.return.rawValue].tap()
+        XCTAssertTrue(app.keyboards.element.waitForNonExistence(timeout: 2))
+        XCUIDevice.shared.orientation = .landscapeLeft
+        XCTAssertEqual(supervisor.value as? String, "Adaptive Supervisor")
+
+        let week = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Week of")).firstMatch
+        waitForElement(week)
+        week.tap()
+        waitForElement(app.navigationBars["Select Week"])
+        app.buttons["Done"].tap()
+        XCTAssertTrue(app.navigationBars["Select Week"].waitForNonExistence(timeout: 2), "The calendar sheet must be dismissible without an edge gesture")
+    }
+
+    func testYellowSheetEmptyContentAndPrimaryActionRemainReadable() {
+        let app = JobTrackerUITestSupport.launch()
+        app.buttons["Yellow Sheet"].tap()
+        waitForElement(app.descendants(matching: .any)["YellowSheet.Root"])
+        let save = app.buttons["YellowSheet.Save"]
+        waitForElement(save)
+        XCTAssertTrue(save.isHittable)
+        XCTAssertTrue(app.staticTexts["No yellow sheet jobs"].exists || app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "Job Number:")).firstMatch.exists)
+        XCUIDevice.shared.orientation = .landscapeLeft
+        waitForElement(save)
+        XCTAssertTrue(save.isHittable)
+    }
+
+    func testRouteMapperControlsRemainReachableAfterResizing() {
+        let app = JobTrackerUITestSupport.launch()
+        app.buttons["More"].tap()
+        waitForElement(app.navigationBars["More"])
+        app.staticTexts["Route Mapper"].tap()
+        waitForElement(app.descendants(matching: .any)["Maps.Root"])
+        waitForElement(app.staticTexts["Map Controls"])
+        XCUIDevice.shared.orientation = .landscapeRight
+        waitForElement(app.staticTexts["Map Controls"])
+        XCTAssertTrue(app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "location")).firstMatch.exists)
+    }
+
+    func testSettingsSelectionIsPreservedAcrossRotation() {
+        let app = JobTrackerUITestSupport.launch()
+        app.buttons["More"].tap()
+        app.staticTexts["Settings"].tap()
+        waitForElement(app.descendants(matching: .any)["Settings.Root"])
+        let routing = app.switches["Enable Smart Routing"]
+        waitForElement(routing)
+        XCUIDevice.shared.orientation = .landscapeLeft
+        waitForElement(routing)
+        XCTAssertTrue(app.staticTexts["Settings"].exists, "The More detail selection should survive an adaptive transition")
+    }
+
+    func testSupervisorDashboardPositionSelectionSurvivesRotation() {
+        let app = JobTrackerUITestSupport.launch(admin: true)
+        waitForElement(app.descendants(matching: .any)["SupervisorDashboard.Root"])
+        waitForElement(app.descendants(matching: .any)["SupervisorDashboard.Positions"])
+        waitForElement(app.staticTexts["Crew Overview"])
+        XCUIDevice.shared.orientation = .landscapeRight
+        waitForElement(app.staticTexts["Crew Overview"])
+        XCTAssertTrue(app.datePickers["Date"].isHittable)
+    }
+}
+
+private extension XCUIElement {
+    func clearAndEnterText(_ text: String) {
+        tap()
+        typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: (value as? String)?.count ?? 0))
+        typeText(text)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic iPad simulator coverage for adaptive/split-layout regressions across the app’s major flows (Dashboard, Search, Timesheet, Yellow Sheet, Create/Edit Job, Maps, Settings, Supervisor). 
- Use stable accessibility identifiers to avoid fragile coordinate-based assertions and enable reliable selection/interaction in rotation and resizing scenarios. 
- Document how to run the adaptive suite in Xcode Cloud and add manual Stage Manager / Split View QA steps where XCTest cannot control window geometry.

### Description
- Added a new UI-test suite `Job TrackerUITests/IPadAdaptiveLayoutUITests.swift` that exercises portrait and landscape continuity, sidebar/detail behavior, empty states, primary actions reachability, keyboard dismissal, form scrolling, sheet/popover dismissal, and preservation of selection after rotation or resizing using the existing `JobTrackerUITestSupport` helpers. The suite skips on non‑iPad runners via `try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .pad)`. 
- Exposed stable accessibility identifiers in multiple SwiftUI views so tests avoid coordinate assertions: `IPadShell.Root` (`MainTabView.swift`), `Dashboard.CreateJob` / `Dashboard.Root` (`DashboardView.swift`), `Search.Root` / `Search.Query` / `Search.EmptyState` (`JobSearchView.swift`), `CreateJob.Root` / `CreateJob.Save` (`CreateJobView.swift`), `Timesheet.Root` / `Timesheet.Supervisor` (`WeeklyTimesheetView.swift`), `YellowSheet.Root` / `YellowSheet.Save` (`YellowSheetView.swift`), `Maps.Root` (`MapsView.swift`), and `SupervisorDashboard.Root` / `SupervisorDashboard.Positions` (`SupervisorHomeDashboardView.swift`). 
- Updated the safety-net test plan name to reflect iPad coverage in `Job Tracker Safety Net.xctestplan` and added an iPad simulator `xcodebuild` command example and manual multitasking QA checklist in `Documentation/XcodeCloudTesting.md`. 
- Small test-focused assertions were hardened (keyboard dismissal/wait helpers and non-existence waits) in the new suite to avoid timing flakiness across device orientations.

### Testing
- Validated the modified test plan JSON with `python3 -m json.tool 'Job Tracker Safety Net.xctestplan'` (succeeded). 
- Ran static/shell checks against the safety-net guard (`bash -n ci_scripts/ci_pre_xcodebuild.sh`) and executed the guard script `ci_scripts/ci_pre_xcodebuild.sh` which completed its configuration checks (it skipped xcodebuild-specific resolution locally because `xcodebuild` was not present). 
- Verified repository changes pass `git diff --cached --check` and local diff/consistency checks (no check failures). 
- Note: the full `xcodebuild test` run for `IPadAdaptiveLayoutUITests` was not executed in this environment because Xcode and iOS Simulator runtimes are not available here; the PR includes the documented `xcodebuild` command to run the suite on an iPad simulator destination (`-destination 'platform=iOS Simulator,name=iPad Pro 11-inch (M4)'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b66d4bb08832d917b7dea5f0f0f6f)