### PR TITLE
Fix Splice Assist accessibility value

### DIFF
--- a/Job Tracker/Features/SpliceAssist/SpliceAssistView.swift
+++ b/Job Tracker/Features/SpliceAssist/SpliceAssistView.swift
@@ -26,7 +26,7 @@ struct SpliceAssistView: View {
                         .buttonStyle(.plain)
                         .frame(minHeight: 44)
                         .accessibilityLabel("Dismiss message")
-                        .accessibilityValue(message)
+                        .accessibilityValue(message.text)
                         .accessibilityHint("Clears this message")
                         .accessibilityIdentifier("spliceAssist.dismissMessage")
                         .transition(.opacity.combined(with: .move(edge: .top)))


### PR DESCRIPTION
### Motivation
- Pass the message text (a `String`) to SwiftUI's `.accessibilityValue` so VoiceOver announces the intended content and to satisfy the `StringProtocol` requirement.

### Description
- Replace `.accessibilityValue(message)` with `.accessibilityValue(message.text)` in `Job Tracker/Features/SpliceAssist/SpliceAssistView.swift` and verify that `SpliceAssistViewModel.Message.text` remains declared as `String`.

### Testing
- Ran `git diff --check` (no issues), `rg -n -C 4 'let text: String' 'Job Tracker/Features/SpliceAssist/SpliceAssistViewModel.swift'` (confirmed `let text: String`), `git status --short`, and `git show --stat --oneline --decorate HEAD` to confirm the change was applied and committed; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc96b2140832db1ccf5e2a9f0f3d9)